### PR TITLE
M4: trace tool + cross-language structural resolver

### DIFF
--- a/.memories/.active-brief
+++ b/.memories/.active-brief
@@ -1,0 +1,1 @@
+miller-project-direction-amp-milestone-state

--- a/.memories/2026-05-30/163213_f513.md
+++ b/.memories/2026-05-30/163213_f513.md
@@ -1,0 +1,49 @@
+---
+id: checkpoint_f5139c21
+timestamp: 2026-05-30T16:32:13.343Z
+tags:
+  - miller
+  - testing
+  - infrastructure
+  - milestone
+git:
+  branch: main
+  commit: f8d7c07
+summary: Committed and pushed 4 commits on top of M7 (98f4ab7 → f8d7c07)
+type: checkpoint
+evidence:
+  - build 0 warnings / 0 errors
+  - bare dotnet test = 793 passed (fast suite, Scale excluded by default)
+  - dotnet test --filter Category=Scale = 12 passed
+  - git push 98f4ab7..f8d7c07 main -> main, local==origin, tree clean
+  - "T2 negative test: comment-only trait FAILS guard, real attribute PASSES"
+next: M4 (trace + cross-language resolver) — blocked on julie enrichment (bridge
+  anchors + test_role). Nothing actionable on Miller side until those land.
+---
+
+## Committed and pushed 4 commits on top of M7 (98f4ab7 → f8d7c07)
+
+Landed all the uncommitted work from this session as logical commits, then pushed to `github.com/anortham/miller` (main). Working tree clean, local == origin.
+
+- **`676dd6f` feat(server): M8** — logging polish: per-pid log files (`miller-<pid>-.{log,jsonl}`), `MillerRole` leader/reader Serilog enricher, `LogFileReaper` (keep-N, excludes live pids), `LogLevelParse` (MILLER_LOG_LEVEL), `ExtractErrorLog.Describe`, correlation id (cid) shared by telemetry row + LogContext. Compact JSON sink.
+- **`173d3e3` docs: M9** design (PARKED — viability-gated on julie's full-content ingest cost).
+- **`ef15ecf` test:** T1-T4 fast/scale split defenses.
+- **`f8d7c07` chore:** goldfish checkpoint artifact.
+
+## Test-suite defenses (the main work)
+
+Goal: stop a bare `dotnet test` from running the slow Scale tests — the failure mode that left julie's suite at 30+ min.
+
+- **T1**: `VSTestTestCaseFilter=Category!=Scale` in Miller.Tests.csproj (bare run = fast only; `--filter` overrides).
+- **T2**: `ScaleTraitConventionTests` source-scans the tree, fails the build if any julie-spawning test (keyed on the single `ScaleTestSupport` launch signal) lacks `[Trait("Category","Scale")]`. Comment-stripped so a trait quoted in prose can't fool it.
+- **T3**: `scripts/test.sh` wall-clocks the fast suite, fails >30s (local mirror of CI ceiling).
+- **T4**: `scripts/test.sh {fast|scale|all}` + README/CLAUDE.md docs.
+- **Dedup**: 7× copied `RepoRoot()`/`LocateJulieServer()`/skip-preamble → `ScaleTestSupport`.
+
+## Verified (clean rebuild, TRX)
+Build 0 warn / 0 err; bare `dotnet test` = **793** (fast only); `--filter Category=Scale` = **12**.
+
+## Self-corrections worth remembering
+- First "green" (805) was contaminated — the `.runsettings` filter silently never applied. True fast count is 793.
+- Documented-then-retracted a false claim that `.runsettings <TestCaseFilter>` doesn't work; it DOES (the real bug was a malformed XML comment). Kept the csproj property anyway: fails loudly on typo vs silently running everything.
+- Negative test exposed a real guard hole (trait quoted in a comment fooled the substring match) → fixed with comment-stripping, re-tested both directions.

--- a/.memories/2026-05-30/192053_4e3b.md
+++ b/.memories/2026-05-30/192053_4e3b.md
@@ -1,0 +1,353 @@
+---
+id: checkpoint_4e3b5dec
+timestamp: 2026-05-30T19:20:53.295Z
+tags:
+  - M4
+  - structure
+  - implementation-reference
+  - codebase-map
+git:
+  branch: main
+  commit: c42f8b5
+summary: Miller Codebase Map (M4 Implementation Reference)
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+---
+
+## Miller Codebase Map (M4 Implementation Reference)
+
+### 1. Project Layout & Dependencies
+
+**Projects under src/ (from .csproj files):**
+- `Miller.Core` (I/O-free, pure logic) — extract-contract types, BM25 index, structural resolver
+  - **Zero dependencies:** no SQLite, no subprocess, no MCP, no file I/O
+  - Located: `/Users/murphy/source/codesearch/src/Miller.Core/`
+  - Key types: `SearchableDocument`, `SymbolGraph`, `GraphEdge`, `GraphNode`, `ReachedNode`, edit/diff/tokenization/search logic
+  
+- `Miller.Indexing` (infrastructure) — julie extract wrapper, SQLite read layer, file watcher, index building
+  - Dependencies: `Miller.Core`, `Microsoft.Data.Sqlite` (v10.0.8)
+  - Located: `/Users/murphy/source/codesearch/src/Miller.Indexing/`
+  - Key classes: `SqliteSymbolReader`, `SymbolGraphReader`, `FreshnessReader`, `RepositoryIndexLoader`, `IndexedSymbol`, `MillerRepositoryIndex`, `IndexHolder`, `JulieSchemaGate`, `MillerExtractContract`
+
+- `Miller.Server` (MCP host + tools + hosting) — CLI entry point, tool endpoints, freshness polling, telemetry
+  - Dependencies: `Miller.Core`, `Miller.Indexing`, `ModelContextProtocol` (v1.3.0), `Microsoft.Extensions.Hosting`, `Microsoft.Data.Sqlite` (owns writable telemetry.db)
+  - Located: `/Users/murphy/source/codesearch/src/Miller.Server/`
+  - Key tools: `SearchTool`, `InspectTool`, `ContextTool`, `ImpactTool`, `EditTool`, `WorkspaceTool`
+  - Key services: `FreshnessService`, `IndexBootstrapService`, `IndexerService`, `TelemetryLedger`
+
+---
+
+### 2. SQLite Read Layer (Miller.Indexing)
+
+**Where Miller reads julie's symbols.db:**
+- File: `/Users/murphy/source/codesearch/src/Miller.Indexing/SqliteSymbolReader.cs` (lines 1-109)
+  - Opens DB with `Mode=ReadOnly` via `SqliteReadOnlyAccess.Open(dbPath)` (shared D4 discipline)
+  - Runs `JulieSchemaGate.Verify()` before reading (lines 35)
+  - SELECT: `id, name, signature, kind, language, file_path, start_line, end_line, parent_id, metadata` FROM symbols WHERE name IS NOT NULL ORDER BY file_path, start_line, id (lines 39-44)
+  - Returns: `IReadOnlyList<IndexedSymbol>` with 0-based DocId ordinals
+
+**Edge reading layer:**
+- File: `/Users/murphy/source/codesearch/src/Miller.Indexing/SymbolGraphReader.cs` (lines 1-125)
+  - Two sources: `relationships` (precise id→id edges) and `identifiers` (name-resolved edges with containing_symbol_id)
+  - SelectRelationships: `from_symbol_id, to_symbol_id, kind` FROM relationships (lines 67-83)
+  - SelectIdentifiers: `name, kind, containing_symbol_id` FROM identifiers WHERE containing_symbol_id IS NOT NULL (lines 96-100)
+  - Returns: `IReadOnlyList<GraphEdge>` (union of both sources, name-resolved)
+
+**Freshness/versioning layer:**
+- File: `/Users/murphy/source/codesearch/src/Miller.Indexing/FreshnessReader.cs` (lines 1-137)
+  - Opens MODE=ReadOnly, persistent connection for polling
+  - `LatestRevision(workspaceId)`: `SELECT MAX(revision) FROM canonical_revisions WHERE workspace_id=@id` (lines 73-75)
+  - `ChangedSince(sinceRevision, workspaceId)`: `SELECT revision, file_path, change_kind FROM revision_file_changes WHERE workspace_id=... AND revision > ...` (lines 95-99)
+
+---
+
+### 3. Model Types (The Shape M4 Extends)
+
+**IndexedSymbol** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/IndexedSymbol.cs`, lines 12-31)
+```csharp
+public sealed record IndexedSymbol(
+    int DocId,              // Miller-assigned 0-based row ordinal
+    string SymbolId,        // julie opaque MD5-hex id (M4 join key — TREAT AS OPAQUE)
+    string Name,
+    string? Signature,
+    string Kind,
+    string Language,
+    string FilePath,        // relative-unix to root_path
+    int StartLine,          // 1-based (NULL→0)
+    int EndLine,            // whole-symbol span end, 1-based (NULL→0)
+    string? ParentId,       // julie parent_id (containment; M4 join key)
+    bool IsTest = false)    // julie's symbols.metadata.is_test (cross-language, all 34 langs)
+```
+
+**SymbolDetail** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/SymbolDetail.cs`, lines 8-15)
+```csharp
+public sealed record SymbolDetail(
+    string? DocComment,
+    string? Visibility,
+    string? CodeContext,
+    int? BodyStartByte,
+    int? BodyEndByte,
+    int? BodyStartLine,
+    int? BodyEndLine);
+```
+
+**SymbolRef** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/SymbolDetail.cs`, lines 23-28)
+```csharp
+public sealed record SymbolRef(
+    string Name,
+    string Kind,
+    string FilePath,
+    int StartLine,
+    string? ContainingSymbolId);
+```
+
+**IdentifierSite** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/SymbolDetail.cs`, lines 42-46)
+```csharp
+public sealed record IdentifierSite(
+    string FilePath,
+    int StartByte,      // Inclusive, absolute UTF-8 byte offset
+    int EndByte,        // Exclusive, absolute UTF-8 byte offset
+    int StartLine);     // 1-based
+```
+
+**RevisionFileChange** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/FreshnessReader.cs`, lines 23)
+```csharp
+public sealed record RevisionFileChange(long Revision, string FilePath, RevisionChangeKind ChangeKind);
+```
+
+**Metadata parsing:** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/SqliteSymbolReader.cs`, lines 88-106)
+- JSON parse only if `"is_test"` substring present (perf optimization)
+- Returns `bool` for `is_test` (default false; malformed/absent = false)
+- Used at line 73 to seed `IndexedSymbol.IsTest`
+
+---
+
+### 4. In-Memory Index Structure
+
+**MillerRepositoryIndex** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/MillerRepositoryIndex.cs`, lines 13-310)
+- Central facade tying SQLite reads to Core scoring
+- Built once by `RepositoryIndexLoader.Load()` → `SqliteSymbolReader.Read()` → `SymbolGraphReader.Read()` → `MillerRepositoryIndex.Build()`
+- Fields (lines 15-35):
+  - `_index` (MillerSearchIndex) — BM25 scoring
+  - `_byDocId[DocId]` → IndexedSymbol (O(1) hydration from DocId)
+  - `_bySymbolId[SymbolId]` → IndexedSymbol (O(1) lookup by julie id)
+  - `_byName[name]` → List<IndexedSymbol> (multi-valued, for homonyms)
+  - `_byFilePath[path]` → List<IndexedSymbol>
+  - `_byParentId[parentId]` → List<IndexedSymbol> (containment)
+  - `_byFileName[basename]` → List<string> (full paths, for file resolution)
+  - `_graph` (SymbolGraph) — the dependency graph (lines 35, 66)
+
+**SymbolGraph** (file: `/Users/murphy/source/codesearch/src/Miller.Core/Graph/SymbolGraph.cs`, lines 47-217)
+- Immutable, built once with index
+- Fields (lines 49-51):
+  - `_dependencies[id]` → string[] (what this id depends on — callees)
+  - `_dependents[id]` → string[] (what depends on this id — callers; blast radius)
+  - `_isTest[id]` → bool (cross-language test flag)
+- Neighbors are SortedSet<string> deduplicated at build, then frozen to string[] (lines 100-116)
+- Edge hygiene at build (lines 86-95):
+  - Drop self-loops
+  - Drop edges with unknown endpoints (not in the node set)
+  - Collapse duplicate (from, to) pairs per direction
+
+**GraphEdge** (file: `/Users/murphy/source/codesearch/src/Miller.Core/Graph/SymbolGraph.cs`, lines 8-16)
+```csharp
+public sealed record GraphEdge(string From, string To, string Kind);
+```
+
+**GraphNode** (file: `/Users/murphy/source/codesearch/src/Miller.Core/Graph/SymbolGraph.cs`, lines 3-6)
+```csharp
+public sealed record GraphNode(string Id, bool IsTest);
+```
+
+**ReachedNode** (file: `/Users/murphy/source/codesearch/src/Miller.Core/Graph/SymbolGraph.cs`, lines 18-21)
+```csharp
+public sealed record ReachedNode(string Id, int Hop);
+```
+
+---
+
+### 5. M3 Freshness Machinery (M4 Will Reuse)
+
+**IndexHolder** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/IndexHolder.cs`, lines 19-64)
+- Single volatile reference to immutable (index, revision) pair
+- Lock-free for readers; atomic swap for publisher
+- Methods:
+  - `Current` → MillerRepositoryIndex (read per tool call)
+  - `BuiltRevision` → long (the canonical_revisions cursor)
+  - `Snapshot()` → (MillerRepositoryIndex, long revision) (consistent pair, single volatile read)
+  - `Swap(MillerRepositoryIndex next, long revision)` (freshness rebuild publishes here)
+
+**FreshnessService** (file: `/Users/murphy/source/codesearch/src/Miller.Server/Hosting/FreshnessService.cs`, lines 22-250)
+- BackgroundService that polls every 2s (line 25)
+- Reads `FreshnessReader.LatestRevision(workspaceId)` (line 227)
+- If newer than `_holder.BuiltRevision`, rebuilds via `IndexRebuilder.Rebuild()` and `_holder.Swap()`
+- `PollNow()` (lines 129-165) allows on-demand poll from tools (workspace refresh/full)
+- Test seams: `InitReaderForTest()`, `DisposeReaderForTest()`, `RunUnderPollGateForTest()`
+
+**RepositoryIndexLoader** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/RepositoryIndexLoader.cs`, lines 19-58)
+- Single production build path (D9, line 7): symbols → edges → index + graph
+- `Load(dbPath)` returns MillerRepositoryIndex with populated graph
+- Order: (1) read symbols, (2) build name→ids map, (3) read edges (name-resolving through map), (4) build index+graph
+
+**Miller owns ONE separate SQLite DB:**
+- File: `/Users/murphy/source/codesearch/src/Miller.Server/Telemetry/TelemetryLedger.cs` (lines 1-160)
+- Path: `<root>/.miller/telemetry.db` (Mode=ReadWriteCreate, separate from julie's symbols.db)
+- Schema: `tool_telemetry` table (STRICT, lines 18-33) with telemetry metrics
+- Initialized in `IndexBootstrapService` (DI singleton)
+- No migration code; DDL is `CREATE TABLE IF NOT EXISTS` (line 19)
+
+**Julie extract DB path:**
+- File: `/Users/murphy/source/codesearch/src/Miller.Server/Hosting/WorkspaceContext.cs` (lines 10-41)
+- Record: `WorkspaceContext` holds paths:
+  - `ExtractDbPath`: `<root>/.miller/symbols.db` (julie extract, Mode=ReadOnly)
+  - `TelemetryDbPath`: `<root>/.miller/telemetry.db` (Miller-owned, Mode=ReadWriteCreate)
+  - `WorkspaceId`: nullable string (resolved after scan from `external_extract_metadata`)
+
+---
+
+### 6. Existing MCP Tools (Pattern trace Follows)
+
+**Tool Declaration Pattern** (all in `/Users/murphy/source/codesearch/src/Miller.Server/Tools/`):
+
+Tool class signature:
+```csharp
+[McpServerToolType]
+public sealed class XyzTool {
+    [McpServerTool(Name = "xyz")]
+    [Description("...")]
+    public string Xyz(
+        [Description("...")] string param1,
+        ...) { ... }
+}
+```
+
+Registration: via `WithToolsFromAssembly()` in Program.cs (line 18-19), all tools auto-discovered and DI-resolved.
+
+**Existing tools:**
+
+1. **SearchTool** (`/Users/murphy/source/codesearch/src/Miller.Server/Tools/SearchTool.cs`, lines 37-100)
+   - Constructor: `IndexHolder holder`
+   - Method: `Search(query, mode, limit, exclude_tests, format)`
+   - Core: `Run()` delegates to `MillerRepositoryIndex.Search()` (BM25 ranking)
+   - Output: compact (text) or json
+   - Telemetry: ResultCount, BytesExamined proxy (count of filtered results)
+
+2. **InspectTool** (lines not shown but known to exist)
+   - Constructor: `IndexHolder holder`, `WorkspaceContext workspace`
+   - DB-backed (reads SymbolDetail on demand from identifiers/relationships tables)
+   - One-hop callers/callees via graph
+
+3. **ContextTool** (`/Users/murphy/source/codesearch/src/Miller.Server/Tools/ContextTool.cs`, lines 31-100)
+   - Constructor: `IndexHolder holder`, `SmartTargetResolver resolver`
+   - Method: `Context(query, token_budget, max_hops, entry_symbols, failing_test, stack_trace, format)`
+   - Core: `Run()` seeds from BM25 search + parsed hints, expands both directions with `Graph.Reach()`, packs to token budget
+   - Telemetry: ResultCount (selected), BytesExamined (candidate set before budget)
+   - In-memory, sub-100ms
+
+4. **ImpactTool** (`/Users/murphy/source/codesearch/src/Miller.Server/Tools/ImpactTool.cs`, lines 34-187)
+   - Constructor: `IndexHolder holder`, `SmartTargetResolver resolver`
+   - Method: `Impact(target, changed_paths, diff, max_depth, limit, format)`
+   - Core: `Run()` resolves seed symbols (target / file / diff), REVERSE Reach, partitions by IsTest
+   - Traversal: `index.Graph.Reach(seedIds, maxDepth, limit, Direction.Reverse)` (line 168)
+   - Telemetry: ResultCount (impacted non-tests), BytesExamined (whole reached set)
+   - In-memory, very fast
+
+5. **EditTool** (lines not shown but known)
+   - Constructor: `IndexHolder holder`, `WorkspaceContext workspace`, others
+   - DB-backed (IdentifierSite reads for exact-span edits)
+   - Freshness-gated mutation
+
+6. **WorkspaceTool** (lines not shown but known)
+   - Handles refresh/full commands that trigger `FreshnessService.PollNow()`
+
+**Graph traversal pattern** (from ImpactTool.Run, lines 166-169):
+```csharp
+var reached = index.Graph.Reach(seedIds, maxDepth, limit, Direction.Reverse);
+nodesVisited = reached.Count;  // D10 bytes_examined proxy
+foreach (var node in reached) {
+    var symbol = index.FindBySymbolId(node.Id);  // hydrate
+    (symbol.IsTest ? tests : impacted).Add(new Reached(symbol, node.Hop));
+}
+```
+
+---
+
+### 7. Version Gate (M4 Re-pins It)
+
+**MillerExtractContract** (file: `/Users/murphy/source/codesearch/src/Miller.Indexing/MillerExtractContract.cs`, lines 9-16)
+```csharp
+internal static class MillerExtractContract {
+    public const long ExpectedSchemaVersion = 26;
+    public const long ExpectedExtractContractVersion = 1;
+    public const string PinnedJulieServerVersion = "7.12.2";
+}
+```
+- Comment (line 11): "Bumps to (28, 2) at M4 when the bridge-anchor extraction enrichment is consumed."
+- Checked at: `JulieSchemaGate.Verify(connection)` before every read
+- Also checked in `JulieExtractRunner` (subprocess cross-check)
+
+---
+
+### 8. Test Conventions
+
+**In-memory unit test fixtures** (NO julie subprocess):
+- File: `/Users/murphy/source/codesearch/tests/Miller.Tests/Graph/SymbolGraphTests.cs` (lines 13-200)
+  - Pure dependency-graph tests, instant, no I/O
+  - Fixture: `N(id, isTest=false)` → GraphNode, `E(from, to, kind="calls")` → GraphEdge
+  - Build: `SymbolGraph.Build([nodes], [edges])`
+  - Assert on `Reach()` results directly
+  - Example test: `Reach_MaxDepthZero_ReturnsEmpty()` (lines 84-89)
+
+- File: `/Users/murphy/source/codesearch/tests/Miller.Tests/Server/ImpactToolTests.cs` (lines 24-120)
+  - Synth index built in-memory via `MillerRepositoryIndex.Build(symbols, edges)` (line 55)
+  - `BuildFixture()` (lines 38-57): creates IndexedSymbol list + GraphEdge list, builds index + resolver
+  - Example: `Run_TargetSymbol_ReturnsReverseClosure_PartitionsLikelyTests()` (lines 62-78)
+  - IsTest flag exercised: ProcessWorks marked `IsTest: true` (line 46) → partitioned into tests section (lines 96)
+
+**Scale trait convention** (julie spawning):
+- File: `/Users/murphy/source/codesearch/tests/Miller.Tests/ScaleTestSupport.cs` (lines 16-50)
+  - `RequireJulieServer()` (lines 43-49): locates pinned binary under `.tools/`, skips (not fails) if missing
+  - `LocateJulieServer()` (lines 31-36): probes for `julie-server` / `julie-server.exe`
+  - Mark with `[Trait("Category","Scale")]` to exclude from default suite
+  - One reference: `ScaleTestSupport.RequireJulieServer()` in any test file marks it as julie-spawning
+
+---
+
+### 9. Key Design Decisions for M4 Integration
+
+1. **Graph is built once, atomically with index** (RepositoryIndexLoader.Load, lines 30-56)
+   - M4's resolver must fit into this single-pass pattern
+   - Both symbols and edges read from the same julie extract DB
+   - New tables (type_arguments, literals, symbol_annotations) must be read at this stage
+
+2. **Metadata parsing is isolated** (SqliteSymbolReader.ParseIsTest, lines 88-106)
+   - M4's new metadata field `test_role` should follow the same pattern:
+     - Lazy JSON parse only if substring match
+     - Default to sentinel value (false for is_test; TBD for test_role)
+     - Never throws; malformed = default
+
+3. **Symbol id is the join key, NOT name** (IndexedSymbol.SymbolId comment, line 14)
+   - All cross-references use opaque `symbolId` (MD5-hex)
+   - Name resolution (homonyms) happens once at graph-build time (RepositoryIndexLoader, lines 40-54)
+   - M4's bridge graph must key on symbolId throughout
+
+4. **Immutability + volatile reference swap is the concurrency model** (IndexHolder, lines 19-64)
+   - No locks inside index; atomic reference replacement
+   - In-flight reads keep old snapshot; new tool calls see new one
+   - M4's bridge graph travels with the index (line 35: _graph)
+
+5. **Test detection is cross-language and flow-free** (IsTest on GraphNode, SymbolGraph lines 3-6)
+   - Julie's `symbols.metadata.is_test` is the sole signal (extracted by language-agnostic test_detection.rs)
+   - M4's `test_role` must similarly avoid name-based heuristics
+
+---
+
+### Summary: M4 Will Slot In As
+
+- **New tables in julie's extract DB**: type_arguments, literals, symbol_annotations (read by new reader class)
+- **New field on IndexedSymbol**: test_role (parsed from symbols.metadata, like is_test)
+- **New GraphNode field**: test_role (carried alongside IsTest)
+- **New SymbolGraph method/index**: bridge-graph lookup (or separate BridgeGraph class, same pattern)
+- **Version bump**: ExpectedSchemaVersion 26→28, ExpectedExtractContractVersion 1→2
+- **New tool in Miller.Server.Tools**: TraceTool (same [McpServerToolType] + [McpServerTool] pattern, DI resolver)
+- **Test fixture pattern**: Same in-memory IndexedSymbol + GraphEdge synthesis (add type_arguments, literals rows where needed)

--- a/.memories/2026-05-31/073836_3ad3.md
+++ b/.memories/2026-05-31/073836_3ad3.md
@@ -1,0 +1,61 @@
+---
+id: checkpoint_3ad3f251
+timestamp: 2026-05-31T07:38:36.913Z
+tags:
+  - M4
+  - phase-c
+  - trace
+  - bridge-graph
+  - milestone
+git:
+  branch: main
+  commit: a5d9de1
+  files:
+    - .claude/scheduled_tasks.lock
+    - docs/plans/2026-05-30-m4-cross-language-resolver-design.md
+    - src/Miller.Core/Graph/BridgeGraph.cs
+    - src/Miller.Core/Graph/BridgeGraphBuilder.cs
+    - src/Miller.Core/Graph/SymbolGraph.cs
+    - src/Miller.Indexing/IndexedSymbol.cs
+    - src/Miller.Indexing/MillerRepositoryIndex.cs
+    - src/Miller.Indexing/RepositoryIndexLoader.cs
+    - src/Miller.Indexing/SqliteBridgeReader.cs
+    - src/Miller.Indexing/SqliteSymbolReader.cs
+    - src/Miller.Server/Tools/TraceTool.cs
+    - tests/Miller.Tests/Graph/BridgeGraphBuilderTests.cs
+    - tests/Miller.Tests/Graph/BridgeGraphTests.cs
+    - tests/Miller.Tests/Graph/SymbolGraphShortestPathTests.cs
+    - tests/Miller.Tests/Indexing/JulieDbFixture.cs
+    - tests/Miller.Tests/Indexing/RepositoryIndexLoaderBridgeTests.cs
+    - tests/Miller.Tests/Indexing/SqliteBridgeReaderTests.cs
+    - tests/Miller.Tests/Indexing/SqliteSymbolReaderTests.cs
+    - tests/Miller.Tests/Tools/TraceToolTests.cs
+summary: M4 Phase C complete — committing trace tool + bridge graph; Phase D next
+briefId: miller-project-direction-amp-milestone-state
+type: milestone
+next: "Phase D: Scale test + per-leg honesty probe; needs .tools/julie-server
+  (absent). Write precision/recall per leg into design §9."
+---
+
+## M4 Phase C complete — committing trace tool + bridge graph; Phase D next
+
+Build 0/0 (Release, warnings-as-errors), fast suite **1050 passed / 0 failed / 0 skipped** (4s). 3 independent reviews approved (LOW-only). User authorized commit + proceed with Phase D.
+
+### WHAT Phase C added (on top of Phase B legs at a5d9de1)
+- `src/Miller.Core/Graph/BridgeGraph.cs` — immutable undirected adjacency over ScoredEdge; `Build`, `Walk(start,maxDepth)` (deterministic id-sorted BFS), node-identity helpers.
+- `src/Miller.Core/Graph/BridgeGraphBuilder.cs` — 4 reductions -> 3 legs -> BridgeScorer -> BridgeGraph. Dapper path emits EMPTY DapperFromCandidates (contract gap).
+- `src/Miller.Core/Graph/SymbolGraph.cs` — added `ShortestPath(from,to,maxDepth)` BFS.
+- `src/Miller.Indexing/SqliteBridgeReader.cs` — reads type_arguments/literals/annotations/DbSet props; LiteralSites map.
+- `src/Miller.Indexing/{IndexedSymbol,MillerRepositoryIndex,RepositoryIndexLoader,SqliteSymbolReader}.cs` — TestRole, BridgeGraph in index, measured build.
+- `src/Miller.Server/Tools/TraceTool.cs` — `trace` MCP tool, 3 modes (auto/path/bridge), honesty flags.
+- Tests: Graph/{BridgeGraph,BridgeGraphBuilder,SymbolGraphShortestPath}, Indexing/{SqliteBridgeReader,RepositoryIndexLoaderBridge}, Tools/TraceTool; JulieDbFixture always creates the 3 bridge tables.
+
+### WHY / design honesty
+docs/plans/2026-05-30-m4-cross-language-resolver-design.md records 3 lean-contract deviations (§4 Leg 3, §8 risk 9, §9 acceptance): Dapper-FROM dropped (unbuildable on julie 28/2 — needs julie-side type_arguments widening; DbSet is sole entity<->table anchor); CreateMap name-blind; endpoint->class [Route] join by name.
+
+### NEXT: Phase D (Task 11) — Scale test + per-leg honesty probe
+Needs `.tools/julie-server` (currently ABSENT). Must be `[Trait(\"Category\",\"Scale\")]` + `ScaleTestSupport.RequireJulieServer()` (skips, not fails, if binary missing). Probe = precision/recall PER LEG on a real fixture, numbers written into §9. §9 calls this the shippable gate.
+
+### IMPACT / watch out
+- Channel glitch this session: Bash/Read intermittently returned empty then flushed; once I wrongly believed a checkpoint file was corrupted and deleted it — recovered from context. Verify tool output, never trust self-reports.
+- Excluded from commit: `.claude/scheduled_tasks.lock` (ephemeral).

--- a/.memories/briefs/live-test-engine-agent-friendly-continuous-testing.md
+++ b/.memories/briefs/live-test-engine-agent-friendly-continuous-testing.md
@@ -1,0 +1,26 @@
+---
+id: live-test-engine-agent-friendly-continuous-testing
+title: Live-test engine (agent-friendly continuous testing) — parked design
+status: active
+created: 2026-05-30T18:29:46.690Z
+updated: 2026-05-30T18:29:46.690Z
+tags: []
+---
+
+PARKED design idea (behind M4). Full spec: docs/plans/2026-05-30-live-test-engine-design.md.
+
+WHAT: a Wallaby/NCrunch-style continuous-testing engine *for agents*, so an agent asks "did my edits break anything I have a test for, and what did I leave unverified?" instead of compulsively re-running the whole suite after every trivial edit.
+
+THE REFRAME (the strongest idea): it's a SAFETY tool, not a status tool. Headline = a negative claim ("nothing you changed is covered by a now-failing test") because that's the common case, cheaper to make trustworthy (only re-run tests covering changed lines, not whole suite), and exactly what an agent acts on. TRAP: a negative claim is false-clear if the code has NO test. So it's a DUAL claim — "broke" (confirmed-red) AND "uncovered" (co-headline, the add-a-test signal).
+
+WHY IT'S NOT JUST A TOOL: goal is behavior change, not tool existence. Agents have a verification prior + explicit "run the tests" instructions. So deliverable = engine + output-as-argument (evidence: what ran/when/which hash + explicit "you can skip") + a behavioral skill stanza (same pattern as Miller's "use julie not grep"). Honest success bar: kill COMPULSIVE re-runs (80%), not all runs.
+
+KEY DECISIONS (locked in brainstorm): per-file coverage MVP but true per-method NCrunch parity is the north star; lives IN Miller via existing MCP server; .NET runner first (dogfood Miller's suite); primary tool = check_changes (dual claim), secondary = get_test_status + run_tests; trust state machine green|red|running|stale|uncovered|unknown with invariant "never report clear for changed-but-not-rerun unit"; flake = confirm-before-report (trust-critical); ITestRunner plugin seam (discovery via julie is_test = language-agnostic, execution per-runner = the honest exception to don't-hardcode-languages); separate ct.db keyed by content hashes.
+
+STRATEGIC: consumes M4 impact analysis as the cheap pre-filter → makes M4 MORE valuable, lands AFTER M4.
+
+#1 RISK / SPIKE FIRST: can MTP + a coverage data collector give per-test (per-method) attribution in ONE warm-host run (no process-per-test)? Run against Miller.Tests before locking the parity architecture. Per-file MVP under-delivers on the headline's precision, so the parity path is where the safety value actually lands.
+
+OUT OF SCOPE: live inline values, time-travel debug, gutter overlays (human-IDE features, no agent analog).
+
+STATUS: design captured + committed; NOT scheduled. M4 remains the real next work (blocked on julie enrichment).

--- a/.memories/briefs/miller-project-direction-amp-milestone-state.md
+++ b/.memories/briefs/miller-project-direction-amp-milestone-state.md
@@ -1,0 +1,44 @@
+---
+id: miller-project-direction-amp-milestone-state
+title: Miller — project direction &amp; milestone state
+status: active
+created: 2026-05-30T16:32:42.067Z
+updated: 2026-05-30T16:32:42.067Z
+tags: []
+---
+
+## What Miller is
+
+A read-only **.NET 10** SQLite/MCP server that consumes `julie-server extract` output to answer structural code-intelligence questions (search, inspect, context, trace, impact, edit, workspace) for AI coding agents — token-thrifty, no embeddings, no source parsing of its own. Lineage: **Julie** (Rust, shipping, the extractor) → **Miller** (.NET, building, this repo) → **Eros** (commercial, future). Miller is a **product for unknown users**, not a personal tool — hold tests + error handling to product bar.
+
+Repo: `github.com/anortham/miller`, branch `main`. julie pins: schema 26, contract 1, julie-server v7.12.2 (binary fetched into `.tools/`, gitignored).
+
+## The differentiator (why Miller exists)
+
+A **deterministic cross-language structural resolver** — links code across language boundaries (C# entity ↔ EF table, TS call ↔ the C# route that serves it) **without embeddings**. This is M4 and it's the whole point; everything before it is table stakes.
+
+## Milestone state (as of 2026-05-30)
+
+- **M0-M7: DONE & committed.** Scaffold, read core, MCP host + search/inspect/telemetry, freshness (single-writer indexer + watcher), context + impact, edit, workspace.
+- **M8 logging polish: DONE & pushed** (676dd6f) — per-pid files, role enricher, reaper, correlation id.
+- **Test-suite defenses: DONE & pushed** (ef15ecf) — fast/scale split is now enforced; see "Guardrails" below.
+- **M4 trace + cross-language resolver: BLOCKED on julie.** Needs two julie-side enrichment plans first: (1) bridge anchors, (2) `test_role`. Re-pin to schema/contract once those land. This is the next real work — the hope is julie is ready soon.
+- **M9 ad-hoc big-file/log-viewer: PARKED** (spec only, 173d3e3). Build deferred until the make-or-break risk is measured: julie's full-content-into-SQLite ingest cost on a multi-GB log. Real competitor is grep/rg/jq, not just tail. The one durable win is structurally-bounded output. Likely fork if built: structured→julie ingest, logs/text→direct streaming line-reader. Don't build without running the gating experiments in docs/m9-design.md.
+
+## Guardrails that are now load-bearing (don't erode)
+
+- **Two test suites.** Default (`Category!=Scale`) must stay <10s and pure. Scale (`Category=Scale`) spawns real julie-server / builds big fixtures and is opt-in. A bare `dotnet test` runs ONLY fast (csproj `VSTestTestCaseFilter`).
+- **Any julie-spawning test MUST** be `[Trait("Category","Scale")]` at class level AND obtain the binary via `ScaleTestSupport.RequireJulieServer()`. The `ScaleTraitConventionTests` guard fails the build otherwise — add the trait, don't weaken the guard.
+- **Build is 0 warnings / 0 errors** (`TreatWarningsAsErrors`); analyzer warnings (CA1416, xUnit1051) are build errors.
+- **Never trust a workflow/test self-report.** Independently rebuild + run both suites via TRX counters before claiming green.
+- `Miller.Core` stays pure (zero I/O deps).
+
+## Cross-language principle (project-wide)
+
+Features ship for **every capable language**, not just C#/TS. Consume julie's all-language signals (e.g. `is_test` in `symbols.metadata`, computed across 34+ langs by julie's `test_detection.rs`); never hardcode a "languages I care about" list. This directly governs how M4's resolver must be built.
+
+## Working norms
+
+- Commit/push only when asked (just did, at user request; pushes to anortham/miller are pre-authorized).
+- Redirect noisy bash to /tmp logfiles and Read back; never parallel-batch shell calls where one grep/find exit-1 cascades-cancels the batch.
+- ADHD-friendly replies: lead with the answer, concise bullets, plain words.

--- a/docs/findings/m4-extract-reality-28-2.md
+++ b/docs/findings/m4-extract-reality-28-2.md
@@ -1,0 +1,136 @@
+# M4 ground truth — what julie 28/2 ACTUALLY captures (verified extract, 2026-05-30)
+
+Produced by extracting **MyraNext** (the richest 3-repo study target: AutoMapper + Dapper + typed axios) with the
+local **julie-server 7.13.0** binary (schema 28 / contract 2) and inspecting the real rows. This supersedes the
+*assumed* shapes in the M4 design's first draft and corrects two overclaims in
+[cross-language-bridge.md](cross-language-bridge.md). Every number below is from the real DB
+(`/tmp/mn.sqlite`, 29,663 symbols, 24,830 identifiers).
+
+**Why this doc exists:** the first M4 design was written against assumed column shapes and was caught by a codex
+adversarial review + this extract. The rule it violated: *negative/▢shape claims need positive verification.* This
+is that verification.
+
+---
+
+## Row counts (MyraNext)
+
+| table | rows | note |
+|---|---|---|
+| symbols | 29,663 | |
+| identifiers | 24,830 | |
+| type_arguments | 1,797 | ~7% of identifiers (matches julie's measured bloat budget) |
+| symbol_annotations | 1,339 | mostly test traits; the bridge-relevant ones are a minority |
+| literals | 111 | 96 `url` + 15 `sql` |
+
+## Verified table shapes (from `.schema`)
+
+**`type_arguments`** — `id, identifier_id→identifiers(id), parent_arg_id→type_arguments(id) (nesting), ordinal,
+type_name, target_symbol_id (NULL at extract), file_path, language, last_indexed`. **Keyed by `identifier_id`.**
+
+**`literals`** — `id, literal_text (DECODED, interpolation folded to {}), kind (url|sql|route|other),
+carrier (the verbatim callee), arg_position, language, file_path, start/end span, containing_symbol_id, confidence`.
+**NO `identifier_id`** — only `containing_symbol_id` + span. (Codex finding confirmed.)
+
+**`symbol_annotations`** — `id, symbol_id→symbols(id), ordinal, annotation, annotation_key (lowercased),
+raw_text (the verbatim attribute incl. args), carrier, UNIQUE(symbol_id, ordinal)`. **Args live ONLY in
+`raw_text`** (e.g. `HttpGet("name/{name}")`); no parsed-arg columns, no file/line columns. (Codex finding confirmed.)
+
+---
+
+## What each resolver leg ACTUALLY gets (the decisive part)
+
+### ✅ Leg 2 — DTO ↔ Entity via `CreateMap<A,B>` — STRONG
+Real rows, ordered + directional:
+```
+CreateMap [0] Core.Reporting.Data.Account      [1] ResponseObjects.Account
+CreateMap [0] Permission                        [1] ResponseObjects.SecurityPermission
+CreateMap [0] Core.Reporting.Data.Investigator  [1] ResponseObjects.InvestigatorRole
+```
+20 maps, ordinal 0 = source entity, ordinal 1 = dest DTO. **This leg works exactly as designed.** Join
+`type_arguments` (where the use-site identifier name = `CreateMap`) → ordered `type_name`s.
+
+### ✅ Leg 3 — Entity ↔ Table via `DbSet<Entity>` — STRONG (but NOT via `[Table]` or Dapper)
+```
+DbSet [0] ApplicationUser   DbSet [0] Preferences   DbSet [0] AppSetting   DbSet [0] ObjectCodeMapping ...
+```
+11 entities, clean. **Critical correction:** none of these entities carry a `[Table]` annotation (verified: 0
+`table` keys in `symbol_annotations`). EF uses **convention** = the DbSet *property name* as the table. So the
+table name comes from the **property symbol that owns the `DbSet<T>` use-site** (via `containing_symbol_id`), NOT
+from a `[Table]` attribute and NOT from a pluralizer-on-the-entity-name. The pluralizer is at most a fallback.
+
+### ✅ Leg 1 — TS call → C# endpoint via (verb, route) — STRONG, but via carrier+literal, NOT axios<T>
+TS side (96 `url` literals, all `arg_position=0`):
+```
+/api/appsettings            carrier=axios.post   @createApplicationSetting
+/api/messages/{}/dismiss    carrier=axios.patch  @dismissMessage
+/api/objectcodemappings/{}  carrier=axios.delete @deleteObjectCodeMaping
+```
+C# side (`symbol_annotations` on controller methods):
+```
+GetByUsername  httpget  HttpGet("username/{username}")
+Post           httppost HttpPost("award")
+Delete         httpdelete HttpDelete("{id}")
+```
+**The carrier encodes the HTTP verb** (`axios.post` → POST). `literal_text` is the route with `{}` for params.
+So `(verb, normalized-route)` is derivable on BOTH sides with **no type argument needed.** The route bridge is
+fully intact.
+
+---
+
+## The corrections (assumptions that were WRONG)
+
+### ✗ `axios.get<T>` response generic is NOT captured (codex finding — CONFIRMED)
+`type_arguments` keyed by callee shows **zero** `get`/`post`/`put`/`delete` entries. julie's TS extractor records
+generic args for `extends`, `new`, and type references — **not generic calls** (`typescript/identifiers.rs:57-99`).
+**Workaround (turns this from blocking → non-issue):** the response DTO is the **C# controller method's return
+type** (existing `symbols.signature`), reachable once the (verb,route) match identifies the endpoint. Resolve the
+response shape from the backend, not the frontend. The TS-side generic was never needed for the link, only for the
+shape — and the shape is on the C# side.
+
+### ✗ Dapper `FROM`-table leg BARELY FIRES on real data (NOT in codex's review — found only by extracting)
+This is the most important correction. Of 15 `sql` literals, **only 2 contain `FROM`** — and both are a
+`ReadinessCheck` healthcheck (`SELECT TOP 1 Id FROM dbo.AppSettings`). The other 13 are stored-proc artifacts:
+```
+[AccountNumber, ProjectRole]  carrier=QueryAsync  @GetAwardProjectsFor   arg=2   <- Dapper splitOn: columns
+[ProjectRole]                 carrier=QueryAsync  @GetNegotiationProjectsFor arg=2
+[ActivityId]                  carrier=QueryAsync  @GetUnfundedAgreementsFor  arg=2
+```
+MyraNext's real data access uses **stored procedures** (`CommandType.StoredProcedure`), so there is **no inline
+`SELECT…FROM`** for julie to capture — it captures the string *arguments* to `QueryAsync` (splitOn column lists,
+param names), classified `sql` because the carrier is a SQL carrier. **The study's "Dapper FROM (17 tables)" was the
+12-agent source probe reading raw source — NOT what julie's literal extraction yields.** There is a real gap between
+"recoverable from source" and "present in the contract." **Consequence:** entity↔table must lean on EF `DbSet`;
+the Dapper-FROM anchor is opportunistic bonus that fires only on repos with inline SQL, not stored-proc repos.
+
+### ✗ `carrier`/`kind` were mislabeled in the design draft (codex finding — CONFIRMED)
+Draft said `carrier ∈ {url,route}`, `carrier=sql`. Reality: **`carrier` = the callee** (`axios.post`, `QueryAsync`,
+`GetAsync`); **`kind` = url|sql|route|other**. Filter/branch on `kind`; read the verb from `carrier`.
+
+### ✗ `[FromBody]`, `[Table]`, `ToTable` not captured (codex findings — CONFIRMED, but low impact)
+- Parameter attributes (`[FromBody]`) are not persisted (only decl-level attrs). The request-body DTO degrades to
+  the controller method's parameter type in `signature`. Not needed for the call→endpoint link.
+- `[Table]`/`ToTable` not captured → entity→table is DbSet-property-name + convention (see Leg 3). Fine for EF.
+
+### ✗ `literals` cannot join to `type_arguments` by key (codex finding — CONFIRMED)
+`type_arguments.identifier_id` vs `literals.containing_symbol_id`+span — no shared call-site key. Pairing a
+`QueryAsync` literal with its generic `T` requires **span-proximity within the same containing symbol**, not a join.
+Low impact given the Dapper leg is weak anyway, but the rule must be explicit where it's used.
+
+---
+
+## Net assessment
+
+**All three legs resolve on real data** — the differentiator is intact — but:
+- **Strong, contract-backed:** `CreateMap` (DTO↔entity), `DbSet` (entity↔table), carrier+literal+annotation
+  (TS↔endpoint route). These are MyraNext's actual recall drivers.
+- **Pivots that defuse 2 "blocking" findings:** verb-from-carrier; response-DTO-from-C#-return-type.
+- **Genuinely degraded:** Dapper-FROM (stored-proc repos lose it), request-body typing, table-name overrides.
+- **The honesty caveat stands harder than before:** recall numbers from the study were measured on *source*, and
+  the *contract* captures a subset. Re-measure recall on the **contract** (this extract), not the source probe,
+  before claiming a number to anyone.
+
+## Reproduce
+```
+/Users/murphy/source/julie/target/release/julie-server extract --db /tmp/mn.sqlite --root ~/source/MyraNext --json scan
+sqlite3 /tmp/mn.sqlite < /tmp/probe.sql   # (and probe2.sql)
+```

--- a/docs/plans/2026-05-30-live-test-engine-design.md
+++ b/docs/plans/2026-05-30-live-test-engine-design.md
@@ -1,0 +1,285 @@
+# Live-Test Engine — agent-friendly continuous testing
+
+**Status:** PARKED design (parking-lot). Not scheduled. M4 (cross-language resolver) is the real
+next work and this is intentionally behind it. Captured 2026-05-30 from a brainstorming session so
+the design survives compaction.
+
+**One-line:** a Wallaby/NCrunch-style continuous-testing engine *for coding agents* — so an agent can
+ask "did my edits break anything I have a test for, and what did I just leave unverified?" instead of
+compulsively re-running the whole suite after every trivial change.
+
+---
+
+## 1. Problem & intent
+
+**Observed behavior:** agents run `dotnet test` / `npm test` obsessively — after every one-line edit,
+rename, or comment change. It is slow, token-expensive, and unnecessary for the ~80% of edits that
+don't touch tested behavior.
+
+**Goal:** give agents a *cheap, trustworthy* read of test state so they skip the compulsive re-run.
+
+**Critical distinction — the goal is behavior change, not tool existence.** A `get_test_status` tool
+can exist and agents will *still* run tests, because:
+
+1. **Verification prior** — models are trained to confirm by executing; a bare external "green" reads
+   as an unverified claim.
+2. **Explicit instructions** — TDD skills + CLAUDE.md say "run the tests." A passive tool loses to an
+   active instruction.
+3. **Staleness uncertainty** — if freshness is unknowable, re-running is always the safe default.
+4. **No felt cost** — the agent doesn't *experience* a 30s run as expensive the way a human does, so
+   "save time" alone doesn't motivate it.
+
+The engine is necessary but **not sufficient**. What changes behavior is the *output framing* + a
+*behavioral skill stanza* (see §6).
+
+**Honest success bar:** eliminate the *compulsive* re-run after trivial edits (the 80% case). Running
+at genuine decision points (about to commit, feature done) is **correct behavior, not failure.** Do
+not oversell this as "agents never run tests again."
+
+---
+
+## 2. The reframe: a safety tool, not a status tool
+
+Wallaby answers "what's the state of my tests?" (status). The agent's real question after an edit is:
+
+> **"Did I just break anything I have a test for?"**
+
+That's a **safety question**, and the common answer is **no**. So the headline output is a *negative
+claim*: "nothing you changed is covered by a now-failing test." Why this is better:
+
+- **It's the common case** → the tool's most frequent answer is a confident, cheap "you're clear."
+- **Cheaper to make trustworthy** → a green *status* needs the whole relevant suite re-run; a
+  "you didn't break anything" claim only needs *the tests covering your changed lines* re-run and
+  passing. Narrower scope = faster, fresher, easier to defend.
+- **It's exactly what the agent acts on** → "you're clear" → keep working.
+
+### The trap: a negative claim is only as good as "covered by a test"
+
+> `"Nothing you changed is covered by a failing test"` can be true because **the code has no test at
+> all.** That is a **false all-clear — the most dangerous output the tool can produce.**
+
+**Mitigation — the dual claim.** The negative claim MUST carry its denominator. The **uncovered set
+is co-headline, not a footnote**:
+
+> ✅ "Your edits to A.cs, B.cs are covered by 9 tests; all 9 re-ran 0.8s ago, 0 failures.
+>    C.cs has NO covering test — 14 lines unverified."
+
+"You're clear *where you have coverage*, and here's exactly where you don't." This is both more honest
+than a green and more useful — it tells the agent where to *add* a test, which is the TDD-aligned next
+move.
+
+---
+
+## 3. The loop
+
+```
+file watcher → debounce → diff changed files → (M4 impact pre-filter) → select affected tests via
+coverage map → run affected in background → confirm reds → update state → agent reads check_changes (cheap)
+```
+
+The warm, long-lived Miller MCP server is what makes this pay off: the daemon outlives individual
+agent calls, so the coverage map and last results are already warm when an agent connects.
+
+---
+
+## 4. Architecture
+
+Mirrors Miller's existing Core/Server discipline.
+
+- **`Miller.LiveTest.Core`** — pure, ZERO-I/O, unit-tested in ms:
+  - selection algorithm (changed files → affected test units)
+  - coverage-map model (granularity-agnostic: keyed by file *or* method id)
+  - the **state machine** + staleness rules (pure functions over events)
+  - debounce policy as pure functions over an event stream
+- **I/O layer** (in `Miller.Server` or a `Miller.LiveTest` I/O project):
+  - file watcher (reuse M3's watcher infra where possible)
+  - `ITestRunner` adapters (process spawning, the non-pure part)
+  - coverage parsing (per-runner formats)
+  - `ct.db` persistence
+- **Exposed via the existing Miller MCP server** — the agent uses the connection it already has.
+
+**Identity note:** this expands Miller from *read-only structural intelligence* into a *process
+executor with runtime state*. Contained to Server + the new lib. `Miller.Core` and julie-consumption
+stay strictly read-only. This is a real identity expansion and should be a conscious decision when
+the work is actually scheduled.
+
+### Persistence — `ct.db`
+
+- **Dedicated DB, NOT julie's read-only `symbols.db`.**
+- Coverage map + last results keyed by **content hashes** (test file hash + source file hash) so a
+  restart does not rebuild the expensive map; invalidate an entry only when its hash changes.
+- Persisting last results means a fresh agent session gets instant status.
+
+---
+
+## 5. The trust contract (the whole point)
+
+State per unit (file now, method later):
+
+`green | red | running | stale | uncovered | unknown`
+
+- **Invariant:** never report `green`/clear for a unit whose covered content changed without a
+  completed passing re-run. Degrade to `stale` and say why. **The tool never lies — that's what lets
+  an agent skip running.**
+- `uncovered` is a **feature**, not an error: "this source has no covering test" is gold for an agent.
+- **Output is an argument, not a verdict.** Every response carries its evidence: what ran, when,
+  against which content hash, and an explicit discharge ("you do not need to run these"). A bare
+  `{status:"green"}` does not change agent behavior; a defensible claim does.
+
+### Flake handling — trust-critical, not a nicety
+
+A negative claim ("you didn't break it") destroyed by a *flaky* red is a false alarm that **retrains
+the agent to distrust the tool** — fatal to the whole premise. Likewise a flake-driven false green.
+
+- **Confirm-before-report:** a red in the affected set is re-run (≥1×) before it is reported as
+  "you broke this." Track confirmed-red vs flaky-red as distinct.
+- Flag order-dependence / inconsistency; consider quarantine for chronically flaky tests.
+- (Detailed flake policy not yet fully specced — drill before building.)
+
+---
+
+## 6. Adoption — the part that isn't in the tool
+
+Tool quality alone loses to an explicit "run the tests" instruction. The deliverable is three things,
+not one:
+
+1. **The engine** (§3–§5).
+2. **Output-as-argument** — the persuasion layer (§5). The output schema is a *product surface*.
+3. **A behavioral skill stanza / CLAUDE.md instruction** — a first-class shipped artifact:
+   > "Before running tests, call `check_changes`. If it reports the affected tests fresh-clear with
+   > evidence, trust it and skip the run. Run only when status is stale/red/unknown for your change."
+
+This is the **same adoption pattern Miller already uses** for "use julie not grep" — proven in-house.
+Dropping #3 makes #1 and #2 underperform.
+
+---
+
+## 7. `ITestRunner` plugin seam
+
+- `Discover` → leans on **julie's `is_test`** for cross-language discovery (language-agnostic);
+  the runner maps to framework-specific test IDs.
+- `Run(selection, wantCoverage)` → results (pass/fail/duration/message/stack) **+ coverage map**.
+- **Granularity-agnostic coverage unit** (keyed by file *or* method id) so per-file → per-method does
+  not touch consumers.
+- Capability flags: `SupportsPerMethodCoverage`, `SupportsWarmHost`.
+
+**Honest cross-language note:** *discovery* stays language-agnostic (julie). *Execution* is
+necessarily per-runner — there is no universal test protocol (xunit ≠ nunit ≠ jest ≠ vitest). This is
+the legitimate exception to the project's "don't hardcode a languages-I-care-about list" rule:
+discovery is universal, execution adapters are inherently per-framework.
+
+---
+
+## 8. Coverage acquisition
+
+The map (test → lines it executes) is a **runtime** artifact. **Amortization insight that makes this
+tractable:** you pay the expensive instrumented pass *once per test-body change*; every edit after
+that is a surgical re-run of the few affected tests. "Slow to build the map" is fine — it happens
+rarely, in the background.
+
+### .NET (the #1 technical risk — be honest)
+
+- Stock **coverlet** gives *aggregate-per-run*, not per-test.
+- xunit v3 (already used by `Miller.Tests`) runs on **Microsoft.Testing.Platform (MTP)** — a native
+  host you can drive programmatically. This helps; you're not fighting legacy VSTest.
+- **MVP (per-file):** run the MTP test project filtered to one test file at a time with MS Code
+  Coverage; attribute covered source → that test file. Slow but amortized + incremental + background
+  (only rebuild changed files' entries).
+- **Parity (per-method):** a custom MTP **data collector** that snapshots coverage deltas at
+  `TestCaseStart`/`TestCaseEnd` → per-method attribution in **one** instrumented pass + a **warm
+  host** for instant re-runs. This is the real engineering and the actual road to NCrunch feel.
+
+### JS/TS
+
+- vitest / c8 / v8 give per-test coverage **much** more cheaply than .NET. Phase 2 forces
+  `ITestRunner` honest (two real impls stop framework assumptions leaking) at low cost.
+
+---
+
+## 9. MCP surface
+
+- **`check_changes`** (PRIMARY) — "since your last edits: what **broke** (confirmed-red) + what's now
+  **unverified** (uncovered)." The dual claim of §2. Token-thrifty default; evidence included.
+- **`get_test_status`** (secondary) — whole-suite view (counts + reds detail + scope filter +
+  verbosity).
+- **`run_tests`** (secondary) — force a run at a scope (all/project/file/test) for explicit
+  re-validation.
+
+---
+
+## 10. Strategic coupling to M4
+
+`check_changes` needs "what changed → what does it reach" = **impact analysis**, which is exactly
+M4 (the cross-language resolver, Miller's differentiator). The live-test engine becomes a
+**consumer of M4** — the static impact graph is the cheap pre-filter that narrows the change delta
+*before* consulting the (expensive) coverage map. This is strategically tidy: it makes M4 *more*
+valuable rather than competing with it. It also means this work should land **after** M4, not before.
+
+---
+
+## 11. Risks
+
+1. **.NET per-test attribution in one warm run** — the #1 risk. **Spike before locking the parity
+   architecture** (see §13). Everything downstream depends on whether MTP + a coverage collector can
+   give per-test attribution without N processes.
+2. **False all-clear from missing coverage** — mitigated by making `uncovered` co-headline (§2).
+3. **Flaky red/green retraining distrust** — mitigated by confirm-before-report (§5).
+4. **Map-build perf on big suites** — mitigated by incremental/background build, but **measure**.
+5. **Identity expansion** (read-only → executor) — contained to Server + new lib; conscious decision
+   at scheduling time.
+6. **Per-file MVP under-delivers on the headline.** "Uncovered" precision (which *lines* have no
+   test) concentrates the safety value, and that wants per-method/per-line. The reframe **raises the
+   value of the parity path** from "nice polish" to "where the headline gets its precision." Know
+   that the MVP is a stepping stone, not the product.
+
+---
+
+## 12. Roadmap
+
+- **MVP:** .NET runner, per-file coverage, watch loop, state machine, `ct.db`, `check_changes` +
+  the two secondary tools, the skill stanza. **Dogfood on Miller's own suite.**
+- **Phase 2:** JS/TS runner (vitest/c8) — cheap coverage, forces `ITestRunner` honest.
+- **Phase 3 (parity):** per-method collector + warm host. **Gated on the §13 spike.**
+
+---
+
+## 13. The spike to run first (when this is picked up)
+
+**Question:** Can MTP + a coverage extension/data collector produce **per-test (ideally per-method)
+coverage attribution in a single warm-host run**, without spawning one process per test?
+
+- **If yes:** true NCrunch/Wallaby parity is far closer than the N-runs approach implies; design the
+  parity architecture around the collector from the start.
+- **If no:** per-file MVP via individual filtered runs is the realistic near-term ceiling; parity
+  needs heavier custom instrumentation.
+
+Run the spike against `Miller.Tests` (a suite we know cold) before committing to the parity
+architecture. This is real work, not brainstorm — scope it when scheduling.
+
+---
+
+## 14. Out of scope (Wallaby/NCrunch features with no agent analog)
+
+Do **not** chase these — they are human-IDE features that don't help a tool-calling agent:
+
+- live inline variable values
+- time-travel debugging
+- editor gutter overlays
+
+"Parity" here means the **coverage-driven selection engine + warm execution + the safety claim**, not
+the IDE overlay. That's the tractable, agent-relevant half.
+
+---
+
+## Acceptance criteria (for the eventual MVP, not now)
+
+- [ ] `Miller.LiveTest.Core` is pure (zero I/O deps), selection + state machine unit-tested in ms.
+- [ ] File watcher → debounce → select → background run → state update loop works on Miller's suite.
+- [ ] `check_changes` returns the dual claim (broke + uncovered) with evidence (what/when/hash).
+- [ ] Trust invariant holds: no clear/green for a changed-but-not-rerun unit (degrades to `stale`).
+- [ ] Reds are confirm-before-report (flake guard); confirmed-red vs flaky-red distinguished.
+- [ ] `uncovered` set reported as co-headline.
+- [ ] `ct.db` is separate from `symbols.db`; coverage map keyed by content hash; survives restart.
+- [ ] `ITestRunner` coverage unit is granularity-agnostic (file→method without consumer changes).
+- [ ] Behavioral skill stanza shipped alongside the tool.
+- [ ] Dogfooded: Miller's own dev loop uses `check_changes` instead of compulsive `dotnet test`.

--- a/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
+++ b/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
@@ -1,0 +1,331 @@
+# M4 — Cross-language structural resolver + `trace` (design, v3.2)
+
+**Status:** spec for review (v3.1 — revised after a real extract + codex adversarial review + an 8-agent verification
+workflow incl. a completeness critic). M4 is Miller's differentiator: deterministic cross-language code tracing
+nothing else does, with no embeddings. Captured 2026-05-30.
+
+**Scope decision (from brainstorm):** build it *right* the first time — all three bridge legs + the `trace` tool
+against the full chain, not a spine-only MVP. The "do it right" call is the user's explicit instruction.
+
+**Grounding (do not re-derive — read these):**
+- **VERIFIED extract reality (READ FIRST):** [findings/m4-extract-reality-28-2.md](../findings/m4-extract-reality-28-2.md)
+  — what julie 28/2 *actually* captures, from a real MyraNext extract, triangulated by three independent reviews.
+- 3-repo evidence: [findings/cross-language-bridge.md](../findings/cross-language-bridge.md) (NB: its recall numbers
+  were measured on *source*; the *contract* captures a subset. Re-measure on the contract before quoting a number.)
+- Memory: `xlang-bridge-resolver-design`, `codesearch-viability-verdict`. Seam: [findings/architecture-decision.md](../findings/architecture-decision.md)
+
+**Review history:** v1 assumed column shapes (5 wrong). v2 re-grounded on a real extract but over-graded leg strength
++ got the DbSet join wrong. v3 folded in codex + 7 data-verifier agents. **v3.1** adds the completeness critic's
+finding (ASP.NET `[controller]`/`[action]` route-token expansion — a hard break if missed) plus the CreateMap
+copy-direction and signal-payload refinements. Corrections flagged inline as **[v3]/[v3.1]**.
+
+---
+
+## 1. What M4 delivers
+
+**The capability:** follow a thread of code *across languages*, deterministically. Two bridge kinds:
+1. **Type-correspondence chain** (data model): `IUser.ts → UserDto.cs → ApplicationUser.cs → ApplicationUsers (table)`.
+2. **Call bridge** (control flow): a Vue/TS HTTP call ↔ the C# controller endpoint it hits, plus the shape it sends
+   (request DTO) and receives (response DTO, when the endpoint exposes one).
+
+**The tool:** `trace`, three modes — `auto` (callers/callees via `SymbolGraph`), `path` (shortest path), `bridge`
+(the cross-language chain via the new `BridgeGraph`).
+
+**Why this is the differentiator:** the 3-repo study proved the bridge is recoverable by cheap deterministic signals,
+and that **embeddings rescue 0 concepts and would *add* false positives**. The resolver reads what the code *states*;
+embeddings guess. **Honesty caveat:** the study's recall was source-measured; the contract captures a subset and each
+leg's strength varies (§2/§4). M4 ships measured per-leg grades, not one headline number.
+
+---
+
+## 2. The contract bump (26/1 → 28/2)
+
+M4 consumes julie's `miller-bridge` enrichment (v7.13.0, schema 28 / contract 2). Verified sources + real-data strength:
+
+| Resolver signal | verified julie source (28/2) | strength on real data |
+|---|---|---|
+| `CreateMap<A,B>` ordered generic args | `type_arguments` via `identifiers.name='CreateMap'` **`kind='type_usage'`** | **STRONG** — 10 calls / 20 rows; ordinal = **copy-source→dest** (not entity→DTO) **[v3.1]** |
+| DbSet entity + table name | the **DbContext property symbol** (`kind=property`, signature has `DbSet<T>`) | **STRONG** — 11; **[v3] NOT via use-site `containing_symbol_id` (→ the class)** |
+| TS route + verb | `literals` `kind=url`, **frontend-lang + non-test**; verb from `carrier` only if it ends in a verb / `<Verb>Async` | **STRONG on axios.`<verb>`** — 39 TS; **[v3] verb-unknown for fetch/$fetch/ky/got; wrappers dropped by julie** |
+| C# endpoint route + verb | `symbol_annotations` (`httpget/...`; route in `raw_text`) + class `[Route]`; **`[controller]`/`[action]` are literal tokens** | **STRONG once tokens expanded** **[v3.1]** |
+| C# endpoint **response DTO** | endpoint method's `signature` return type, **balanced-bracket unwrapped** | **[v3.2] PARTIAL — ~55% (39/71 excl. primitives); 1 `Task<bool>` dropped; bare `ActionResult`/`IActionResult` (31/71, 44%) → no edge** |
+| request DTO | `[FromBody]`/param type in method `signature` | **[v3] `consumes→` edge** — recovers the mutation case |
+| `ToDto(this Entity) → XDto` | extension-method `signature` | **[v3] UNVERIFIED** — 0 in MyraNext; needs a manual-mapping fixture |
+| inline `new XDto { ... }` projections | `identifiers` + `code_context` (no structured src→dest) | **[v3] WEAK** — name-overlap, corroborator-only, never High |
+| field-sets; C# `record` positional params | child symbols via `parent_id`; records parsed from `signature` | **[v3] records have no property children → parse positional params** |
+| `test_role` | `symbols.metadata` JSON | NEW field (not a resolver input; excludes test HttpClient calls + feeds M5) |
+
+**[v3/v3.1] corrections folded in** (all triangulated by codex + workflow + SQL):
+- DbSet→table: use the property symbol, not `containing_symbol_id` (→ DbContext class).
+- "96 TS calls" = 39 TS + 57 C# test HttpClient — filter url literals by language + test_role.
+- verb-from-carrier is not a julie invariant (verb-less carriers + dropped wrappers) → derive conditionally.
+- response-DTO is partial (~55%); parse return types by **balanced bracket depth** (`Task<ActionResult>` vs
+  `Task<ActionResult<X>>` differ by one token — substring match would misclassify all 25 bare ones).
+- CreateMap ordinal encodes **copy data-flow (source→dest), NOT entity→DTO**; use-site `kind='type_usage'` not `'call'`.
+- ASP.NET routes use literal `[controller]`/`[action]` tokens (21/23 controllers) — **must expand** (§4/§5).
+
+**`test_role` is NOT a resolver input.** Used to exclude C# test HttpClient calls from the route bridge + feed M5.
+
+**Gate stays exact-equality.** `MillerExtractContract` flips `26→28`/`1→2` (strict `!=`; both dials moved together,
+no intermediate pair released). Local re-pin + version tests land now; `julie-pins.json` sha256s + Scale tests wait on
+the v7.13.0 release assets.
+
+---
+
+## 3. Architecture — where everything lives
+
+Respects the existing logic↔infra seam.
+
+```
+Miller.Core   (pure, ZERO I/O)
+  • Contracts: TypeArgument, LiteralRecord, SymbolAnnotation, FieldSet, DbSetProperty
+  • Resolver/
+      - RouteNormalizer     (verb known/unknown; [controller]/[action]/[area] token expansion; route canonicalization)
+      - NameNormalizer      (affix-fold, singular↔plural, I-/_ strip)
+      - FieldSetExtractor   (properties via parent_id + C# record positional params)
+      - SymbolResolver      (resolve type_name → symbol by NAME; namespace tie-break; ambiguous → drop/low, never High)
+      - leg resolvers:      RouteBridge, DtoEntityBridge, EntityTableBridge
+      - BridgeScorer        (confidence + corroborator-only invariant; typed Signal payloads)
+  • Graph/BridgeGraph                (immutable, built once per index; mirrors SymbolGraph)
+  • Graph/SymbolGraph.ShortestPath   (new: BFS path query)
+
+Miller.Indexing
+  • SqliteBridgeReader   reads type_arguments / literals (+language) / symbol_annotations + DbContext property symbols
+  • SqliteSymbolReader   extend metadata parse to also read test_role
+  • RepositoryIndexLoader runs BridgeGraphBuilder after the symbol/graph build, publishes BridgeGraph in
+                          MillerRepositoryIndex (rebuilt on FreshnessService.Swap)
+
+Miller.Server
+  • TraceTool            (NEW) 3 modes, token-thrifty output, telemetry — [McpServerTool] pattern
+```
+
+### [v3] Cross-file resolution is by NAME (target_symbol_id is NULL at extract — verified 0/1797 type_args, 0/24830 identifiers)
+Every leg resolves a `type_name` ("ApplicationUser") and a return-type to a symbol **by string name** across files —
+julie ships zero resolved links. CreateMap is entirely cross-file (profile file → entity/DTO defs elsewhere). So
+`SymbolResolver` is a named, tested Core component: resolve by name, tie-break by namespace/project; **>1 match with
+no tie-break → ambiguous → the edge is dropped or emitted at reduced confidence, never High.** A negative test asserts
+two same-named types in different files never auto-resolve to a High edge.
+
+### Storage decision: in-memory, NOT a new SQLite DB
+Built in-memory as a layer of `MillerRepositoryIndex`, like `SymbolGraph`, rebuilt on `FreshnessService.Swap()`. No
+`bridges.db`.
+- **ID-churn safety:** julie IDs are span-derived and churn on edits → always rebuild from the fresh index, never
+  persist across an edit keyed on symbol id. (This is why in-memory rebuild, not persistence, is safe.)
+- **[v3] Cost driver is name resolution, not the breadcrumb set.** Breadcrumbs are tiny (~10 CreateMap, 11 DbSet, ~71
+  controller annotations, 39 TS calls), but the builder resolves names over ~5–7k code symbols (29,663 total). Likely
+  sub-second; **unmeasured at monorepo scale.** Measure at `Swap()` (plan Task 9); persist only if over budget, keyed
+  by schema+contract+resolver-version+workspace+sorted-file-hashes (never `files.hash` alone), never speculatively.
+
+### Single workspace (one index), by design
+M4 resolves bridges within one polyglot tree. Cross-*repo* bridging is out of scope.
+
+---
+
+## 4. The resolver — three legs
+
+All legs emit **typed, evidence-carrying candidate edges**; `BridgeScorer` (§5) assigns confidence. Node kinds:
+`TsType`, `CsDto`, `CsEntity`, `DbTable`, `Endpoint`. Each candidate carries: `kind`, `sourceRef`, `targetRef`,
+`evidence[]` (file:line), `signals[]` (**typed Signal records — §5**), and optional `sourceFieldSet`/`targetFieldSet`.
+
+### Leg 1 — TS call ↔ C# endpoint (route bridge) — STRONG on axios; conditional otherwise [v3/v3.1]
+- **Source (TS):** a `kind=url` literal whose `language` is a **frontend/client language** AND not `test_role`.
+  **[v3.2] Filter against julie's OWN language identifier strings** (`typescript`, `javascript`, `vue`, `svelte`, …) —
+  julie stores full names, so the literal set `('ts','js','vue')` matches **0** rows. Equivalent language-agnostic
+  phrasing: `literal.language != the endpoint language` AND not test. On `/tmp/mn.sqlite` the only two literal languages
+  are `csharp=57` (all test HttpClient) and `typescript=39` (all real calls), so this yields exactly the 39 real TS
+  routes. `literal_text` is the route (`{}`-folded). Containing TS function = `containing_symbol_id`. **Contract test:**
+  the 39 `typescript` url literals survive the filter and the 57 `csharp` ones do not.
+- **Verb derivation:** read the verb from `carrier` **only** when its tail-token is an HTTP verb (`axios.post`→POST) or
+  `<Verb>Async`. For julie's verb-less url carriers (`fetch`, `$fetch`, `ofetch`, bare `axios`, `request`, `ky`,
+  `got`, C# `sendasync`) the verb is in an uncaptured options arg → mark **verb-unknown** (reduced confidence, never
+  assume GET). Custom wrappers (`useApi`, `apiClient`) are dropped by julie's bloat gate → **document the recall gap.**
+- **Target (C#):** a method with `httpget/...` in `symbol_annotations` (verb from `annotation_key`, route from
+  `raw_text`), prefixed by the class `[Route]`. The `parent_id`→class join is 71/71.
+- **[v3.1] Route token expansion (load-bearing — the flagship-leg break if missed):** ASP.NET class routes are the
+  literal token `Route("api/[controller]")` (21/23 controllers) and methods use `[action]`. **Before** prefix
+  concatenation, RouteNormalizer must substitute `[controller]`→ parent class name minus trailing "Controller",
+  lowercased; `[action]`→ method name lowercased; (`[area]` too). Without this, every C# endpoint normalizes to
+  `api/[controller]/…` and matches **zero** TS literals like `/api/appsettings`. The normalizer therefore takes the
+  **parent class name** as input, not just the raw route string.
+- **Match:** `RouteNormalizer` → `(verb, normalized-route)`: token-expand → absolute-override > controller-prefix
+  concat → `${param}`/`{param}`/`:param`→`{}` → trailing-slash + case fold + query strip. A verb-unknown TS call
+  matches on route alone at reduced confidence. **Collision guard:** two controllers with identical method templates
+  (`{id}`) must normalize to **distinct** routes (`api/appsettings/{}` vs `api/objectcodemappings/{}`), never merge.
+- **Response DTO edge — PARTIAL:** `Endpoint —responds→ CsDto` only when the `signature` return type **unwraps (by
+  balanced bracket depth)** `Task<>`/`ActionResult<>`/`IEnumerable<>` to a **named user type — class, interface, or
+  record** (e.g. `AppSetting`, and interface/collection-element targets like `IProject` from `Task<IEnumerable<IProject>>`).
+  **[v3.2] 39/71 excluding primitives (~55%)**; the unwrap also produces **one primitive — `Task<bool>`
+  (`GetAwardFamilyHasSubawardExpenses`) — which is dropped**, so the earlier "40/71" double-counted that `bool`. Bare
+  `Task<ActionResult>`/`Task<IActionResult>` (31/71, ~44%, mostly mutations) → **no edge, no penalty to the route
+  match.** Optional recovery: parse `Ok(dto)`/`CreatedAtAction(…,dto)` from `code_context`.
+- **Request DTO edge:** `TsCall/Endpoint —consumes→ CsDto` from the method's `[FromBody]`/parameter type in `signature`.
+
+### Leg 2 — C# DTO ↔ Entity — STRONG only for CreateMap [v3/v3.1 re-graded]
+- **AutoMapper `CreateMap<A,B>` (STRONG):** `type_arguments` where `identifiers.name='CreateMap'` and
+  **`kind='type_usage'`** (NOT `'call'`), grouped by `identifier_id`, read ordinal 0/1. **[v3.1] ordinal = copy-source
+  → copy-dest (AutoMapper declared order — a julie-tested invariant); do NOT infer entity-vs-DTO from ordinal.** All 10
+  MyraNext maps are entity→DTO read maps *by luck of the fixture*; an inbound `CreateMap<CreateOrderRequest, Order>`
+  legitimately puts the DTO at ordinal 0. Resolve both sides, then classify which side is the entity from independent
+  signals (namespace/folder, `Dto/Request/Response/VM` suffix, or DbSet membership), and tag the edge source→dest.
+  Detect a sibling `ReverseMap` and emit the inverse edge.
+- **`ToDto(this Entity) → XDto` (UNVERIFIED):** 0 in MyraNext; parse extension-method `signature` when present, but
+  **ungraded until a manual-mapping fixture exists** (Task 1).
+- **inline `new XDto { ... }` projections (WEAK):** no structured source→dest signal; source entity by name-overlap
+  over `code_context`. **Corroborator-only, never High.**
+- **`[JsonProperty("x")]` renames:** `symbol_annotations` (arg from `raw_text`; affects field-set matching).
+
+### Leg 3 — C# Entity ↔ DB table — STRONG via the DbSet PROPERTY symbol [v3 corrected]
+- **Primary:** enumerate `symbols WHERE kind='property' AND signature LIKE '%DbSet<%'`. **Table = the property name;
+  entity = the `DbSet<T>` generic arg** — both from one symbol row (11/11 correct). Do **NOT** follow the DbSet
+  use-site identifier's `containing_symbol_id` (it points to the DbContext class → "MyraNextContext" for every table).
+  **Guard:** if a symbol reached via `containing_symbol_id` has `kind!='property'`, never use its name as the table.
+- **`[Table("X")]` (when present):** `symbol_annotations` `annotation_key=table`, arg from `raw_text`. `ToTable` is
+  not captured. Pluralizer is a last resort only (would mis-map `Preferences`/`AppSettings`).
+- **Dapper `FROM` (opportunistic only):** a `kind=sql` literal whose text contains `FROM` (rare on stored-proc repos —
+  MyraNext: 2/15), paired to its `T` by span-proximity within `containing_symbol_id`. FROM-table only, never JOINs or
+  multi-map. Never the primary anchor.
+
+### The TS↔C# DTO finisher (name leg)
+- `NameNormalizer`: strip `I`/`_`; strip `Dto/Model/Request/Response/View/VM/Entity`; singular↔plural. Exact-then-affix.
+  The "safe finisher" — **never the sole signal** for an entity↔DTO or entity↔table edge.
+
+---
+
+## 5. Confidence scoring — the trust contract
+
+Every bridge edge carries a score; `trace mode=bridge` shows it. The **corroborator-only invariant** is load-bearing.
+
+**[v3.1] `signals[]` carries TYPED payloads, not bare rule names.** Each Signal = `{rule, value, evidence}` where:
+field-set signals carry `fieldCount` + Jaccard; name signals carry match-tier (`exact|affix`); structural signals
+(`CreateMap`, `DbSetProperty`, `RouteVerbMatch`, `RouteOnlyMatch`, `ReturnTypeDto`, `FromBodyDto`, `DapperFrom`) carry
+a boolean + evidence. The closed rule set is defined in plan Task 4 *before* any leg emits, so the §5 rules are
+decidable by the scorer from the candidate alone — no leg-side precision logic, no Task-5 retrofit. **[v3.2] Name
+ambiguity rides in the payload too: each side carries a `NameResolution{endpoint, status: resolved|ambiguous|unresolved,
+matchCount}` signal from `SymbolResolver`, so the *ambiguous-name → never High* rule (below) is enforced from the
+candidate alone; the scorer never re-queries the resolver, and `unresolved` ⇒ no edge.**
+
+- **High (≥0.9):** an explicit structural breadcrumb fired — `CreateMap`, `DbSetProperty`, or a `(verb, route)` match
+  with a known verb (after token expansion). `DapperFrom` is High only when a real `FROM` literal is present.
+  **An edge whose name resolves ambiguously (>1 symbol, no tie-break) can NEVER be High.**
+- **Medium (~0.7–0.85):** exact/affix name match with ≥1 corroborator; or a route-only match (verb-unknown).
+- **field-set Jaccard is NEVER a sole signal** — it only raises an existing edge. A 1-field/generic shape can't anchor
+  (kills the `RevisionEntry ↔ DocumentRevisionDto` class of false positives). The scorer reads `fieldCount`/Jaccard
+  from the Signal payload to enforce this — a bare `signals:["fieldset"]` could not. **field-set source = properties
+  via `parent_id` PLUS C# `record` positional params from `signature`** (records have no property children → naive
+  query gives an empty set and misfires the corroborator).
+- **Multi-signal boost:** N independent signals score higher and are marked as such.
+
+**Hardening rules (each closed a real precision/recall bug):** transitive return-type unwrap (balanced brackets);
+record positional params; Dapper `FROM` vs JOIN; route normalization; **[v3.1] `[controller]`/`[action]` token
+expansion + route collision guard; verb-unknown handling; name-collision suppression; test HttpClient exclusion;
+CreateMap copy-direction (classify entity/DTO independently, handle ReverseMap).**
+
+---
+
+## 6. The `trace` tool
+
+```
+trace <target> [mode=auto|path|bridge] [to=<symbol>] [depth=N] [limit=N] [format=compact|full]
+```
+- **default / `auto`** — callers + callees from `SymbolGraph` (depth-bounded).
+- **`to=<symbol>`** — shortest path via new `ShortestPath` (BFS + parent reconstruction; deterministic tie-break by id).
+- **`bridge`** — walk the `BridgeGraph`: TS type → DTO/entity/table chain; TS call → endpoint + consumed/returned
+  shapes; entity → its DTOs/TS types/table.
+
+Token-thrifty `compact` default:
+```
+UserDto (C# DTO, Api/Dtos/UserDto.cs:7)
+  ←name──────  IUser            (TS,     web/src/models/user.ts:3)              0.85
+  ←CreateMap─  ApplicationUser  (C# entity, Domain/User.cs:12)  Profile.cs:24  0.98
+               ApplicationUser
+                 ←DbSet──────  ApplicationUsers (table; AppDbContext.cs:18, DbSet property)  0.97
+```
+`full` adds firing signals per edge + competing lower-scored candidates. Each edge ends in its score; **verb-unknown
+route edges and ambiguous-name edges render with their reduced score + a flag** — nothing is presented as certain when
+it isn't. Target resolution: smart-string (reuse inspect's resolver). Telemetry via the existing interceptor/`Measure`.
+
+---
+
+## 7. Testing
+
+TDD throughout; the resolver is pure `Miller.Core`, unit-tested in milliseconds.
+
+- **Normalizers (table-driven `[Theory]`):** `RouteNormalizer` (verb-known vs verb-unknown carriers; **`[controller]`/
+  `[action]` expansion**; absolute-override; param folding); `NameNormalizer`; `FieldSetExtractor` (incl. C# record
+  positional params); `SymbolResolver` (name collision → drop/low). Every §5 rule = ≥1 row.
+- **BridgeScorer (focused):** field-set-only candidate → no edge; 1-field wrapper never anchors; ambiguous-name never
+  High; multi-signal outscores single — fed by typed Signal payloads (`fieldset{count=1}`→no edge;
+  `fieldset{count=8,jaccard=0.6}`+structural→scores). Proven before any leg exists.
+- **Legs (in-memory fixtures) with mandatory negatives:**
+  - Leg 3: `ApplicationUser` → table `ApplicationUsers` (**not** `MyraNextContext`); `AppSetting`→`AppSettings`.
+  - Leg 1: `Route("api/[controller]")` on `AppSettingsController` + `HttpGet("{id}")` → `api/appsettings/{}`;
+    **collision negative** — two controllers' `{id}` templates → two distinct routes; bare `Task<ActionResult>` → no
+    `responds→`; `[FromBody]` → `consumes→`; a `fetch`/verb-less carrier → route-only (not assumed GET); a C# test
+    HttpClient url literal is excluded.
+  - Leg 2: CreateMap directional via copy-source/dest with **independent entity/DTO classification** (an inbound
+    `CreateMap<XRequest,Entity>` is NOT mislabeled); inline projection corroborator-only; ToDto only via the
+    manual-mapping fixture.
+- **BridgeGraph + ShortestPath:** combined fixture yields the full chain; an ambiguous type name → no High edge; path
+  correctness incl. no-path + tie-break.
+- **Infra (contract tests):** `SqliteBridgeReader` vs a synthesized 28/2 DB; reader→Core mapping + populated
+  `BridgeGraph` after `Load()`. Fast suite, no binary.
+- **trace tool:** `Run()` unit tests for all three modes + output shape (incl. flags).
+- **Scale (opt-in, `[Trait("Category","Scale")]`):** extract a polyglot fixture via `RequireJulieServer()`; assert a
+  known bridge set + scores. Skips without the binary.
+- **Honesty probe (acceptance gate):** run on a deliberately undisciplined fixture; record precision; confirm
+  corroborator-only + ambiguous-name-never-High hold. **Recall measured on the CONTRACT, PER LEG**, written into this
+  doc's appendix. No unmeasured recall claim ships.
+
+Fast suite stays < 10s (`Category!=Scale`).
+
+---
+
+## 8. Risks & honest caveats
+
+1. **Precision on undisciplined repos.** Value prop is "trust the score." If the corroborator-only, name-collision, or
+   route-collision guards leak, the tool emits confident garbage. Mitigation: each unit-tested in isolation; honesty
+   probe is an acceptance gate.
+2. **Single-repo generalization (the big one).** Every "STRONG" grade is verified only on MyraNext. Gaps MyraNext does
+   NOT exercise: fetch/`$fetch`/ky/got verb coverage; custom wrappers dropped by julie's bloat gate (zero route
+   recall); `ReverseMap`/inbound-map direction; `ToDto`/inline-projection legs (0 / no-signal here); name collisions
+   across namespaces; whether `[controller]` token routing holds elsewhere. Mitigation: Task 1 extracts Tycho +
+   LabHandbookV2 + needs a fetch-based and a manual-mapping fixture before any cross-repo strength claim.
+3. **Route token expansion is on the critical path [v3.1].** 21/23 controllers use `[controller]`; miss it and the
+   flagship leg yields zero edges; do it wrong (drop the controller segment) and two controllers' `{id}` templates
+   collide into a High-confidence wrong link. Mitigation: expansion in the core normalizer + the collision negative test.
+4. **Response-DTO is partial (~55%).** Mutations mostly return bare `ActionResult`. No edge when bare; recover via
+   `consumes→` from `[FromBody]`; parse return types by balanced bracket depth, never substring.
+5. **CreateMap direction [v3.1].** Ordinal = copy-source→dest, not entity→DTO; inbound maps invert. Classify
+   entity/DTO independently; handle ReverseMap. Hardcoding entity=0 would emit confident reversed edges.
+6. **Name-based cross-file resolution.** `target_symbol_id` NULL → string-name resolution; collisions → drop/lower,
+   never High.
+7. **BridgeGraph build cost unmeasured at scale.** Cost driver is name resolution over ~5–7k code symbols, not the
+   breadcrumb set. Measure at `Swap()`; persist (full cache key) only if over budget; monorepo unvalidated.
+8. **Symbol-ID churn / single workspace / read-only.** Always rebuilt from the fresh index; cross-repo out of scope;
+   no new process, no writes to julie's DB.
+
+---
+
+## 9. Acceptance criteria
+
+- [ ] `MillerExtractContract` = 28/2; gate rejects any other pair with a typed error; version tests updated;
+      `julie-pins.json` updated once assets publish.
+- [ ] Read layer ingests `type_arguments`, `literals` (+language), `symbol_annotations`, DbContext property symbols,
+      and `test_role`; contract tests on a synthesized 28/2 DB pass.
+- [ ] `Miller.Core` resolver is pure (zero I/O); table-driven tests for every normalizer, `SymbolResolver`, and every
+      §5 hardening rule.
+- [ ] **Leg 3 resolves table = DbSet property name (not the DbContext class).**
+- [ ] **Leg 1: `[controller]`/`[action]` tokens expanded via parent class name; route collisions stay distinct;
+      bare-return endpoints emit no `responds→`; `[FromBody]` emits `consumes→`; url literals filtered to
+      frontend-language + non-test; verb-less carriers are verb-unknown (never assumed GET).**
+- [ ] **Leg 2: CreateMap STRONG via copy-source→dest with independent entity/DTO classification + ReverseMap handling;
+      use-site `kind='type_usage'`; inline projection corroborator-only; ToDto only via a manual-mapping fixture.**
+- [ ] Candidate-edge contract carries typed Signal payloads (fieldCount/Jaccard/name-tier) + source/target field-sets
+      (props via `parent_id` + record positional params); scorer's corroborator-only + ambiguous-name-never-High
+      invariants unit-proven from the payload, not the rule name.
+- [ ] `BridgeGraph` in-memory inside `MillerRepositoryIndex`, rebuilt on `Swap()`, never persisted across an edit;
+      `SymbolResolver` ambiguity policy enforced; `SymbolGraph.ShortestPath` deterministic.
+- [ ] `trace` tool: all three modes, token-thrifty `compact`/`full`, verb-unknown + ambiguous flags shown; telemetry.
+- [ ] Fast suite < 10s and pure; Scale tests tagged + gated on `RequireJulieServer()`; build 0 warnings / 0 errors.
+- [ ] **Honesty probe run; precision recorded; recall measured on the contract PER LEG; numbers written into this doc.**
+      The "shippable to unknown users" gate — without it, M4 is not done.

--- a/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
+++ b/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
@@ -181,9 +181,14 @@ All legs emit **typed, evidence-carrying candidate edges**; `BridgeScorer` (§5)
   **Guard:** if a symbol reached via `containing_symbol_id` has `kind!='property'`, never use its name as the table.
 - **`[Table("X")]` (when present):** `symbol_annotations` `annotation_key=table`, arg from `raw_text`. `ToTable` is
   not captured. Pluralizer is a last resort only (would mis-map `Preferences`/`AppSettings`).
-- **Dapper `FROM` (opportunistic only):** a `kind=sql` literal whose text contains `FROM` (rare on stored-proc repos —
-  MyraNext: 2/15), paired to its `T` by span-proximity within `containing_symbol_id`. FROM-table only, never JOINs or
-  multi-map. Never the primary anchor.
+- **Dapper `FROM` (opportunistic only) — NOT BUILT in Phase C [v3.2 corrected].** The plan was: a `kind=sql` literal
+  whose text contains `FROM`, paired to its `T` by span-proximity within `containing_symbol_id`. **This is unbuildable
+  under the lean 28/2 contract** — `TypeArgument` carries no containing-symbol id and no span, and `LiteralRecord` has
+  no `identifier_id`, so a SQL literal cannot be co-located to its entity type-argument. `BridgeGraphBuilder` therefore
+  passes an **empty `DapperFromCandidates`** list; the `EntityTableBridge` Dapper code path (built + unit-tested in
+  Phase B) is forward-ready but unfed. **EF `DbSet<T>` is the sole entity↔table anchor.** Re-enabling Dapper-FROM is a
+  **julie-side** change (add `containing_symbol_id` + span to `type_arguments`, and/or `identifier_id` to `literals`),
+  not a Miller fix. Low live impact (MyraNext: 2/15 sql literals had a real FROM); larger on inline-SQL/Dapper repos.
 
 ### The TS↔C# DTO finisher (name leg)
 - `NameNormalizer`: strip `I`/`_`; strip `Dto/Model/Request/Response/View/VM/Entity`; singular↔plural. Exact-then-affix.
@@ -303,6 +308,20 @@ Fast suite stays < 10s (`Category!=Scale`).
    breadcrumb set. Measure at `Swap()`; persist (full cache key) only if over budget; monorepo unvalidated.
 8. **Symbol-ID churn / single workspace / read-only.** Always rebuilt from the fresh index; cross-repo out of scope;
    no new process, no writes to julie's DB.
+9. **Lean-contract gaps surfaced building Phase C [v3.2].** Three places where julie 28/2's lean rows force a weaker
+   build than the design assumed. All bounded; none emit confident-wrong High edges.
+   - **Dapper-FROM is unbuildable → dropped** (see Leg 3 above). EF `DbSet<T>` is the sole entity↔table anchor;
+     restoring Dapper needs a julie-side `type_arguments` widening. Highest-impact of the three.
+   - **CreateMap detection is name-blind.** `TypeArgument` has no use-site name/kind discriminator, so the builder
+     admits *every* un-nested exactly-2-top-level-arg generic group as a copy A→B (ordinal 0=source, 1=dest, never
+     flipped). Over-production is bounded by the 2-arg rule and filtered downstream by `SymbolResolver` (unresolvable
+     name → no edge) + `BridgeScorer`. `ReverseMap` is unobservable on the lean contract → `HasReverseMap` always false.
+   - **Endpoint→class `[Route]` join is by name.** The lean contract has no parent-symbol id, so the class route is
+     joined via `SymbolDetail.ParentClassName` (first class with that name in id order). Mis-join risk on duplicate
+     class names across namespaces; the verb-known route match still anchors the `Hits` edge when the class route is
+     loose/missing. The `[FromBody]` honesty holds: `RequestBodyType` is populated only from a plausible complex
+     request-body param on a body-bearing verb, never an arbitrary first parameter (findings 28-2: `[FromBody]` not
+     persisted).
 
 ---
 
@@ -314,7 +333,8 @@ Fast suite stays < 10s (`Category!=Scale`).
       and `test_role`; contract tests on a synthesized 28/2 DB pass.
 - [ ] `Miller.Core` resolver is pure (zero I/O); table-driven tests for every normalizer, `SymbolResolver`, and every
       §5 hardening rule.
-- [ ] **Leg 3 resolves table = DbSet property name (not the DbContext class).**
+- [ ] **Leg 3 resolves table = DbSet property name (not the DbContext class); DbSet is the SOLE entity↔table anchor
+      (Dapper-FROM dropped — unbuildable on the lean contract, see §4/§8).**
 - [ ] **Leg 1: `[controller]`/`[action]` tokens expanded via parent class name; route collisions stay distinct;
       bare-return endpoints emit no `responds→`; `[FromBody]` emits `consumes→`; url literals filtered to
       frontend-language + non-test; verb-less carriers are verb-unknown (never assumed GET).**

--- a/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
+++ b/docs/plans/2026-05-30-m4-cross-language-resolver-design.md
@@ -347,5 +347,110 @@ Fast suite stays < 10s (`Category!=Scale`).
       `SymbolResolver` ambiguity policy enforced; `SymbolGraph.ShortestPath` deterministic.
 - [ ] `trace` tool: all three modes, token-thrifty `compact`/`full`, verb-unknown + ambiguous flags shown; telemetry.
 - [ ] Fast suite < 10s and pure; Scale tests tagged + gated on `RequireJulieServer()`; build 0 warnings / 0 errors.
-- [ ] **Honesty probe run; precision recorded; recall measured on the contract PER LEG; numbers written into this doc.**
-      The "shippable to unknown users" gate — without it, M4 is not done.
+- [x] **Honesty probe run; precision recorded; recall measured on the contract PER LEG; numbers written into this doc.**
+      The "shippable to unknown users" gate — without it, M4 is not done. _(See Appendix: Phase D
+      honesty-probe results [measured 2026-05-31]. Precision 6/6 = 1.00; per-leg recall 1.00/1.00/1.00;
+      Dapper-FROM excluded. Scale gate `LiveBridgeTraceTests` green; fast suite 1050/1050 with Scale
+      excluded.)_
+
+---
+
+## Appendix: Phase D honesty-probe results [measured 2026-05-31]
+
+These numbers are the actual output of the Scale gate
+[`LiveBridgeTraceTests`](../../tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs), run end-to-end
+against the pinned `julie-server` extractor (`scripts/test.sh scale` /
+`dotnet test --filter "FullyQualifiedName~LiveBridgeTraceTests"`). Both Facts pass. The figures are
+emitted by the tests themselves (xUnit `ITestOutputHelper`) and copied verbatim from the run; they are
+not hand-computed.
+
+### Precision (undisciplined fixture)
+
+`HonestyProbe_UndisciplinedFixture_GuardsHold_PrecisionAndRecall` enumerates every surviving scored
+edge on a deliberately messy polyglot fixture and classifies each as TP/FP against a fixed oracle.
+
+| Metric | Value | Floor |
+| --- | --- | --- |
+| Precision (all legs) | **6/6 = 1.00** | 0.75 |
+
+Per-edge verdicts (all TP, copied verbatim from the run):
+
+| Edge | Band | Score | Ambiguous | VerbUnknown | Why |
+| --- | --- | --- | --- | --- | --- |
+| `Account --MapsTo--> AccountDto` | Medium | 0.75 | yes | no | Leg2 CreateMap; ambiguity capped, not High |
+| `Customer --MapsTo--> CustomerDto` | High | 0.95 | no | no | Leg2 Customer↔CustomerDto |
+| `UpdateCustomerRequest --MapsTo--> Customer` | High | 0.90 | no | no | Leg2 inbound CreateMap; Request not mislabeled as entity |
+| `Customer --StoredIn--> Customers` | High | 0.95 | no | no | Leg3 Customer→Customers |
+| `api/orders --Hits--> CreateOrder` | High | 0.90 | no | no | Leg1 POST /api/orders → CreateOrder |
+| `api/reports --Hits--> GetReports` | Medium | 0.70 | no | yes | Leg1 route-only /api/reports → GetReports (verb-unknown, honest Medium) |
+
+**Read this number as a floor-check, not a discriminating detector.** `ClassifyHonesty` labels every
+edge shape this fixture can produce as a TP, so 6/6 = 1.00 is the *designed* outcome of a passing run,
+not a sensitive measurement — a regression that, say, promoted the ambiguous `Account` edge to High
+would still count as a precision TP. The discriminating power lives in the four hard guards below
+(corroborator-only, ambiguous-name-never-High, test-literal-excluded, verb-unknown-not-assumed-GET),
+which assert on the scored payload directly and *would* fail on such a regression. Precision here proves
+"no surviving edge is an outright phantom"; the guards prove "the edges that survive are correctly
+bounded."
+
+### Recall (per leg)
+
+Reported per leg against the known bridge set on the same fixture. Dapper-FROM is **excluded from the
+denominator**: it is not buildable on the lean extract contract (`DapperFromCandidates` is always empty
+in `BridgeGraphBuilder.Build`), so counting it would understate recall against a capability the contract
+does not currently expose.
+
+| Leg | Recall | Detected | Notes |
+| --- | --- | --- | --- |
+| Leg 1 — route (`Hits`) | **1.00** | 1/1 | verb+route and route-only both recovered |
+| Leg 2 — DTO↔entity (`MapsTo`) | **1.00** | 1/1 | Customer↔CustomerDto (probe denominator); Account + inbound Request also detected |
+| Leg 3 — entity↔table (`StoredIn`) | **1.00** | 1/1 | Customer→Customers via `DbSet<T>` |
+| Dapper-FROM | EXCLUDED | — | not buildable on lean contract; `DapperFromCandidates` always empty |
+
+### Guards proven (honesty probe)
+
+Each guard is asserted by the probe, not merely described:
+
+- **Corroborator-only / 1-field-never-anchors** — the 1-field wrapper never anchored a `MapsTo` edge
+  (`MinAnchoringFieldCount = 2`).
+- **Ambiguous-name-never-High** — `Account` (a duplicated type name) caps at Medium, never High.
+- **Test-literal-excluded** — the C# test `HttpClient` url literal produced no `Hits` edge
+  (`IsRealClientCall` filters `csharp` + test-role url refs).
+- **Verb-unknown-not-assumed-GET** — the `/api/reports` route-only edge is Medium with
+  `IsVerbUnknown = true`, not silently promoted to a High assumed-GET.
+- **Inbound-CreateMap-not-mislabeled** — `CreateMap<UpdateCustomerRequest, Customer>` keeps the Request
+  as the source side; it is not relabeled as an entity.
+
+### Disciplined fixture (known bridge set)
+
+`DisciplinedFixture_AllThreeLegs_KnownBridgeSet` asserts the canonical three-leg set with real values
+(copied verbatim from the run):
+
+```
+Leg3 StoredIn: AppSetting -> AppSettings        band=High score=0.95
+Leg2 MapsTo:   AppSetting <-> AppSettingDto      band=High score=0.95
+Leg1 Hits:     api/appsettings/{} -> GetById     band=High score=0.90 verbUnknown=False
+```
+
+It also renders `trace --mode bridge` for `AppSetting` and asserts the rendered hop
+`AppSetting  --DbSet-->  AppSettings  (High)`.
+
+### Production fix landed alongside the gate
+
+The gate surfaced a real trace-output bug, now fixed in
+[`BridgeGraphBuilder.AddNode`](../../src/Miller.Core/Graph/BridgeGraphBuilder.cs): a symbol-backed node
+was rendered with `edgeRef.Display`, which for a `Hits` endpoint carries the **normalized route**
+(`RouteBridge` sets the endpoint `EdgeRef.Display` to `endpointRoute.Route`). The trace therefore showed
+the controller action as `api/appsettings/{}` instead of `GetById`. The node now renders the resolved
+**symbol name** (`symbol.Name`). This is user-facing (`TraceTool.EndpointDisplay` returns
+`node.Display`), not test-only.
+
+### Run evidence (verbatim)
+
+```
+LiveBridgeTraceTests: Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2, Duration: 150 ms
+ScaleTraitConvention:  Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1
+Fast suite (Category!=Scale): Passed!  - Failed: 0, Passed: 1050, Skipped: 0, Total: 1050, Duration: 1 s
+  fast suite wall time: 3s (local target <10s, ceiling 30s)
+Build: 0 Warning(s) / 0 Error(s)
+```

--- a/docs/plans/2026-05-30-m4-cross-language-resolver-plan.md
+++ b/docs/plans/2026-05-30-m4-cross-language-resolver-plan.md
@@ -1,0 +1,268 @@
+# M4 — implementation plan (v3.2)
+
+Companion to [2026-05-30-m4-cross-language-resolver-design.md](2026-05-30-m4-cross-language-resolver-design.md).
+**Read the design first, and read [findings/m4-extract-reality-28-2.md](../findings/m4-extract-reality-28-2.md)** —
+every task is written against *verified* julie 28/2 output, triangulated by a codex review + an 8-agent verification
+workflow (incl. a completeness critic) + direct SQL.
+
+**v3.2 changes (post v3.1 re-review — codex + SQL):** (1) url-literal filter uses julie's FULL language strings
+(`typescript`, not `ts`/`js`/`vue` which match 0 rows); (2) response-DTO bucket corrected to **39/71 excl. primitives**
+(the lone `Task<bool>` dropped; old 40/71 double-counted it; targets may be interfaces e.g. `IProject`); (3) the
+candidate payload now carries a `NameResolution{status, matchCount}` signal so *ambiguous-name → never High* is
+decidable by the scorer from the payload alone (Task 4).
+
+**v3.1 changes (post triple-review):**
+- **Leg 1 / RouteNormalizer (Tasks 3, 7):** expand ASP.NET `[controller]`/`[action]`/`[area]` route tokens using the
+  parent class name BEFORE prefix concat — 21/23 controllers use `Route("api/[controller]")` literally; without
+  expansion the flagship route leg matches ZERO endpoints. Plus: filter url literals to frontend-language + non-test
+  (39 TS, not 96), derive the verb conditionally (verb-unknown for fetch/ky/got/wrappers), make the response-DTO edge
+  conditional (~55%, balanced-bracket unwrap), add a `consumes→` request-DTO edge.
+- **Leg 2 (Task 6):** CreateMap use-site is `kind='type_usage'` (NOT `'call'`); ordinal = copy-source→dest (NOT
+  entity→DTO) — classify entity/DTO from independent signals; handle ReverseMap. ToDto UNVERIFIED; inline-projection
+  WEAK/corroborator-only.
+- **Leg 3 (Task 5):** read DbContext property symbols directly (the v2 `containing_symbol_id` join → DbContext class).
+- **Task 4:** candidate `signals[]` are TYPED records with payload (fieldCount/Jaccard/name-tier), not bare names —
+  else the scorer can't enforce "1-field can't anchor" without leg-side logic.
+- **Task 3:** `SymbolResolver` (name-based resolution + collision handling; `target_symbol_id` is NULL at extract).
+- **Task 1:** data-gates + two new fixtures (fetch-based frontend, manual-mapping backend) before cross-repo claims.
+
+**Conventions (binding):** TDD (failing test first, against `Miller.Core`); default `dotnet test` < 10s
+(`Category!=Scale`); julie-spawning tests `[Trait("Category","Scale")]` + `ScaleTestSupport.RequireJulieServer()`;
+build 0 warnings / 0 errors; use Julie/Eros MCP to verify unfamiliar julie symbols; each task ends green.
+
+---
+
+## Task 0 — Re-pin to 28/2 (mechanical; external blocker cleared)
+
+julie **v7.13.0** is tagged; the local binary emits schema 28 / contract 2.
+- **Local, now:** `MillerExtractContract.cs:13-14` → `ExpectedSchemaVersion = 28`, `ExpectedExtractContractVersion =
+  2`; `PinnedJulieServerVersion = "7.13.0"`; docstring. Flip version-assertion tests (synthesize DBs, no binary):
+  `JulieSchemaGateTests`, `ExtractReportParsingTests`, `JulieExtractRunnerTests`, `JulieDbFixture`,
+  `IndexBootstrapServiceTests`, `LargeDbWriter`; update the "newer schema rejected" probes.
+- **External, when assets publish:** `scripts/julie-pins.json` ← v7.13.0 + 4 sha256s; `scripts/restore-julie-server.sh`;
+  confirm restored binary reports 28/2.
+
+**Test:** version-assertion suite green at 28/2 (fast suite).
+
+---
+
+## Task 1 — Data verification FIRST (no resolver code against an unverified column)
+
+- [x] Extract MyraNext (local 7.13.0); inspect real rows → [findings/m4-extract-reality-28-2.md](../findings/m4-extract-reality-28-2.md).
+      Triangulated by codex + 8-agent workflow + SQL.
+- [ ] Extract **Tycho** + **LabHandbookV2**; confirm the same column shapes + signal presence; **confirm the
+      `[controller]` token-routing pattern holds** (or record where it differs).
+- [ ] **New cross-repo fixtures (gate):** obtain/build (a) a **fetch-based** frontend repo and (b) a **manual-mapping**
+      (non-AutoMapper, `ToDto`/projection) backend repo. The fetch and ToDto legs are UNVERIFIED until these exist; do
+      not grade them STRONG before.
+- [ ] **Per-repo data gates (record the numbers, gate the grades):** % controller actions with a concrete
+      (balanced-unwrappable) return type vs bare `ActionResult`/`IActionResult`; count of `ToDto` methods + inline
+      `new XDto{}` projections; url-literal language split (TS vs C# test HttpClient) + carrier verb-vs-verbless
+      distribution; DbSet property path yields name+entity (and `containing_symbol_id` → class, not property); route
+      raw_text token distribution (`[controller]`/`[action]` vs absolute).
+- [ ] Every Core input field in Task 2 traces to a verified column.
+
+**Exit:** the reality doc is the binding contract for Tasks 2+.
+
+---
+
+## Task 2 — Core input contracts (pure types)
+
+`Miller.Core/Contracts/`, each field traceable to a verified column:
+- [ ] `TypeArgument` (identifier_id, ordinal, parent_arg_id, type_name, file_path). `target_symbol_id` NULL → resolve
+      by `type_name`.
+- [ ] `LiteralRecord` (literal_text, kind, **carrier = callee**, arg_position, **language**, containing_symbol_id, span).
+- [ ] `SymbolAnnotation` (symbol_id, ordinal, annotation, annotation_key [lowercased], **raw_text**, carrier).
+- [ ] `DbSetProperty` (property symbol id, property name = table, entity type from `DbSet<T>`, file:line) — parsed from
+      `symbols` (kind=property, signature has `DbSet<…>`), NOT from type_arguments.
+- [ ] `FieldSet` (owner id, ordered field names+types) — source = child symbols via `parent_id` PLUS C# record
+      positional params parsed from `signature`.
+- [ ] Extend symbol detail with `TestRole?` from `symbols.metadata`. For controller methods, carry the **parent class
+      name** (needed for `[controller]` expansion in Task 3).
+
+---
+
+## Task 3 — Pure normalizers + SymbolResolver (table-driven; precision lives here)
+
+`Miller.Core/Resolver/`. Case table first.
+- [ ] `RouteNormalizer` → `(verb, normalizedRoute)`.
+      - **verb-known** (carrier tail = HTTP verb or `<Verb>Async`) vs **verb-unknown** (fetch/$fetch/ofetch/bare
+        axios/request/ky/got/sendasync → route-only, reduced confidence, never assume GET).
+      - **[v3.1] token expansion BEFORE prefix concat:** `[controller]` → parent class name minus trailing
+        "Controller", lowercased; `[action]` → method name lowercased; `[area]` → area. The normalizer takes the
+        parent class name as input, not just the raw route string.
+      - route cases: controller-prefix concat, absolute-override, `{param}`/`${param}`/`:param`→`{}`, trailing slash,
+        case fold, query strip.
+- [ ] `NameNormalizer` → canonical stem (I/_ strip; Dto/Model/Request/Response/View/VM/Entity strip; singular↔plural).
+- [ ] `FieldSetExtractor` → `FieldSet`. Cases: class properties via `parent_id`; **C# record positional params from
+      `signature`**; `[JsonProperty]` rename from `raw_text`; wrapper unwrap for transitive returns.
+- [ ] **`SymbolResolver`** → resolve a `type_name` to a symbol by NAME (target_symbol_id NULL). Tie-break by
+      namespace/project; **>1 match with no tie-break → ambiguous (caller drops or lowers confidence, never High).**
+
+**Test:** one `[Theory]` per normalizer; rows for **`[controller]`/`[action]` expansion**, the **route-collision
+negative** (two controllers' `{id}` → distinct routes), verb-unknown carriers, record positional params, and the
+name-collision case.
+
+---
+
+## Task 4 — BridgeScorer + full candidate contract, BEFORE the legs
+
+- [ ] **Candidate-edge model:** `{kind, sourceRef, targetRef, evidence[], signals[], sourceFieldSet?,
+      targetFieldSet?}`, no final score yet. Field-sets MUST be on the tuple (the §5 Jaccard corroborator needs them).
+      **[v3.2] `sourceRef`/`targetRef` each carry the SymbolResolver outcome `{status: resolved|ambiguous|unresolved,
+      matchCount}`** so ambiguity is visible in the payload (it backs the `NameResolution` signal + the scorer's
+      ambiguous-never-High rule).
+- [ ] **[v3.1] `signals[]` are TYPED Signal records, not bare names:** `{rule, value, evidence}` where field-set
+      signals carry `fieldCount`+Jaccard, name signals carry match-tier (`exact|affix`), **[v3.2] a `NameResolution`
+      signal carries `{endpoint, status, matchCount}` per edge side**, and structural signals
+      (`CreateMap, DbSetProperty, RouteVerbMatch, RouteOnlyMatch, ReturnTypeDto, FromBodyDto, DapperFrom`) carry a
+      boolean+evidence. The §5 rules — **including ambiguous-name-never-High (scorer reads `NameResolution.status`,
+      never re-queries the resolver)** — must be decidable from the payload alone.
+- [ ] `BridgeScorer`: §5 bands — High for explicit breadcrumbs (CreateMap, DbSetProperty, RouteVerbMatch after token
+      expansion); Medium for name+corroborator or RouteOnlyMatch; **FieldSetJaccard NEVER sole**; **1-field shapes
+      (read `fieldCount`) can't anchor**; **ambiguous-name edge NEVER High**; multi-signal boost.
+
+**Test:** corroborator-only invariant proven from the PAYLOAD: `fieldset{count=1}` → no edge;
+`fieldset{count=8,jaccard=0.6}` + a structural signal → scores; ambiguous-name never High; multi-signal outscores
+single — all against synthetic candidates before legs exist.
+
+---
+
+## Task 5 — Leg: Entity ↔ table (build first; strongest, fewest deps) [v3 corrected]
+
+`Miller.Core/Resolver/EntityTableBridge`. Emits candidates; scorer scores.
+- [ ] **Primary:** consume `DbSetProperty` records (Task 2) → `CsEntity —stored_in→ DbTable` where table = property
+      name, entity = generic arg. **Do NOT use the DbSet use-site `containing_symbol_id`** (→ DbContext class).
+      **Guard:** if a symbol reached via `containing_symbol_id` has `kind!='property'`, never use its name as the table.
+- [ ] `[Table("X")]` when present (`symbol_annotations` key=table, arg from `raw_text`). Pluralizer last-resort only.
+- [ ] Dapper `FROM` opportunistic: `kind=sql` literal containing `FROM`, paired to its `T` by span-proximity; FROM
+      table only, never JOINs/multi-map.
+
+**Test:** `ApplicationUser` → table `ApplicationUsers` (**not** `MyraNextContext`); `Preferences`→`Preferences`,
+`AppSetting`→`AppSettings` (proves property name, not pluralized entity); stored-proc SQL literal with no FROM → no
+table edge.
+
+---
+
+## Task 6 — Leg: DTO ↔ Entity [v3/v3.1 re-graded]
+
+`Miller.Core/Resolver/DtoEntityBridge`.
+- [ ] **CreateMap (STRONG):** `type_arguments` where `identifiers.name='CreateMap'` and **`kind='type_usage'`** (NOT
+      `'call'`), grouped by `identifier_id`, read ordinal 0/1. **[v3.1] ordinal = copy-source→copy-dest, NOT
+      entity→DTO** — resolve both sides via `SymbolResolver`, classify which is the entity from independent signals
+      (namespace/folder, `Dto/Request/Response/VM` suffix, DbSet membership), tag the edge source→dest. Detect a
+      sibling `ReverseMap` and emit the inverse edge. (An inbound `CreateMap<XRequest,Entity>` must NOT be mislabeled.)
+- [ ] **ToDto (UNVERIFIED):** parse extension-method `signature` when present; **leg ungraded until the manual-mapping
+      fixture exists** (Task 1). Behind a feature check, not claimed STRONG.
+- [ ] **inline projection (WEAK):** DTO ctor from `identifiers`; source entity by name-overlap over `code_context`;
+      **corroborator-only, never High.**
+- [ ] field-renaming projection + `[JsonProperty]` as field-level corroborators.
+
+**Test:** CreateMap directional incl. the zero-shared-field case; an **inbound `CreateMap<XRequest,Entity>` is tagged
+correctly** (entity/DTO from independent signals, not ordinal); inline projection never High alone; ToDto exercised
+only by the manual-mapping fixture.
+
+---
+
+## Task 7 — Leg: TS call ↔ C# endpoint (route bridge) [v3/v3.1 re-grounded]
+
+`Miller.Core/Resolver/RouteBridge`.
+- [ ] TS side: `kind=url` literal **filtered to a frontend/client `language` (julie's FULL strings: `typescript`/
+      `javascript`/`vue`/…, NOT `('ts','js','vue')` which match 0) AND not test_role** — equivalently
+      `literal.language != endpoint language`; on MyraNext = the 39 `typescript` literals, excluding the 57 `csharp`
+      test HttpClient literals. Contract test: 39 survive, 57 do not. Verb via `RouteNormalizer` verb-known/unknown. Containing TS function from
+      `containing_symbol_id`. No type argument read.
+- [ ] C# side: verb from `annotation_key`, route from `raw_text`, prefixed by class `[Route]`; **wire the parent class
+      name into `RouteNormalizer` so `[controller]`/`[action]` expand** (parent_id→class join is 71/71).
+- [ ] Match `(verb, route)`; verb-unknown TS calls match on route alone at reduced confidence. Emit `TsCall —hits→
+      Endpoint`.
+- [ ] **`responds→` (PARTIAL):** only when the endpoint `signature` return **unwraps by balanced bracket depth** to a
+      **named user type (class/interface/record, incl. collection element like `IProject`)** — **39/71 excl. primitives
+      (~55%); the lone `Task<bool>` is dropped (old 40/71 double-counted it)**; bare `ActionResult`/`IActionResult`
+      (31/71) → no edge, no penalty.
+- [ ] **`consumes→`:** request DTO from the method's `[FromBody]`/parameter type in `signature`.
+
+**Test:** `Route("api/[controller]")`+`HttpGet("{id}")` on `AppSettingsController` → `api/appsettings/{}`;
+**collision negative** — two controllers' `{id}` → distinct routes; near-miss route does NOT match; a `fetch`/verb-less
+carrier → route-only (not assumed GET); a C# test HttpClient url literal is excluded; bare-return endpoint → no
+`responds→`; `[FromBody]` → `consumes→`.
+
+---
+
+## Task 8 — BridgeGraph assembly + queries (Core)
+
+- [ ] `Miller.Core/Graph/BridgeGraph`: nodes (`TsType`/`CsDto`/`CsEntity`/`DbTable`/`Endpoint`), typed
+      evidence+score edges; adjacency + `Walk(start,…)`. Mirror `SymbolGraph` immutability/atomic build.
+- [ ] `BridgeGraphBuilder`: run all legs → candidates → `SymbolResolver` (name resolution + ambiguous handling) →
+      scorer → graph. Deterministic ordering.
+- [ ] `SymbolGraph.ShortestPath(from,to,maxDepth)`: BFS + parent reconstruction, deterministic tie-break.
+
+**Test:** combined fixture yields the `UserDto → IUser / ApplicationUser → ApplicationUsers` chain; an ambiguous type
+name does NOT produce a High edge; `ShortestPath` correctness incl. no-path + tie-break determinism.
+
+---
+
+## Task 9 — Indexing: read new tables + DbContext properties + test_role (infra)
+
+`Miller.Indexing`.
+- [ ] `SqliteBridgeReader`: SELECTs for `type_arguments`, `literals` (with language), `symbol_annotations`, and
+      **DbContext property symbols** (`kind=property, signature LIKE '%DbSet<%'`) → Task 2 records (relative paths,
+      opaque ids, annotation args parsed from `raw_text`). Carry controller methods' parent class name.
+- [ ] `SqliteSymbolReader`: extend metadata parse to read `test_role` alongside `is_test`.
+- [ ] `RepositoryIndexLoader.Load()`: after symbol/graph build, run `BridgeGraphBuilder`, publish `BridgeGraph` in
+      `MillerRepositoryIndex`. `FreshnessService.Swap()` refreshes it for free.
+- [ ] **Measure** BridgeGraph build cost at load — the cost driver is name resolution over the code-symbol set
+      (~5–7k), not the breadcrumb set (design §3/§8). Persist only if over budget; key =
+      schema+contract+resolver-version+workspace+sorted-file-hashes.
+
+**Test:** contract tests against a synthesized 28/2 DB; assert reader→Core mapping + populated `BridgeGraph` after
+`Load()`. Fast suite.
+
+---
+
+## Task 10 — `trace` MCP tool (Server)
+
+`Miller.Server/Tools/TraceTool.cs`, `[McpServerToolType]`/`[McpServerTool]` + pure `Run()`.
+- [ ] Inputs: `target`, `mode=auto|path|bridge`, `to`, `depth`, `limit`, `format=compact|full`; smart-string target.
+- [ ] `auto`→`SymbolGraph` callers+callees; `path`→`ShortestPath`; `bridge`→`BridgeGraph.Walk`.
+- [ ] Token-thrifty output (design §6): compact chain w/ scores; **verb-unknown + ambiguous-name flags shown**; full
+      adds firing signals + competing candidates.
+- [ ] Telemetry via the existing interceptor/`Measure`; `WithToolsFromAssembly`.
+
+**Test:** `Run()` unit tests on in-memory fixtures for all three modes + output shape (incl. flags). No MCP/DI.
+
+---
+
+## Task 11 — End-to-end Scale validation + honesty probe (needs published binary)
+
+- [ ] `[Trait("Category","Scale")]`: extract a polyglot fixture via `ScaleTestSupport.RequireJulieServer()`; assert a
+      known bridge set resolves with expected scores.
+- [ ] **Honesty probe (design §7/§8):** run on a deliberately mismatched-naming fixture; record precision; confirm
+      corroborator-only + ambiguous-name-never-High + route-collision guards hold. **Measure recall on the CONTRACT,
+      PER LEG** (CreateMap / DbSet / route / response-DTO separately — they differ widely). Write results into the
+      design appendix. The "shippable to unknown users" gate.
+
+**Test:** `scripts/test.sh scale` green with the binary; skips cleanly without it.
+
+---
+
+## Sequencing
+
+```
+Task 0 (re-pin)   Task 1 (verify data + new fixtures/gates)
+Task 2 (input records incl. DbSetProperty + parent class name) → Task 3 (normalizers + token expansion + SymbolResolver)
+  → Task 4 (scorer + typed-signal candidate contract)
+    → Task 5 (entity↔table via property) → Task 6 (dto↔entity) → Task 7 (route)   [legs emit candidates; scorer scores]
+      → Task 8 (BridgeGraph + SymbolResolver wiring + ShortestPath)
+        → Task 9 (infra read) → Task 10 (trace tool)
+          → Task 11 (Scale + per-leg honesty probe; needs published binary)
+```
+Tasks 1–8 are pure Core, TDD, no binary. Data-verify precedes everything; scorer (with the typed-signal candidate
+contract) precedes the legs.
+
+## Out of scope (do not silently include)
+- Cross-repo / multi-workspace bridging.
+- Persisting the BridgeGraph (in-memory; persist only if Task 9 measurement demands it, full cache key).
+- `test_role` *consumers* (impact likely-tests) — M5; M4 only ingests + uses it to exclude test HttpClient calls.
+- Grading ToDto / inline-projection / fetch-route / Dapper-FROM as STRONG before the Task 1 fixtures measure them.
+- Embeddings / semantic anything (settled: rescues 0, adds FPs).

--- a/scripts/julie-pins.json
+++ b/scripts/julie-pins.json
@@ -1,10 +1,22 @@
 {
-  "version": "7.12.2",
+  "version": "7.13.0",
   "urlTemplate": "https://github.com/anortham/julie/releases/download/v{VER}/{asset}",
   "assets": {
-    "aarch64-apple-darwin":    { "name": "julie-v7.12.2-aarch64-apple-darwin.tar.gz",    "sha256": "5113bac946a66dceda1508b075b410c14f5480c2b24422a571e13c67ce9eb034" },
-    "x86_64-apple-darwin":     { "name": "julie-v7.12.2-x86_64-apple-darwin.tar.gz",     "sha256": "39122a57545fec313d1072775fe52596c017516269a1ee12c78170b466383381" },
-    "x86_64-unknown-linux-gnu":{ "name": "julie-v7.12.2-x86_64-unknown-linux-gnu.tar.gz","sha256": "e2b8528e72c3ea549bad1b764df00134224f915c3e5811eb67dbaf2e80c995c1" },
-    "x86_64-pc-windows-msvc":  { "name": "julie-v7.12.2-x86_64-pc-windows-msvc.zip",     "sha256": "fb5b5c1432a05a6b6073719db4227c08029be4b0a4d09e22b2828350e6d5c1d9" }
+    "aarch64-apple-darwin": {
+      "name": "julie-v7.13.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "3d312f06eea9d43555bced1f1689adf3e6b6bab33f79ba916c98257cb067cc97"
+    },
+    "x86_64-apple-darwin": {
+      "name": "julie-v7.13.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "5aa29121f748b37c798bd4d309a6383cb10e2b8bf810956db2dcc74af63e762e"
+    },
+    "x86_64-unknown-linux-gnu": {
+      "name": "julie-v7.13.0-x86_64-unknown-linux-gnu.tar.gz",
+      "sha256": "e038495bddf5bddc4b1a718704e8cbfffea7a0daffd2301ea95fad0277df7c88"
+    },
+    "x86_64-pc-windows-msvc": {
+      "name": "julie-v7.13.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "c6cec8e3b2c2e5e9872b2afdb5c1c053e3369ca59912dbb87e0bcd06cdb7d809"
+    }
   }
 }

--- a/src/Miller.Core/Contracts/DbSetProperty.cs
+++ b/src/Miller.Core/Contracts/DbSetProperty.cs
@@ -1,0 +1,30 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// A DbContext <c>DbSet&lt;T&gt;</c> property — the verified-strong entity↔table anchor (Leg 3). Built from a
+/// <c>symbols</c> row whose <c>kind=property</c> and whose <c>signature</c> contains <c>DbSet&lt;…&gt;</c>; the EF
+/// convention is that the table name IS the property name and the entity IS the generic argument. BOTH come from this
+/// one property symbol.
+///
+/// <para><b>Do not derive the table from the use-site.</b> The verified mistake the v2 design made was following the
+/// DbSet use-site identifier's <c>containing_symbol_id</c>, which points at the DbContext CLASS (e.g.
+/// <c>MyraNextContext</c>) for every table. MyraNext entities carry no <c>[Table]</c> attribute (0 <c>table</c> keys),
+/// so the property name + convention is the anchor, not a pluralizer on the entity name.</para>
+/// </summary>
+/// <param name="PropertySymbolId">The id of the DbContext property symbol (<c>kind=property</c>) this is parsed from.</param>
+/// <param name="TableName">
+/// The table name = the property's name (EF convention), e.g. property <c>ApplicationUsers</c> ⇒ table
+/// <c>ApplicationUsers</c>. NOT the pluralized entity name.
+/// </param>
+/// <param name="EntityTypeName">
+/// The entity type = the <c>DbSet&lt;T&gt;</c> generic argument parsed from the signature (e.g. <c>ApplicationUser</c>).
+/// Resolved to an entity symbol by name downstream.
+/// </param>
+/// <param name="FilePath">The DbContext file (workspace-relative), for evidence.</param>
+/// <param name="StartLine">The 1-based line of the property declaration, for evidence (file:line).</param>
+public sealed record DbSetProperty(
+    string PropertySymbolId,
+    string TableName,
+    string EntityTypeName,
+    string FilePath,
+    int StartLine);

--- a/src/Miller.Core/Contracts/Evidence.cs
+++ b/src/Miller.Core/Contracts/Evidence.cs
@@ -1,0 +1,11 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// One piece of locating evidence for a bridge edge or a firing signal: a <c>file:line</c> the claim can be traced to
+/// (a CreateMap call-site, an <c>[HttpGet]</c> annotation, a DbSet property declaration, a url literal). Pure data; the
+/// <c>trace</c> tool renders it so a user can verify the edge by hand — nothing is presented as certain that cannot be
+/// pointed at.
+/// </summary>
+/// <param name="FilePath">The workspace-relative file the evidence lives in.</param>
+/// <param name="Line">The 1-based line of the evidence within that file.</param>
+public sealed record Evidence(string FilePath, int Line);

--- a/src/Miller.Core/Contracts/FieldSet.cs
+++ b/src/Miller.Core/Contracts/FieldSet.cs
@@ -1,0 +1,25 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// One field of a type's shape: an ordered (name, type) pair. For a class/interface this comes from a child symbol
+/// (a property/field via <c>parent_id</c>); for a C# <c>record</c> it is parsed from the positional parameters in the
+/// declaration <c>signature</c> (records have no property children). A <c>[JsonProperty("x")]</c> rename, when
+/// present, replaces <see cref="Name"/> with the wire name.
+/// </summary>
+/// <param name="Name">The field's name (the JSON wire name when a <c>[JsonProperty]</c> rename applies).</param>
+/// <param name="Type">The field's declared type name as written (may be qualified or generic).</param>
+public sealed record FieldMember(string Name, string Type);
+
+/// <summary>
+/// The ordered field shape of a type — the corroborator the scorer's field-set Jaccard reads. Built by
+/// <c>FieldSetExtractor</c> from either child symbols (class/interface properties via <c>parent_id</c>) or a C#
+/// <c>record</c>'s positional params from its signature. A 1-field/generic shape can never anchor an edge on its own
+/// (the scorer enforces that via <see cref="Count"/>); the field-set only RAISES an edge that already has a signal.
+/// </summary>
+/// <param name="OwnerId">The owning type symbol's id (the type whose shape this is).</param>
+/// <param name="Fields">The ordered fields. Order is the declaration order (property order, or record param order).</param>
+public sealed record FieldSet(string OwnerId, IReadOnlyList<FieldMember> Fields)
+{
+    /// <summary>The number of fields — the scorer reads this to refuse a 1-field shape as a sole anchor.</summary>
+    public int Count => Fields.Count;
+}

--- a/src/Miller.Core/Contracts/LiteralRecord.cs
+++ b/src/Miller.Core/Contracts/LiteralRecord.cs
@@ -1,0 +1,55 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// One row of julie's <c>literals</c> table (extract reality 28/2): a decoded literal (URL/SQL/route/other) captured
+/// at a call-site, with its verbatim callee. The route bridge reads <c>kind=url</c> literals; the (rare) Dapper-FROM
+/// leg reads <c>kind=sql</c> literals.
+///
+/// <para><b>No <c>identifier_id</c>.</b> The verified shape has only <see cref="ContainingSymbolId"/> + span — there
+/// is no shared call-site key to join a literal to <see cref="TypeArgument"/>. Pairing a literal to a generic
+/// argument (the Dapper case) must be done by span-proximity within the same containing symbol, never a join.</para>
+/// </summary>
+/// <param name="LiteralText">
+/// <c>literals.literal_text</c>. The DECODED literal with interpolation folded to <c>{}</c> (e.g.
+/// <c>/api/messages/{}/dismiss</c>). For a url literal this is the route the normalizer canonicalizes.
+/// </param>
+/// <param name="Kind">
+/// <c>literals.kind</c> — <c>url</c> | <c>sql</c> | <c>route</c> | <c>other</c>. Branch on this; do NOT branch on the
+/// carrier to decide the kind.
+/// </param>
+/// <param name="Carrier">
+/// <c>literals.carrier</c> — the verbatim callee (e.g. <c>axios.post</c>, <c>fetch</c>, <c>QueryAsync</c>,
+/// <c>sendasync</c>). The HTTP verb is read from the carrier's tail token ONLY when it is a verb / <c>&lt;Verb&gt;Async</c>;
+/// verb-less carriers (<c>fetch</c>/<c>$fetch</c>/<c>ofetch</c>/bare <c>axios</c>/…) are verb-unknown.
+/// </param>
+/// <param name="ArgPosition">
+/// <c>literals.arg_position</c>. The literal's positional index in the call (url literals are <c>arg_position=0</c>
+/// on the verified data). Carried for evidence / span pairing.
+/// </param>
+/// <param name="Language">
+/// <c>literals.language</c>. julie's FULL language string (e.g. <c>typescript</c>, <c>csharp</c>, <c>vue</c>) — NOT a
+/// short code. The route bridge filters TS-side url literals by this (frontend language, and not a test_role HttpClient
+/// call); the literal set <c>('ts','js','vue')</c> matches 0 rows.
+/// </param>
+/// <param name="ContainingSymbolId">
+/// <c>literals.containing_symbol_id</c> → <c>symbols(id)</c>. The function the literal lives in (the TS caller, or the
+/// repo method for a SQL literal). The only call-site key the literal carries.
+/// </param>
+/// <param name="Span">The literal's source byte span (start/end), for evidence and span-proximity pairing.</param>
+public sealed record LiteralRecord(
+    string LiteralText,
+    string Kind,
+    string Carrier,
+    int ArgPosition,
+    string Language,
+    string ContainingSymbolId,
+    SourceSpan Span);
+
+/// <summary>
+/// An inclusive-start/exclusive-end source byte span (julie's span convention; absolute UTF-8 byte offsets, NOT
+/// UTF-16 char indices). Used by literals (and other span-carrying contract rows) for evidence and for the
+/// span-proximity pairing the Dapper leg needs (literals cannot join to type_arguments by key).
+/// </summary>
+/// <param name="StartByte">Inclusive start byte offset of the span.</param>
+/// <param name="EndByte">Exclusive end byte offset of the span.</param>
+public sealed record SourceSpan(int StartByte, int EndByte);

--- a/src/Miller.Core/Contracts/SymbolAnnotation.cs
+++ b/src/Miller.Core/Contracts/SymbolAnnotation.cs
@@ -1,0 +1,33 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// One row of julie's <c>symbol_annotations</c> table (extract reality 28/2): a declaration-level attribute on a
+/// symbol, e.g. <c>[HttpGet("name/{name}")]</c> on a controller method or <c>[JsonProperty("x")]</c> on a property.
+/// The route bridge reads the <c>httpget/httppost/...</c> annotations (verb from <see cref="AnnotationKey"/>, route
+/// from <see cref="RawText"/>); the entity↔table leg reads any <c>[Table("X")]</c>.
+///
+/// <para><b>Args live ONLY in <see cref="RawText"/>.</b> The verified shape has no parsed-arg columns and no file/line
+/// columns — the route, the JSON name, the table name must be pulled out of the verbatim <see cref="RawText"/>
+/// (e.g. <c>HttpGet("name/{name}")</c>). The pair <c>(SymbolId, Ordinal)</c> is unique.</para>
+/// </summary>
+/// <param name="SymbolId"><c>symbol_annotations.symbol_id</c> → <c>symbols(id)</c>: the annotated symbol.</param>
+/// <param name="Ordinal">
+/// <c>symbol_annotations.ordinal</c>. Position among the symbol's annotations; <c>(SymbolId, Ordinal)</c> is unique.
+/// </param>
+/// <param name="Annotation"><c>symbol_annotations.annotation</c>: the verbatim annotation name as written (case preserved).</param>
+/// <param name="AnnotationKey">
+/// <c>symbol_annotations.annotation_key</c> — the LOWERCASED key (e.g. <c>httpget</c>, <c>httppost</c>, <c>table</c>,
+/// <c>jsonproperty</c>). The HTTP verb for the route bridge is read from this, not from <see cref="Annotation"/>.
+/// </param>
+/// <param name="RawText">
+/// <c>symbol_annotations.raw_text</c>. The verbatim attribute including its args (e.g. <c>HttpGet("name/{name}")</c>).
+/// The only place the route / json-name / table-name argument can be recovered.
+/// </param>
+/// <param name="Carrier"><c>symbol_annotations.carrier</c>: julie's carrier for the annotation, kept for provenance.</param>
+public sealed record SymbolAnnotation(
+    string SymbolId,
+    int Ordinal,
+    string Annotation,
+    string AnnotationKey,
+    string RawText,
+    string Carrier);

--- a/src/Miller.Core/Contracts/SymbolDetail.cs
+++ b/src/Miller.Core/Contracts/SymbolDetail.cs
@@ -1,0 +1,38 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// The symbol facts the cross-language resolver needs about one <c>symbols</c> row, beyond what the dependency graph
+/// carries. A pure projection of julie's <c>symbols</c> table for M4: enough to resolve a type name to a symbol
+/// (name + namespace/file for the tie-break), to read a return/DbSet/record signature, and to apply the route
+/// <c>[controller]</c> token expansion (which needs the controller method's parent CLASS name).
+/// </summary>
+/// <param name="Id"><c>symbols.id</c>: the symbol's resolved id (never invented; comes from the index).</param>
+/// <param name="Name"><c>symbols.name</c>: the symbol's name — the string <c>SymbolResolver</c> matches type names against.</param>
+/// <param name="Kind"><c>symbols.kind</c>: e.g. <c>class</c>, <c>interface</c>, <c>record</c>, <c>method</c>, <c>property</c>.</param>
+/// <param name="FilePath"><c>symbols.file_path</c> (workspace-relative): used for the namespace/project tie-break and as evidence.</param>
+/// <param name="Signature">
+/// <c>symbols.signature</c>: the declaration signature. Source of the endpoint return type (balanced-bracket unwrap),
+/// the <c>DbSet&lt;T&gt;</c> generic arg, a C# record's positional params, and the <c>[FromBody]</c> parameter type.
+/// </param>
+/// <param name="Namespace">
+/// The symbol's declaring namespace when known (for the name-resolution tie-break), or null. Two same-named types in
+/// different namespaces are distinguished by this; absent a tie-break, &gt;1 match is ambiguous.
+/// </param>
+/// <param name="TestRole">
+/// The julie <c>test_role</c> from <c>symbols.metadata</c>, or null when the field is absent. Used to exclude test
+/// HttpClient url literals from the route bridge (see <see cref="Contracts.TestRole"/>).
+/// </param>
+/// <param name="ParentClassName">
+/// For a controller METHOD, the name of its parent class (e.g. <c>AppSettingsController</c>) — the input the route
+/// normalizer needs to expand the <c>[controller]</c> token BEFORE prefix concatenation. Null for symbols that are
+/// not controller methods (or whose parent class is unknown).
+/// </param>
+public sealed record SymbolDetail(
+    string Id,
+    string Name,
+    string Kind,
+    string FilePath,
+    string Signature,
+    string? Namespace,
+    TestRole? TestRole,
+    string? ParentClassName);

--- a/src/Miller.Core/Contracts/TestRole.cs
+++ b/src/Miller.Core/Contracts/TestRole.cs
@@ -1,0 +1,31 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// julie's <c>test_role</c> classification, read from <c>symbols.metadata</c> (a NEW 28/2 field, computed by julie's
+/// cross-language test-role classifier). Carried as the verbatim role string rather than mapped to a fixed C# enum:
+/// the contract publishes whatever role julie persisted, and M4 uses it only as a predicate (exclude a test-role
+/// HttpClient url literal from the route bridge; a future M5 input), never branching on a specific role name. Keeping
+/// the raw value keeps Miller honest to julie's role vocabulary across its 30+ languages instead of hardcoding a
+/// guessed variant list.
+///
+/// <para><b>Every value julie writes here IS a test role.</b> Verified against julie's <c>TestRole</c> enum
+/// (<c>julie-extractors/src/base/kinds.rs</c>): the variants are exactly <c>test_case</c>, <c>parameterized_test</c>,
+/// <c>fixture_setup</c>, <c>fixture_teardown</c>, <c>test_container</c> — all test code. julie writes a
+/// <c>test_role</c> only for test symbols; production code carries no such field. So the presence of a (non-blank)
+/// <c>test_role</c> is itself the test signal — <see cref="IsTest"/> does NOT use a "contains test" substring (which
+/// would wrongly drop <c>fixture_setup</c>/<c>fixture_teardown</c>), it treats any present role as test.</para>
+/// </summary>
+/// <param name="Value">
+/// The verbatim <c>test_role</c> string julie persisted (e.g. <c>test_case</c>, <c>fixture_setup</c>). Never null
+/// here — absence of the field is represented by a null <see cref="TestRole"/> reference, not by this string.
+/// </param>
+public sealed record TestRole(string Value)
+{
+    /// <summary>
+    /// True when this role denotes test code — the single semantic M4 needs (to exclude test HttpClient url literals
+    /// from the route bridge). julie persists a <c>test_role</c> ONLY for test symbols and every variant
+    /// (<c>test_case</c>/<c>parameterized_test</c>/<c>fixture_setup</c>/<c>fixture_teardown</c>/<c>test_container</c>)
+    /// is test code, so any non-blank role value is a test role. A blank value (defensive only) is not.
+    /// </summary>
+    public bool IsTest => !string.IsNullOrWhiteSpace(Value);
+}

--- a/src/Miller.Core/Contracts/TypeArgument.cs
+++ b/src/Miller.Core/Contracts/TypeArgument.cs
@@ -1,0 +1,38 @@
+namespace Miller.Core.Contracts;
+
+/// <summary>
+/// One row of julie's <c>type_arguments</c> table (extract reality 28/2): an ordered generic type argument at a
+/// use-site, e.g. one side of a <c>CreateMap&lt;A,B&gt;</c>. Keyed by <see cref="IdentifierId"/> — all arguments of
+/// one generic use-site share that id and are ordered by <see cref="Ordinal"/>.
+///
+/// <para><b>Resolution is by name.</b> The verified extract has <c>target_symbol_id</c> NULL for 0/1797 rows, so the
+/// bridge never gets a resolved link — <see cref="TypeName"/> is resolved to a symbol by string name downstream
+/// (<c>SymbolResolver</c>). This record deliberately omits the always-NULL <c>target_symbol_id</c> column.</para>
+/// </summary>
+/// <param name="IdentifierId">
+/// <c>type_arguments.identifier_id</c> → <c>identifiers(id)</c>. The grouping key: all generic args of one use-site
+/// (one <c>CreateMap</c> call) carry the same id; read them ordered by <see cref="Ordinal"/>.
+/// </param>
+/// <param name="Ordinal">
+/// <c>type_arguments.ordinal</c>. The declared position (0-based). For <c>CreateMap&lt;A,B&gt;</c> the verified
+/// invariant is copy-source→copy-dest (ordinal 0 = source, 1 = dest); it is NOT entity-vs-DTO — that is classified
+/// independently downstream.
+/// </param>
+/// <param name="ParentArgId">
+/// <c>type_arguments.parent_arg_id</c> → <c>type_arguments(id)</c>, or null at the top level. Encodes nesting for
+/// generic args like <c>List&lt;Foo&gt;</c>; null for an un-nested argument.
+/// </param>
+/// <param name="TypeName">
+/// <c>type_arguments.type_name</c>. The verbatim type name as written at the use-site (may be namespace-qualified,
+/// e.g. <c>Core.Reporting.Data.Account</c>). The string the resolver matches by.
+/// </param>
+/// <param name="FilePath">
+/// <c>type_arguments.file_path</c>. The use-site's file (a workspace-relative path by Miller convention), kept as
+/// evidence and for the namespace/project tie-break in name resolution.
+/// </param>
+public sealed record TypeArgument(
+    string IdentifierId,
+    int Ordinal,
+    string? ParentArgId,
+    string TypeName,
+    string FilePath);

--- a/src/Miller.Core/Graph/BridgeGraph.cs
+++ b/src/Miller.Core/Graph/BridgeGraph.cs
@@ -1,0 +1,286 @@
+using Miller.Core.Resolver;
+
+namespace Miller.Core.Graph;
+
+/// <summary>
+/// The kind of a node in the cross-language <see cref="BridgeGraph"/> (design §4 node kinds). A node is one endpoint of
+/// a scored bridge edge — a TS type, a C# DTO/entity, a database table, or a controller endpoint. The kind is carried
+/// for rendering and to keep the synthetic id of a non-symbol side (table / route endpoint) namespaced by kind so two
+/// different-kind nodes with the same display never collide.
+/// </summary>
+public enum BridgeNodeKind
+{
+    /// <summary>A TypeScript/JS type or client-call endpoint (the frontend side of a route or type chain).</summary>
+    TsType,
+
+    /// <summary>A C# DTO (a data-transfer / request / response shape).</summary>
+    CsDto,
+
+    /// <summary>A C# entity (a persistence / domain shape, typically a DbSet element).</summary>
+    CsEntity,
+
+    /// <summary>A database table (named by EF convention or SQL text — has no code symbol).</summary>
+    DbTable,
+
+    /// <summary>A C# controller action endpoint (a route target — the <c>—hits→</c> destination).</summary>
+    Endpoint,
+}
+
+/// <summary>
+/// One vertex of the <see cref="BridgeGraph"/>: a stable <see cref="Id"/>, its <see cref="Kind"/>, a human
+/// <see cref="Display"/>, and optional locating <see cref="FilePath"/>/<see cref="Line"/>. The graph never invents node
+/// identity — for a symbol-backed side the id IS the resolved <c>SymbolId</c>; for a non-symbol side (DB table, route
+/// endpoint) the id is a stable synthesis of kind + display (see <see cref="BridgeGraph.SynthesizeId"/>) so the two
+/// endpoints of an edge connect deterministically across legs.
+/// </summary>
+/// <param name="Id">The stable node key (a symbol id, or a kind+display synthesis for a non-symbol side).</param>
+/// <param name="Kind">The node's bridge kind (for rendering + non-symbol id namespacing).</param>
+/// <param name="Display">The human-readable label (leaf type name, table name, or normalized route).</param>
+/// <param name="FilePath">The workspace-relative file the node lives in, or null for a pure route/table node.</param>
+/// <param name="Line">The 1-based declaration line, or 0 when there is no single site.</param>
+public sealed record BridgeNode(string Id, BridgeNodeKind Kind, string Display, string? FilePath, int Line);
+
+/// <summary>
+/// The pure, immutable cross-language bridge graph (design §3/§4; plan Task 8). Built once per index from the
+/// surviving <see cref="ScoredEdge"/>s and a node lookup, it keeps an undirected adjacency over <see cref="BridgeNode"/>
+/// ids so a bounded BFS (<see cref="Walk"/>) follows a thread of code across languages — TS type → DTO → entity →
+/// table, or TS call → endpoint → request/response DTO — without touching the DB. Zero I/O; every method is
+/// deterministic. Mirrors <see cref="SymbolGraph"/>'s immutable, id-sorted-adjacency, atomic-build discipline.
+///
+/// <para><b>Adjacency is undirected for the walk.</b> A bridge edge is a correspondence (a DTO maps-to an entity, an
+/// entity is stored-in a table); a trace can start at any endpoint and follow the chain either way, so each scored edge
+/// is registered on BOTH of its node ids. The original directed <see cref="ScoredEdge"/> (with its source/target,
+/// score, band, and flags) is preserved verbatim on every adjacency entry for rendering — the graph never re-scores.</para>
+///
+/// <para><b>Determinism.</b> Neighbour edges per node are ordered by (neighbour id, then edge kind, then a stable edge
+/// signature) so <see cref="Walk"/> visits in a stable order across runs. An edge whose endpoints are not both present
+/// in the node lookup is dropped at build time (bounding the graph to known nodes), and an exact duplicate scored edge
+/// on a node is collapsed.</para>
+/// </summary>
+public sealed class BridgeGraph
+{
+    // node id -> the scored edges incident on it, pre-sorted for deterministic traversal.
+    private readonly IReadOnlyDictionary<string, ScoredEdge[]> _adjacency;
+    private readonly IReadOnlyDictionary<string, BridgeNode> _nodes;
+
+    private static readonly ScoredEdge[] NoEdges = [];
+
+    private BridgeGraph(
+        IReadOnlyDictionary<string, ScoredEdge[]> adjacency,
+        IReadOnlyDictionary<string, BridgeNode> nodes)
+    {
+        _adjacency = adjacency;
+        _nodes = nodes;
+    }
+
+    /// <summary>
+    /// Build a bridge graph from <paramref name="scoredEdges"/> and a <paramref name="nodes"/> lookup. Each edge is
+    /// registered on both of its endpoint node ids (resolved via <see cref="NodeIdOf"/>); an edge whose endpoints are
+    /// not both present in <paramref name="nodes"/> is dropped (bounding the graph to known nodes), self-loops are
+    /// dropped, and an exact-duplicate scored edge on a node is collapsed. Neighbour edge lists are sorted for stable
+    /// traversal. An empty edge/node set yields an empty graph.
+    /// </summary>
+    /// <param name="scoredEdges">The surviving scored bridge edges (post-scorer; nulls already dropped by the caller).</param>
+    /// <param name="nodes">The node lookup: node id → <see cref="BridgeNode"/> (built by the caller for every endpoint).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="scoredEdges"/> or <paramref name="nodes"/> is null.</exception>
+    public static BridgeGraph Build(
+        IReadOnlyList<ScoredEdge> scoredEdges,
+        IReadOnlyDictionary<string, BridgeNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(scoredEdges);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        // Per-node deduped edge set; dedupe by a stable edge signature so the same correspondence is not double-counted.
+        var byNode = new Dictionary<string, Dictionary<string, ScoredEdge>>(StringComparer.Ordinal);
+
+        foreach (var edge in scoredEdges)
+        {
+            var sourceId = NodeIdOf(edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source);
+            var targetId = NodeIdOf(edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target);
+
+            if (sourceId is null || targetId is null)
+                continue; // an endpoint we cannot identify (blank display, no symbol) — cannot connect it
+            if (string.Equals(sourceId, targetId, StringComparison.Ordinal))
+                continue; // self-loop: a node never bridges to itself
+            if (!nodes.ContainsKey(sourceId) || !nodes.ContainsKey(targetId))
+                continue; // endpoint not in the node lookup — bound the graph to known nodes
+
+            var signature = EdgeSignature(edge, sourceId, targetId);
+            AddIncident(byNode, sourceId, signature, edge);
+            AddIncident(byNode, targetId, signature, edge);
+        }
+
+        var adjacency = new Dictionary<string, ScoredEdge[]>(byNode.Count, StringComparer.Ordinal);
+        foreach (var (nodeId, edgeSet) in byNode)
+            adjacency[nodeId] = SortIncident(nodeId, edgeSet.Values);
+
+        return new BridgeGraph(adjacency, new Dictionary<string, BridgeNode>(nodes, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Walk the bridge graph breadth-first from <paramref name="startId"/>, returning the scored edges traversed in
+    /// reach order (BFS layer by layer, deterministic id-sorted neighbours), de-duplicated, and bounded by
+    /// <paramref name="maxDepth"/> hops. An edge appears at most once even when both its endpoints are reached. An
+    /// unknown start id or <paramref name="maxDepth"/> ≤ 0 yields an empty result.
+    /// </summary>
+    /// <param name="startId">The node id to start the walk from (a symbol id or a synthesized id).</param>
+    /// <param name="maxDepth">Maximum number of bridge hops to follow; ≤ 0 yields an empty result.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="startId"/> is null.</exception>
+    public IReadOnlyList<ScoredEdge> Walk(string startId, int maxDepth)
+    {
+        ArgumentNullException.ThrowIfNull(startId);
+
+        if (maxDepth <= 0 || !_adjacency.ContainsKey(startId))
+            return [];
+
+        var depth = new Dictionary<string, int>(StringComparer.Ordinal) { [startId] = 0 };
+        var frontier = new Queue<string>();
+        frontier.Enqueue(startId);
+
+        var emittedEdges = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<ScoredEdge>();
+
+        while (frontier.Count > 0)
+        {
+            var current = frontier.Dequeue();
+            var currentDepth = depth[current];
+            if (currentDepth >= maxDepth)
+                continue; // its edges would exceed the depth cap
+
+            foreach (var edge in Incident(current))
+            {
+                var sourceId = NodeIdOf(edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source);
+                var targetId = NodeIdOf(edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target);
+                var other = string.Equals(sourceId, current, StringComparison.Ordinal) ? targetId : sourceId;
+                if (other is null)
+                    continue;
+
+                // Emit the traversed edge once, in reach order.
+                if (emittedEdges.Add(EdgeSignature(edge, sourceId!, targetId!)))
+                    result.Add(edge);
+
+                // Discover the neighbour at the next layer (BFS keeps the minimum depth).
+                if (!depth.ContainsKey(other))
+                {
+                    depth[other] = currentDepth + 1;
+                    frontier.Enqueue(other);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>The node for <paramref name="id"/>, or null when the id is not a vertex of this graph.</summary>
+    public BridgeNode? Node(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return _nodes.TryGetValue(id, out var node) ? node : null;
+    }
+
+    /// <summary>True when <paramref name="id"/> is a vertex of this graph.</summary>
+    public bool Contains(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return _nodes.ContainsKey(id);
+    }
+
+    /// <summary>The scored edges directly incident on <paramref name="id"/>, in deterministic order; empty if unknown.</summary>
+    public IReadOnlyList<ScoredEdge> Incident(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return _adjacency.TryGetValue(id, out var edges) ? edges : NoEdges;
+    }
+
+    /// <summary>
+    /// The stable node id for an <see cref="EdgeRef"/>: a symbol-backed side uses its resolved <c>SymbolId</c>; a
+    /// non-symbol side (DB table, route endpoint) synthesizes a stable id from its node kind + display so the two ends
+    /// of an edge connect consistently. Returns null when the side has neither a symbol id nor a usable display.
+    /// </summary>
+    public static string? NodeIdOf(EdgeRef edgeRef, BridgeKind edgeKind, EndpointSide side)
+    {
+        if (!string.IsNullOrEmpty(edgeRef.SymbolId))
+            return edgeRef.SymbolId;
+        if (string.IsNullOrWhiteSpace(edgeRef.Display))
+            return null;
+        return SynthesizeId(NodeKindFor(edgeKind, side), edgeRef.Display);
+    }
+
+    /// <summary>
+    /// A stable synthetic id for a non-symbol node, namespaced by kind so a table and a route with the same display
+    /// never collide: <c>"&lt;kind&gt;:&lt;display&gt;"</c> (display lowercased for case-stable matching of route/table text).
+    /// </summary>
+    public static string SynthesizeId(BridgeNodeKind kind, string display) =>
+        $"{kind}:{display.ToLowerInvariant()}";
+
+    /// <summary>
+    /// Map a bridge edge kind + endpoint side to the node kind of that endpoint. The directed legs pin which side is
+    /// which: a StoredIn edge is entity→table; a Hits edge is route(TS)→endpoint; MapsTo is DTO/entity (both C#);
+    /// Responds/Consumes are endpoint→DTO. The source-vs-target side disambiguates the two ends.
+    /// </summary>
+    public static BridgeNodeKind NodeKindFor(BridgeKind edgeKind, EndpointSide side) => edgeKind switch
+    {
+        BridgeKind.StoredIn => side == EndpointSide.Source ? BridgeNodeKind.CsEntity : BridgeNodeKind.DbTable,
+        BridgeKind.Hits => side == EndpointSide.Source ? BridgeNodeKind.TsType : BridgeNodeKind.Endpoint,
+        BridgeKind.Responds => side == EndpointSide.Source ? BridgeNodeKind.Endpoint : BridgeNodeKind.CsDto,
+        BridgeKind.Consumes => side == EndpointSide.Source ? BridgeNodeKind.Endpoint : BridgeNodeKind.CsDto,
+        BridgeKind.MapsTo => BridgeNodeKind.CsDto,
+        BridgeKind.NameMatch => side == EndpointSide.Source ? BridgeNodeKind.TsType : BridgeNodeKind.CsDto,
+        _ => BridgeNodeKind.CsDto,
+    };
+
+    private static void AddIncident(
+        Dictionary<string, Dictionary<string, ScoredEdge>> byNode, string nodeId, string signature, ScoredEdge edge)
+    {
+        if (!byNode.TryGetValue(nodeId, out var set))
+        {
+            set = new Dictionary<string, ScoredEdge>(StringComparer.Ordinal);
+            byNode[nodeId] = set;
+        }
+        // First write wins for a given signature (an exact-duplicate correspondence is collapsed).
+        set.TryAdd(signature, edge);
+    }
+
+    /// <summary>
+    /// A stable, order-independent signature for an edge between two node ids: the kind plus the two ids sorted, so the
+    /// same correspondence reached from either endpoint dedupes to one entry, and the same pair via two edge kinds
+    /// (e.g. a Responds and a Consumes between an endpoint and a DTO) stays distinct.
+    /// </summary>
+    private static string EdgeSignature(ScoredEdge edge, string sourceId, string targetId)
+    {
+        var (a, b) = string.CompareOrdinal(sourceId, targetId) <= 0 ? (sourceId, targetId) : (targetId, sourceId);
+        return $"{edge.Edge.Kind}|{a}|{b}";
+    }
+
+    /// <summary>
+    /// Sort a node's incident edges for deterministic traversal: by the neighbour id, then the edge kind, then the
+    /// full edge signature (so two edges of the same kind to the same neighbour still order stably).
+    /// </summary>
+    private static ScoredEdge[] SortIncident(string nodeId, IEnumerable<ScoredEdge> edges)
+    {
+        var array = edges.ToArray();
+        Array.Sort(array, (x, y) =>
+        {
+            var xs = NodeIdOf(x.Edge.SourceRef, x.Edge.Kind, EndpointSide.Source) ?? string.Empty;
+            var xt = NodeIdOf(x.Edge.TargetRef, x.Edge.Kind, EndpointSide.Target) ?? string.Empty;
+            var ys = NodeIdOf(y.Edge.SourceRef, y.Edge.Kind, EndpointSide.Source) ?? string.Empty;
+            var yt = NodeIdOf(y.Edge.TargetRef, y.Edge.Kind, EndpointSide.Target) ?? string.Empty;
+
+            var xOther = string.Equals(xs, nodeId, StringComparison.Ordinal) ? xt : xs;
+            var yOther = string.Equals(ys, nodeId, StringComparison.Ordinal) ? yt : ys;
+
+            int byNeighbour = string.CompareOrdinal(xOther, yOther);
+            if (byNeighbour != 0)
+                return byNeighbour;
+
+            int byKind = x.Edge.Kind.CompareTo(y.Edge.Kind);
+            if (byKind != 0)
+                return byKind;
+
+            return string.CompareOrdinal(
+                EdgeSignature(x, xs, xt),
+                EdgeSignature(y, ys, yt));
+        });
+        return array;
+    }
+}

--- a/src/Miller.Core/Graph/BridgeGraphBuilder.cs
+++ b/src/Miller.Core/Graph/BridgeGraphBuilder.cs
@@ -425,8 +425,10 @@ public static class BridgeGraphBuilder
 
     /// <summary>
     /// Build a <see cref="BridgeNode"/> for every endpoint of a surviving scored edge, keyed by the same node id
-    /// <see cref="BridgeGraph"/> uses (resolved symbol id, or a kind+display synthesis). A symbol-backed node is
-    /// enriched with the symbol's file:line; a non-symbol node (table / route) carries the edge ref's display + file.
+    /// <see cref="BridgeGraph"/> uses (resolved symbol id, or a kind+display synthesis). A symbol-backed node renders
+    /// with the resolved symbol's NAME (so a route endpoint shows its action method, e.g. GetById, not the route text
+    /// its <see cref="EdgeRef.Display"/> carries) and is enriched with the symbol's file:line; a non-symbol node
+    /// (table / route) carries the edge ref's display + file.
     /// </summary>
     private static IReadOnlyDictionary<string, BridgeNode> BuildNodes(
         IReadOnlyList<ScoredEdge> scored, IReadOnlyDictionary<string, SymbolDetail> symbolsById)
@@ -453,10 +455,13 @@ public static class BridgeGraphBuilder
 
         var kind = BridgeGraph.NodeKindFor(edgeKind, side);
 
-        // A symbol-backed side: enrich with the symbol's own file (the edge ref file is the use-site, not the decl).
+        // A symbol-backed side: render with the symbol's own NAME and enrich with its declaration file (the edge ref
+        // file is the use-site, not the decl). The display MUST be the symbol name, not edgeRef.Display: a Hits edge's
+        // endpoint EdgeRef.Display carries the normalized ROUTE (RouteBridge sets it to endpointRoute.Route), so using
+        // it would render the controller action as "api/appsettings/{}" instead of "GetById" in the trace output.
         if (!string.IsNullOrEmpty(edgeRef.SymbolId) && symbolsById.TryGetValue(edgeRef.SymbolId, out var symbol))
         {
-            nodes[id] = new BridgeNode(id, kind, edgeRef.Display, symbol.FilePath, Line: 0);
+            nodes[id] = new BridgeNode(id, kind, symbol.Name, symbol.FilePath, Line: 0);
             return;
         }
 

--- a/src/Miller.Core/Graph/BridgeGraphBuilder.cs
+++ b/src/Miller.Core/Graph/BridgeGraphBuilder.cs
@@ -1,0 +1,626 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+
+namespace Miller.Core.Graph;
+
+/// <summary>
+/// Assembles the in-memory <see cref="BridgeGraph"/> from the raw julie-derived contract collections (plan Task 8;
+/// design §3/§4). PURE Miller.Core — it takes already-loaded value records (the DB reader, plan Task 9, supplies them)
+/// and performs the per-leg REDUCTIONS the legs explicitly delegate to the builder, then runs the three legs, scores
+/// every candidate, and builds the graph. No DB, no I/O.
+///
+/// <para>The reductions the builder owns (each is named in the corresponding leg's doc-comment as "the graph builder's
+/// job, out of this leg's scope"):
+/// <list type="bullet">
+/// <item><b>CreateMap grouping</b> — group <c>type_arguments</c> by <c>identifier_id</c> into A/B pairs (ordinal 0 =
+/// copy-source, ordinal 1 = copy-dest into a <see cref="CreateMapCandidate"/>). The ordinal IS the copy direction — the
+/// builder NEVER classifies entity-vs-DTO. Only un-nested (no <c>parent_arg_id</c>) two-arg groups are taken; the leg +
+/// scorer + name-resolution gate then filter (an unresolvable pair yields no edge).</item>
+/// <item><b>Controller endpoint reduction</b> — for method symbols carrying an http-verb annotation, find the parent
+/// class by <see cref="SymbolDetail.ParentClassName"/> for the class <c>[Route]</c>, parse the method route from the
+/// verb annotation <c>raw_text</c>, and parse the return + request-body types from the method <c>signature</c> into a
+/// <see cref="ControllerEndpoint"/>.</item>
+/// <item><b>TsClientCall reduction</b> — for <c>kind='url'</c> literals, attach the containing symbol's
+/// <c>test_role</c> and the use-site file:line into a <see cref="TsClientCall"/>.</item>
+/// </list></para>
+///
+/// <para><b>Contract gap (flagged, not silently worked around).</b> The Dapper-FROM secondary anchor (Leg 3's
+/// <see cref="DapperFromCandidate"/>) cannot be produced here: it requires pairing a <c>kind='sql'</c> literal to a
+/// co-located entity <c>type_argument</c> by span proximity within the same containing symbol, but the verified
+/// <see cref="TypeArgument"/> contract carries NEITHER a <c>containing_symbol_id</c> NOR a span — so there is no key or
+/// proximity signal to pair on (and <see cref="LiteralRecord"/> carries no <c>identifier_id</c> for a join — findings
+/// 28-2). The builder therefore emits no Dapper candidates; the DbSet&lt;T&gt; property remains Leg 3's PRIMARY (and on
+/// the verified MyraNext shape, 13/15 sql literals have no FROM clause anyway, so the Dapper path is opportunistic).
+/// Task 9 / a contract revision can add the co-location fields to <see cref="TypeArgument"/> to re-enable it.</para>
+///
+/// <para><b>Literal evidence seam (Task 9 must match this).</b> <see cref="LiteralRecord"/> surfaces only a byte
+/// <c>span</c> + <c>containing_symbol_id</c>; it does not re-expose the <c>literals</c> row's own file/line columns. So
+/// the builder takes a reader-supplied <c>literal → (file, line)</c> lookup (<paramref name="literalSites"/> on
+/// <see cref="Build"/>) rather than extending <see cref="LiteralRecord"/> — keeping Miller.Core free of julie row-shape
+/// leakage. A literal absent from the lookup falls back to its containing symbol's file:line.</para>
+/// </summary>
+public static class BridgeGraphBuilder
+{
+    /// <summary>
+    /// Build the cross-language <see cref="BridgeGraph"/> over a workspace's symbols + julie breadcrumbs.
+    /// </summary>
+    /// <param name="symbols">All resolvable symbols of the workspace (the <see cref="SymbolResolver"/> source + endpoint/field lookups).</param>
+    /// <param name="typeArguments">The <c>type_arguments</c> rows (CreateMap grouping input).</param>
+    /// <param name="literals">The <c>literals</c> rows (url client calls; sql literals are not paired — see remarks).</param>
+    /// <param name="annotations">The <c>symbol_annotations</c> rows (http-verb endpoints, class <c>[Route]</c>).</param>
+    /// <param name="dbSetProperties">The DbContext <c>DbSet&lt;T&gt;</c> property breadcrumbs (Leg 3 PRIMARY).</param>
+    /// <param name="literalSites">
+    /// The reader-supplied <c>literal → (file, line)</c> lookup (the literal-evidence seam — see the type remarks). May
+    /// be null; a missing literal falls back to its containing symbol's file:line.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Any required collection is null.</exception>
+    public static BridgeGraph Build(
+        IReadOnlyList<SymbolDetail> symbols,
+        IReadOnlyList<TypeArgument> typeArguments,
+        IReadOnlyList<LiteralRecord> literals,
+        IReadOnlyList<SymbolAnnotation> annotations,
+        IReadOnlyList<DbSetProperty> dbSetProperties,
+        IReadOnlyDictionary<LiteralRecord, LiteralSite>? literalSites = null)
+    {
+        ArgumentNullException.ThrowIfNull(symbols);
+        ArgumentNullException.ThrowIfNull(typeArguments);
+        ArgumentNullException.ThrowIfNull(literals);
+        ArgumentNullException.ThrowIfNull(annotations);
+        ArgumentNullException.ThrowIfNull(dbSetProperties);
+
+        var symbolsById = BuildSymbolIndex(symbols);
+        var resolver = new SymbolResolver(symbols);
+
+        // --- the reductions (Task 8's job per the leg doc-comments) ---------------------------------------------
+        var createMaps = ReduceCreateMaps(typeArguments);
+        var endpoints = ReduceEndpoints(symbols, annotations);
+        var clientCalls = ReduceClientCalls(literals, symbolsById, literalSites);
+
+        // --- run the three legs (each emits candidates; the scorer scores) --------------------------------------
+        var candidates = new List<CandidateEdge>();
+        candidates.AddRange(EntityTableBridge.Resolve(
+            new EntityTableInput(dbSetProperties, DapperFromCandidates: []), resolver));
+        candidates.AddRange(DtoEntityBridge.Resolve(
+            new DtoEntityInput(createMaps, Projections: [], FieldSources: null), resolver));
+        candidates.AddRange(RouteBridge.Resolve(
+            new RouteBridgeInput(clientCalls, endpoints), resolver));
+
+        // --- score; drop nulls (no-edge per design §5) ----------------------------------------------------------
+        var scored = new List<ScoredEdge>();
+        foreach (var candidate in candidates)
+        {
+            var edge = BridgeScorer.Score(candidate);
+            if (edge is not null)
+                scored.Add(edge);
+        }
+
+        // --- build a node for every endpoint of a surviving edge, then the graph --------------------------------
+        var nodes = BuildNodes(scored, symbolsById);
+        return BridgeGraph.Build(scored, nodes);
+    }
+
+    // ============================ CreateMap grouping (Leg 2 PRIMARY reduction) ==================================
+
+    /// <summary>
+    /// Group the <c>type_arguments</c> of each generic use-site (one group per <c>identifier_id</c>) into the A/B pair
+    /// of a candidate map: ordinal 0 = copy-source, ordinal 1 = copy-dest into a <see cref="CreateMapCandidate"/>. ONLY
+    /// the two top-level args of a use-site are read; nested generic args (<c>parent_arg_id</c> set) are skipped — they
+    /// are the components of a generic type arg, not the map's own A/B. The ordinal encodes the COPY direction; the
+    /// builder NEVER reorders to entity-vs-DTO (the design §8 trap). The leg + scorer + name-resolution gate filter the
+    /// over-produced set: an unresolvable pair yields no edge.
+    ///
+    /// <para><b>Contract limit.</b> The verified <see cref="TypeArgument"/> carries no use-site name or kind, so the
+    /// builder cannot restrict to literal <c>CreateMap</c> calls, and no <c>.ReverseMap()</c> sibling is observable —
+    /// <see cref="CreateMapCandidate.HasReverseMap"/> is therefore always false (a contract gap, see the type remarks).
+    /// Only un-nested, exactly-two-arg groups are admitted, which keeps over-production tight.</para>
+    /// </summary>
+    private static IReadOnlyList<CreateMapCandidate> ReduceCreateMaps(IReadOnlyList<TypeArgument> typeArguments)
+    {
+        // identifier_id -> the two top-level args (ordinal -> type name + a use-site file), plus a count of how many
+        // distinct top-level ordinals appeared (to reject groups that are not a clean A/B pair).
+        var groups = new Dictionary<string, CreateMapGroup>(StringComparer.Ordinal);
+
+        foreach (var arg in typeArguments)
+        {
+            if (arg.ParentArgId is not null)
+                continue; // a nested generic component, not one of the map's own A/B
+            if (string.IsNullOrEmpty(arg.IdentifierId) || string.IsNullOrWhiteSpace(arg.TypeName))
+                continue;
+
+            if (!groups.TryGetValue(arg.IdentifierId, out var group))
+            {
+                group = new CreateMapGroup();
+                groups[arg.IdentifierId] = group;
+            }
+
+            group.TopLevelArgCount++;
+            if (arg.Ordinal == 0)
+                group.Source ??= arg.TypeName;
+            else if (arg.Ordinal == 1)
+                group.Dest ??= arg.TypeName;
+            group.FilePath ??= arg.FilePath;
+        }
+
+        // Deterministic order: by identifier_id.
+        var candidates = new List<CreateMapCandidate>();
+        foreach (var identifierId in Sorted(groups.Keys))
+        {
+            var group = groups[identifierId];
+            if (group.Source is null || group.Dest is null)
+                continue; // not a clean ordinal 0 + 1 pair
+            if (group.TopLevelArgCount != 2)
+                continue; // a 1-arg or 3+-arg generic use-site is not a 2-type map (e.g. Dictionary<,>, single T)
+
+            candidates.Add(new CreateMapCandidate(
+                group.Source,
+                group.Dest,
+                group.FilePath ?? string.Empty,
+                Line: 0,
+                HasReverseMap: false));
+        }
+        return candidates;
+    }
+
+    private sealed class CreateMapGroup
+    {
+        public string? Source;
+        public string? Dest;
+        public string? FilePath;
+        public int TopLevelArgCount;
+    }
+
+    // ============================ Controller endpoint reduction (Leg 1 C# side) =================================
+
+    /// <summary>
+    /// Reduce each method symbol carrying an http-verb annotation into a <see cref="ControllerEndpoint"/>: find the
+    /// parent class by <see cref="SymbolDetail.ParentClassName"/> for the class <c>[Route]</c>, parse the method route
+    /// from the verb annotation <c>raw_text</c>, and parse the return type + a conservative request-body type from the
+    /// method <c>signature</c>. Deterministic: endpoints ordered by symbol id.
+    ///
+    /// <para><b>Contract note.</b> <see cref="SymbolDetail"/> carries <see cref="SymbolDetail.ParentClassName"/> but no
+    /// parent symbol id, so the class is found by name. When several classes share a name, the class <c>[Route]</c> may
+    /// be wrong; the route normalizer + scorer tolerate a missing/loose class route, and the verb-known route match
+    /// still anchors the edge.</para>
+    /// </summary>
+    private static IReadOnlyList<ControllerEndpoint> ReduceEndpoints(
+        IReadOnlyList<SymbolDetail> symbols,
+        IReadOnlyList<SymbolAnnotation> annotations)
+    {
+        // symbol id -> its annotations, for the verb + class [Route] lookups.
+        var annotationsBySymbol = new Dictionary<string, List<SymbolAnnotation>>(StringComparer.Ordinal);
+        foreach (var annotation in annotations)
+        {
+            if (!annotationsBySymbol.TryGetValue(annotation.SymbolId, out var list))
+            {
+                list = [];
+                annotationsBySymbol[annotation.SymbolId] = list;
+            }
+            list.Add(annotation);
+        }
+
+        // class name -> the class symbol's annotations (for the [Route] lookup by ParentClassName). First class with a
+        // [Route] wins for a duplicated name; deterministic by symbol id.
+        var classRouteByName = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var symbol in symbols.OrderBy(s => s.Id, StringComparer.Ordinal))
+        {
+            if (!IsClassKind(symbol.Kind))
+                continue;
+            if (classRouteByName.ContainsKey(symbol.Name))
+                continue;
+            classRouteByName[symbol.Name] =
+                annotationsBySymbol.TryGetValue(symbol.Id, out var classAnnotations)
+                    ? RouteArgOf(classAnnotations)
+                    : null;
+        }
+
+        var endpoints = new List<ControllerEndpoint>();
+        foreach (var method in symbols.OrderBy(s => s.Id, StringComparer.Ordinal))
+        {
+            if (!annotationsBySymbol.TryGetValue(method.Id, out var methodAnnotations))
+                continue;
+
+            var verbAnnotation = methodAnnotations.FirstOrDefault(a => IsHttpVerbKey(a.AnnotationKey));
+            if (verbAnnotation is null)
+                continue;
+
+            var parentClassName = method.ParentClassName ?? string.Empty;
+            if (parentClassName.Length == 0)
+                continue; // cannot expand [controller] without a parent class name
+
+            string? classRoute = classRouteByName.TryGetValue(parentClassName, out var route) ? route : null;
+
+            var methodRoute = FirstStringArg(verbAnnotation.RawText);
+            var (returnType, requestBodyType) = ParseSignatureTypes(method.Signature, verbAnnotation.AnnotationKey);
+
+            endpoints.Add(new ControllerEndpoint(
+                SymbolId: method.Id,
+                VerbKey: verbAnnotation.AnnotationKey,
+                ClassRoute: classRoute,
+                MethodRoute: methodRoute,
+                ParentClassName: parentClassName,
+                MethodName: method.Name,
+                ReturnType: returnType,
+                RequestBodyType: requestBodyType,
+                FilePath: method.FilePath,
+                Line: 0));
+        }
+        return endpoints;
+    }
+
+    private static bool IsClassKind(string kind) =>
+        string.Equals(kind, "class", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(kind, "record", StringComparison.OrdinalIgnoreCase);
+
+    private static readonly string[] HttpVerbKeys =
+    [
+        "httpget", "httppost", "httpput", "httpdelete", "httppatch", "httphead", "httpoptions",
+    ];
+
+    private static bool IsHttpVerbKey(string key)
+    {
+        foreach (var verb in HttpVerbKeys)
+        {
+            if (string.Equals(key, verb, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    // Body-bearing verbs whose request parameter MAY be a request body (findings 28-2: [FromBody] is NOT persisted).
+    private static readonly string[] BodyBearingVerbKeys = ["httppost", "httpput", "httppatch"];
+
+    private static bool IsBodyBearingVerb(string verbKey)
+    {
+        foreach (var verb in BodyBearingVerbKeys)
+        {
+            if (string.Equals(verbKey, verb, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>The route arg of a class's <c>[Route("...")]</c> annotation, or null when the class declares none.</summary>
+    private static string? RouteArgOf(List<SymbolAnnotation> classAnnotations)
+    {
+        foreach (var annotation in classAnnotations)
+        {
+            if (string.Equals(annotation.AnnotationKey, "route", StringComparison.OrdinalIgnoreCase))
+                return FirstStringArg(annotation.RawText);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Parse the method signature into (returnType, requestBodyType). The return type is the leading token run before
+    /// the method-name "(". The request-body type is populated CONSERVATIVELY (findings 28-2: <c>[FromBody]</c> is NOT
+    /// persisted by julie 28/2 — a param attribute degrades to the declared parameter type in the signature): ONLY a
+    /// plausible request-body parameter (a complex, non-primitive, non-route-bound type) on a body-bearing verb
+    /// (POST/PUT/PATCH) is promoted; otherwise null. An arbitrary first parameter is NEVER promoted to a Consumes edge.
+    /// </summary>
+    private static (string ReturnType, string? RequestBodyType) ParseSignatureTypes(string signature, string verbKey)
+    {
+        var returnType = ParseReturnType(signature);
+        string? requestBodyType = null;
+
+        if (IsBodyBearingVerb(verbKey))
+            requestBodyType = ParseRequestBodyType(signature);
+
+        return (returnType, requestBodyType);
+    }
+
+    /// <summary>The return type = the balanced-aware leading token run before the parameter-list <c>(</c>.</summary>
+    private static string ParseReturnType(string signature)
+    {
+        var sig = (signature ?? string.Empty).Trim();
+        int open = TopLevelChar(sig, '(');
+        if (open < 0)
+            return sig; // no parameter list visible — treat the whole thing as the return type
+
+        var head = sig[..open].Trim();
+        // head is "...modifiers Return MethodName" — the return type is the second-to-last top-level token run.
+        int lastSpace = LastTopLevelSpace(head);
+        return lastSpace <= 0 ? string.Empty : head[..lastSpace].Trim();
+    }
+
+    /// <summary>
+    /// The first parameter whose type is a complex (non-primitive) user type, on a body-bearing verb — the
+    /// conservative request-body candidate. A route-bound primitive (<c>int id</c>, <c>string name</c>) is never a body.
+    /// </summary>
+    private static string? ParseRequestBodyType(string signature)
+    {
+        var sig = signature ?? string.Empty;
+        int open = TopLevelChar(sig, '(');
+        if (open < 0)
+            return null;
+        var inner = BalancedInner(sig, open);
+        if (inner is null || inner.Trim().Length == 0)
+            return null;
+
+        foreach (var param in SplitTopLevel(inner))
+        {
+            var type = ParamType(param);
+            if (type is null)
+                continue;
+            if (IsPlausibleBodyType(type))
+                return type;
+        }
+        return null;
+    }
+
+    /// <summary>A parameter's declared type = everything before its last top-level token (the name); null if malformed.</summary>
+    private static string? ParamType(string param)
+    {
+        var p = param.Trim();
+        if (p.Length == 0)
+            return null;
+
+        int eq = TopLevelIndexOf(p, '=');
+        if (eq >= 0)
+            p = p[..eq].Trim();
+
+        int lastSpace = LastTopLevelSpace(p);
+        if (lastSpace <= 0)
+            return null;
+
+        var type = p[..lastSpace].Trim();
+        return type.Length == 0 ? null : type;
+    }
+
+    /// <summary>True when a parameter type is a complex named type plausibly carrying a request body (not a primitive).</summary>
+    private static bool IsPlausibleBodyType(string type)
+    {
+        var t = type.TrimEnd('?').Trim();
+        if (t.Length == 0)
+            return false;
+        // A generic/collection or array param is not a single request DTO; treat only a bare named type as a body.
+        if (t.IndexOfAny(['<', '>', '[', ']']) >= 0)
+            return false;
+        if (Primitives.Contains(t))
+            return false;
+        // Must look like a user type (an upper-case leading char, or interface 'I' prefix).
+        return char.IsUpper(t[0]);
+    }
+
+    private static readonly HashSet<string> Primitives = new(StringComparer.Ordinal)
+    {
+        "bool", "byte", "sbyte", "char", "decimal", "double", "float", "int", "uint", "long", "ulong", "short",
+        "ushort", "string", "object", "void", "Guid", "DateTime", "DateTimeOffset", "TimeSpan", "Boolean", "Int32",
+        "Int64", "Int16", "Double", "Single", "Decimal", "String", "Object", "Byte", "Char", "CancellationToken",
+    };
+
+    // ============================ TsClientCall reduction (Leg 1 TS side) ========================================
+
+    /// <summary>
+    /// Reduce each <c>kind='url'</c> literal into a <see cref="TsClientCall"/>, attaching the containing symbol's
+    /// <c>test_role</c> and the use-site file:line. The leg itself does the language + test filter; the builder only
+    /// supplies the located rows. Deterministic: ordered by literal span.
+    /// </summary>
+    private static IReadOnlyList<TsClientCall> ReduceClientCalls(
+        IReadOnlyList<LiteralRecord> literals,
+        IReadOnlyDictionary<string, SymbolDetail> symbolsById,
+        IReadOnlyDictionary<LiteralRecord, LiteralSite>? literalSites)
+    {
+        var calls = new List<TsClientCall>();
+        var ordered = literals
+            .Where(l => string.Equals(l.Kind, "url", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(l => l.Span.StartByte)
+            .ThenBy(l => l.ContainingSymbolId, StringComparer.Ordinal);
+
+        foreach (var literal in ordered)
+        {
+            TestRole? testRole = null;
+            if (!string.IsNullOrEmpty(literal.ContainingSymbolId) &&
+                symbolsById.TryGetValue(literal.ContainingSymbolId, out var container))
+            {
+                testRole = container.TestRole;
+            }
+
+            var site = SiteFor(literal, symbolsById, literalSites);
+            calls.Add(new TsClientCall(literal, testRole, site.FilePath, site.Line));
+        }
+        return calls;
+    }
+
+    // ============================ node construction ============================================================
+
+    /// <summary>
+    /// Build a <see cref="BridgeNode"/> for every endpoint of a surviving scored edge, keyed by the same node id
+    /// <see cref="BridgeGraph"/> uses (resolved symbol id, or a kind+display synthesis). A symbol-backed node is
+    /// enriched with the symbol's file:line; a non-symbol node (table / route) carries the edge ref's display + file.
+    /// </summary>
+    private static IReadOnlyDictionary<string, BridgeNode> BuildNodes(
+        IReadOnlyList<ScoredEdge> scored, IReadOnlyDictionary<string, SymbolDetail> symbolsById)
+    {
+        var nodes = new Dictionary<string, BridgeNode>(StringComparer.Ordinal);
+        foreach (var edge in scored)
+        {
+            AddNode(nodes, edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source, symbolsById);
+            AddNode(nodes, edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target, symbolsById);
+        }
+        return nodes;
+    }
+
+    private static void AddNode(
+        Dictionary<string, BridgeNode> nodes,
+        EdgeRef edgeRef,
+        BridgeKind edgeKind,
+        EndpointSide side,
+        IReadOnlyDictionary<string, SymbolDetail> symbolsById)
+    {
+        var id = BridgeGraph.NodeIdOf(edgeRef, edgeKind, side);
+        if (id is null || nodes.ContainsKey(id))
+            return;
+
+        var kind = BridgeGraph.NodeKindFor(edgeKind, side);
+
+        // A symbol-backed side: enrich with the symbol's own file (the edge ref file is the use-site, not the decl).
+        if (!string.IsNullOrEmpty(edgeRef.SymbolId) && symbolsById.TryGetValue(edgeRef.SymbolId, out var symbol))
+        {
+            nodes[id] = new BridgeNode(id, kind, edgeRef.Display, symbol.FilePath, Line: 0);
+            return;
+        }
+
+        nodes[id] = new BridgeNode(id, kind, edgeRef.Display, edgeRef.FilePath, Line: 0);
+    }
+
+    // ============================ shared helpers ===============================================================
+
+    private static Dictionary<string, SymbolDetail> BuildSymbolIndex(IReadOnlyList<SymbolDetail> symbols)
+    {
+        var byId = new Dictionary<string, SymbolDetail>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+            byId[symbol.Id] = symbol; // last write wins for a duplicated id
+        return byId;
+    }
+
+    /// <summary>
+    /// Resolve a literal's use-site file:line: the reader-supplied lookup first (the seam), else the containing
+    /// symbol's file (line 0, unknown). A literal with neither yields an empty file + line 0.
+    /// </summary>
+    private static LiteralSite SiteFor(
+        LiteralRecord literal,
+        IReadOnlyDictionary<string, SymbolDetail> symbolsById,
+        IReadOnlyDictionary<LiteralRecord, LiteralSite>? literalSites)
+    {
+        if (literalSites is not null && literalSites.TryGetValue(literal, out var site))
+            return site;
+
+        if (!string.IsNullOrEmpty(literal.ContainingSymbolId) &&
+            symbolsById.TryGetValue(literal.ContainingSymbolId, out var container))
+            return new LiteralSite(container.FilePath, 0);
+
+        return new LiteralSite(string.Empty, 0);
+    }
+
+    private static IEnumerable<string> Sorted(IEnumerable<string> keys)
+    {
+        var list = keys.ToList();
+        list.Sort(StringComparer.Ordinal);
+        return list;
+    }
+
+    /// <summary>The first double-quoted string argument in a raw attribute text, or null.</summary>
+    private static string? FirstStringArg(string rawText)
+    {
+        if (rawText is null)
+            return null;
+        int start = rawText.IndexOf('"');
+        if (start < 0)
+            return null;
+        int end = rawText.IndexOf('"', start + 1);
+        if (end <= start)
+            return null;
+        return rawText[(start + 1)..end];
+    }
+
+    // ---- balanced-bracket helpers (treat <...>/(...)/[...] by depth) -------------------------------------------
+
+    private static int TopLevelChar(string s, char target)
+    {
+        int depth = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '[')
+                depth++;
+            else if (ch is '>' or ']')
+                depth--;
+            else if (ch == target && depth == 0)
+                return i;
+        }
+        return -1;
+    }
+
+    private static string? BalancedInner(string s, int open)
+    {
+        char openCh = s[open];
+        char closeCh = openCh switch { '<' => '>', '(' => ')', '[' => ']', '{' => '}', _ => '\0' };
+        if (closeCh == '\0')
+            return null;
+
+        int depth = 0;
+        for (int i = open; i < s.Length; i++)
+        {
+            if (s[i] == openCh)
+                depth++;
+            else if (s[i] == closeCh)
+            {
+                depth--;
+                if (depth == 0)
+                    return s[(open + 1)..i];
+            }
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> SplitTopLevel(string s)
+    {
+        var parts = new List<string>();
+        var current = new System.Text.StringBuilder();
+        int depth = 0;
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '<' or '(' or '[':
+                    depth++;
+                    current.Append(ch);
+                    break;
+                case '>' or ')' or ']':
+                    depth--;
+                    current.Append(ch);
+                    break;
+                case ',' when depth == 0:
+                    parts.Add(current.ToString());
+                    current.Clear();
+                    break;
+                default:
+                    current.Append(ch);
+                    break;
+            }
+        }
+        if (current.Length > 0)
+            parts.Add(current.ToString());
+        return parts;
+    }
+
+    private static int TopLevelIndexOf(string s, char target)
+    {
+        int depth = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if (ch == target && depth == 0)
+                return i;
+        }
+        return -1;
+    }
+
+    private static int LastTopLevelSpace(string s)
+    {
+        int depth = 0, last = -1;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if ((ch == ' ' || ch == '\t') && depth == 0)
+                last = i;
+        }
+        return last;
+    }
+}
+
+/// <summary>
+/// A literal's resolved use-site file:line (the literal-evidence seam — see <see cref="BridgeGraphBuilder"/> remarks).
+/// The DB reader (plan Task 9) supplies the lookup; Miller.Core stays free of julie's row shape.
+/// </summary>
+/// <param name="FilePath">The workspace-relative file the literal lives in.</param>
+/// <param name="Line">The 1-based line of the literal, or 0 when unknown.</param>
+public readonly record struct LiteralSite(string FilePath, int Line);

--- a/src/Miller.Core/Graph/SymbolGraph.cs
+++ b/src/Miller.Core/Graph/SymbolGraph.cs
@@ -206,6 +206,79 @@ public sealed class SymbolGraph
             .ToArray();
     }
 
+    /// <summary>
+    /// The shortest dependency path from <paramref name="from"/> to <paramref name="to"/> as an ordered id list
+    /// (<c>from … to</c>, inclusive of both endpoints), or null when <paramref name="to"/> is unreachable from
+    /// <paramref name="from"/> within <paramref name="maxDepth"/> hops or either endpoint is not a vertex of the graph.
+    /// Follows the forward (<see cref="Dependencies"/>) adjacency — "what does <c>from</c> reach". Breadth-first with
+    /// parent reconstruction; ties are broken by visiting neighbours in id order (consistent with <see cref="Reach"/>),
+    /// so the returned path is deterministic across runs. <c>from == to</c> (a known vertex) yields the single-node
+    /// path <c>[from]</c>.
+    /// </summary>
+    /// <param name="from">The start vertex id; null/unknown yields null.</param>
+    /// <param name="to">The goal vertex id; null/unknown yields null.</param>
+    /// <param name="maxDepth">Maximum hop distance to explore; <c>≤ 0</c> yields null unless <c>from == to</c>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="from"/> or <paramref name="to"/> is null.</exception>
+    public IReadOnlyList<string>? ShortestPath(string from, string to, int maxDepth)
+    {
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+
+        if (!_isTest.ContainsKey(from) || !_isTest.ContainsKey(to))
+            return null; // an endpoint not in the graph: no path
+
+        if (string.Equals(from, to, StringComparison.Ordinal))
+            return [from]; // a vertex always reaches itself at distance 0 (even when maxDepth <= 0)
+
+        if (maxDepth <= 0)
+            return null;
+
+        // BFS over the forward adjacency, recording the parent each node was first discovered from (BFS guarantees the
+        // first discovery is along a shortest path). Neighbours are already id-sorted, so the parent chain is stable.
+        var parent = new Dictionary<string, string>(StringComparer.Ordinal);
+        var depth = new Dictionary<string, int>(StringComparer.Ordinal) { [from] = 0 };
+        var frontier = new Queue<string>();
+        frontier.Enqueue(from);
+
+        while (frontier.Count > 0)
+        {
+            var current = frontier.Dequeue();
+            var currentDepth = depth[current];
+            if (currentDepth >= maxDepth)
+                continue; // its neighbours would exceed the depth cap
+
+            foreach (var neighbour in Dependencies(current)) // id-sorted; deterministic tie-break
+            {
+                if (depth.ContainsKey(neighbour))
+                    continue; // already discovered at an equal-or-shorter distance
+
+                depth[neighbour] = currentDepth + 1;
+                parent[neighbour] = current;
+
+                if (string.Equals(neighbour, to, StringComparison.Ordinal))
+                    return Reconstruct(parent, from, to);
+
+                frontier.Enqueue(neighbour);
+            }
+        }
+
+        return null; // to was never reached within maxDepth
+    }
+
+    /// <summary>Rebuild the from→to path by walking the parent chain back from <paramref name="to"/> and reversing.</summary>
+    private static IReadOnlyList<string> Reconstruct(IReadOnlyDictionary<string, string> parent, string from, string to)
+    {
+        var reversed = new List<string> { to };
+        var node = to;
+        while (!string.Equals(node, from, StringComparison.Ordinal))
+        {
+            node = parent[node];
+            reversed.Add(node);
+        }
+        reversed.Reverse();
+        return reversed;
+    }
+
     /// <summary>The neighbour ids of <paramref name="id"/> in the requested direction (Both = forward ∪ reverse).</summary>
     private IEnumerable<string> Neighbours(string id, Direction dir) => dir switch
     {

--- a/src/Miller.Core/Resolver/BridgeKind.cs
+++ b/src/Miller.Core/Resolver/BridgeKind.cs
@@ -1,0 +1,33 @@
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// The closed set of cross-language bridge edge kinds the legs emit (design §4). The scorer does NOT branch on the
+/// kind to assign a band — the band is decided from the typed <c>signals[]</c> payload alone — but the kind is the
+/// edge's semantic label and is carried for the <c>trace</c> tool's rendering (<c>UserDto ←CreateMap─ ApplicationUser</c>).
+/// </summary>
+public enum BridgeKind
+{
+    /// <summary>
+    /// A C# entity ↔ DB table edge (Leg 3): <c>CsEntity —stored_in→ DbTable</c>, anchored by a <c>DbSet&lt;T&gt;</c>
+    /// property (table = property name) or, opportunistically, a Dapper <c>FROM</c> literal.
+    /// </summary>
+    StoredIn,
+
+    /// <summary>
+    /// A C# DTO ↔ entity edge (Leg 2): <c>source —maps_to→ dest</c>, anchored by an AutoMapper <c>CreateMap&lt;A,B&gt;</c>
+    /// (copy-source→copy-dest), a <c>ToDto</c> extension method, or a (corroborator-only) inline projection.
+    /// </summary>
+    MapsTo,
+
+    /// <summary>A TS client call ↔ C# endpoint edge (Leg 1): <c>TsCall —hits→ Endpoint</c> by matched (verb, route).</summary>
+    Hits,
+
+    /// <summary>An endpoint ↔ response DTO edge (Leg 1): <c>Endpoint —responds→ CsDto</c> from the unwrapped return type.</summary>
+    Responds,
+
+    /// <summary>A call/endpoint ↔ request DTO edge (Leg 1): <c>—consumes→ CsDto</c> from the <c>[FromBody]</c>/param type.</summary>
+    Consumes,
+
+    /// <summary>A name-finisher edge (the "safe finisher"): a canonical-stem match between a TS type and a C# DTO/entity.</summary>
+    NameMatch,
+}

--- a/src/Miller.Core/Resolver/BridgeScorer.cs
+++ b/src/Miller.Core/Resolver/BridgeScorer.cs
@@ -1,0 +1,202 @@
+namespace Miller.Core.Resolver;
+
+/// <summary>The §5 confidence band an edge lands in.</summary>
+public enum ConfidenceBand
+{
+    /// <summary>≥0.9 — an explicit structural breadcrumb fired on a non-ambiguous edge (design §5).</summary>
+    High,
+
+    /// <summary>~0.7–0.85 — exact/affix name + ≥1 corroborator, route-only, or a breadcrumb degraded by an ambiguous name.</summary>
+    Medium,
+}
+
+/// <summary>
+/// A scored bridge edge: the original <see cref="CandidateEdge"/> wrapped with its computed <see cref="Score"/>,
+/// <see cref="Band"/>, and the §5 flags (<see cref="IsMultiSignal"/>, <see cref="HasAmbiguousName"/>,
+/// <see cref="IsVerbUnknown"/>) the <c>trace</c> tool renders so nothing is presented as certain when it isn't. The
+/// scorer never mutates the candidate; it wraps it.
+/// </summary>
+/// <param name="Edge">The scored candidate, preserved verbatim (evidence + signals) for rendering.</param>
+/// <param name="Score">The confidence in [0,1].</param>
+/// <param name="Band">The §5 band the score falls in.</param>
+/// <param name="IsMultiSignal">True when ≥2 independent positive signals fired (the multi-signal boost applied).</param>
+/// <param name="HasAmbiguousName">True when a side resolved ambiguously — the edge can NEVER be High (it is flagged).</param>
+/// <param name="IsVerbUnknown">True when the edge rests on a route-only (verb-unknown) match — flagged as reduced certainty.</param>
+public sealed record ScoredEdge(
+    CandidateEdge Edge,
+    double Score,
+    ConfidenceBand Band,
+    bool IsMultiSignal,
+    bool HasAmbiguousName,
+    bool IsVerbUnknown);
+
+/// <summary>
+/// Assigns the design §5 confidence band to a candidate edge from its typed-signal PAYLOAD ALONE — no leg-side
+/// precision logic, no re-query of the <see cref="SymbolResolver"/>. The load-bearing invariants, each decidable from
+/// the candidate:
+/// <list type="bullet">
+/// <item><b>unresolved ⇒ no edge.</b> A side whose <c>NameResolution</c> status is Unresolved (in a per-side signal or
+/// on the <see cref="EdgeRef"/>) has no symbol to point at — the edge is dropped (null).</item>
+/// <item><b>field-set Jaccard is NEVER a sole signal,</b> and a <b>1-field/generic shape can't anchor</b> — the scorer
+/// reads <see cref="FieldSetSignal.FieldCount"/>; a corroborator needs ≥2 fields, and a corroborator never stands alone.</item>
+/// <item><b>the name finisher is never the sole signal</b> — a NameMatch needs a structural breadcrumb or a valid
+/// field-set corroborator to form an edge.</item>
+/// <item><b>High (≥0.9) requires an explicit structural breadcrumb</b> (CreateMap, DbSetProperty, RouteVerbMatch, or a
+/// real DapperFrom) on a non-ambiguous edge.</item>
+/// <item><b>an ambiguous-name edge can NEVER be High</b> — the scorer reads <c>NameResolution.status</c> off the
+/// payload and caps the band at Medium, flagging it.</item>
+/// <item><b>multi-signal boost</b> — ≥2 independent positive signals score strictly higher (within the band) and are
+/// flagged.</item>
+/// </list>
+/// </summary>
+public static class BridgeScorer
+{
+    // §5 band anchors. High starts at 0.9; Medium spans ~0.7–0.85. A small per-corroborator increment gives the
+    // multi-signal boost while staying inside the band's ceiling.
+    private const double HighBase = 0.90;
+    private const double HighCeiling = 0.99;
+    private const double MediumBase = 0.70;
+    private const double MediumCeiling = 0.85;
+    private const double CorroboratorStep = 0.05;
+
+    // A field-set overlap can only corroborate when the (smaller) shape has at least this many fields — a 1-field /
+    // generic wrapper Jaccard-matches everything, so it can neither anchor nor corroborate (design §5).
+    private const int MinAnchoringFieldCount = 2;
+
+    /// <summary>
+    /// Score <paramref name="candidate"/>, or return null when the §5 rules say no edge should be emitted (no anchor,
+    /// an unresolved side, or only an insufficient corroborator). The result's <see cref="ScoredEdge.Band"/>/score and
+    /// flags are decided entirely from the candidate payload.
+    /// </summary>
+    /// <param name="candidate">The leg-emitted candidate edge.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="candidate"/> is null.</exception>
+    public static ScoredEdge? Score(CandidateEdge candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        // Gate 1 — unresolved side ⇒ no edge (no symbol to point at). Read from both the per-side signals and the refs.
+        if (HasUnresolvedSide(candidate))
+            return null;
+
+        bool ambiguous = HasAmbiguousSide(candidate);
+
+        // Classify the positive signals from the payload.
+        bool hasStructuralBreadcrumb = false; // a High-eligible structural anchor (CreateMap/DbSet/RouteVerb/DapperFrom/ReturnTypeDto/FromBodyDto)
+        bool hasRouteOnly = false;            // a verb-unknown route match (Medium anchor)
+        bool hasName = false;                 // a name-stem match (finisher; never sole)
+        bool hasFieldCorroborator = false;    // a field-set overlap with >= MinAnchoringFieldCount fields
+
+        // Count DISTINCT positive signal kinds for the multi-signal boost. Deduping by rule stops a leg that emits the
+        // same rule twice (e.g. two field-set comparisons, or two CreateMap sites for one pair) from inflating the
+        // score/flag — the boost rewards N *independent kinds* of evidence, not N signal records.
+        var positiveRules = new HashSet<SignalRule>();
+
+        foreach (var signal in candidate.Signals)
+        {
+            switch (signal)
+            {
+                case StructuralSignal { Present: true } s:
+                    if (s.Rule == SignalRule.RouteOnlyMatch)
+                    {
+                        hasRouteOnly = true;
+                    }
+                    else
+                    {
+                        hasStructuralBreadcrumb = true;
+                    }
+                    positiveRules.Add(s.Rule);
+                    break;
+
+                case NameSignal:
+                    hasName = true;
+                    positiveRules.Add(SignalRule.NameMatch);
+                    break;
+
+                case FieldSetSignal fs when fs.FieldCount >= MinAnchoringFieldCount && fs.Jaccard > 0.0:
+                    hasFieldCorroborator = true;
+                    positiveRules.Add(SignalRule.FieldSetJaccard);
+                    break;
+
+                // A present=false structural signal, a NameResolution signal, or a sub-threshold field-set: not a
+                // positive corroborator. (NameResolution is metadata; it never raises a band.)
+                default:
+                    break;
+            }
+        }
+
+        int positiveSignals = positiveRules.Count;
+
+        // Gate 2 — there must be a real anchor:
+        //   * a structural breadcrumb, OR
+        //   * a route-only match, OR
+        //   * a name match WITH a valid field-set corroborator (name is never sole; field-set is never sole).
+        bool nameAnchored = hasName && hasFieldCorroborator;
+        bool hasAnchor = hasStructuralBreadcrumb || hasRouteOnly || nameAnchored;
+        if (!hasAnchor)
+            return null;
+
+        bool multiSignal = positiveSignals >= 2;
+
+        // Band selection (design §5):
+        //   High  — a structural breadcrumb on a non-ambiguous edge.
+        //   Medium — everything else that anchored (route-only, name+corroborator, or a breadcrumb degraded by an
+        //            ambiguous name).
+        ConfidenceBand band = (hasStructuralBreadcrumb && !ambiguous) ? ConfidenceBand.High : ConfidenceBand.Medium;
+
+        double score = ScoreFor(band, positiveSignals);
+
+        return new ScoredEdge(
+            candidate,
+            score,
+            band,
+            IsMultiSignal: multiSignal,
+            HasAmbiguousName: ambiguous,
+            IsVerbUnknown: hasRouteOnly);
+    }
+
+    /// <summary>
+    /// The numeric score within a band: the band base plus a per-extra-positive-signal step (the multi-signal boost),
+    /// capped at the band ceiling. One signal sits at the base; each additional independent signal raises it, so a
+    /// multi-signal edge strictly outscores an otherwise-identical single-signal one without crossing the band line.
+    /// </summary>
+    private static double ScoreFor(ConfidenceBand band, int positiveSignals)
+    {
+        var (@base, ceiling) = band == ConfidenceBand.High
+            ? (HighBase, HighCeiling)
+            : (MediumBase, MediumCeiling);
+
+        int extra = Math.Max(0, positiveSignals - 1);
+        double raw = @base + extra * CorroboratorStep;
+        return Math.Min(raw, ceiling);
+    }
+
+    /// <summary>True when any side resolved Unresolved (per-side signal OR the ref's own resolution).</summary>
+    private static bool HasUnresolvedSide(CandidateEdge candidate)
+    {
+        if (candidate.SourceRef.Resolution.Status == ResolutionStatus.Unresolved ||
+            candidate.TargetRef.Resolution.Status == ResolutionStatus.Unresolved)
+            return true;
+
+        foreach (var signal in candidate.Signals)
+        {
+            if (signal is NameResolutionSignal { Status: ResolutionStatus.Unresolved })
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when any side resolved Ambiguous (per-side signal OR the ref's own resolution).</summary>
+    private static bool HasAmbiguousSide(CandidateEdge candidate)
+    {
+        if (candidate.SourceRef.Resolution.Status == ResolutionStatus.Ambiguous ||
+            candidate.TargetRef.Resolution.Status == ResolutionStatus.Ambiguous)
+            return true;
+
+        foreach (var signal in candidate.Signals)
+        {
+            if (signal is NameResolutionSignal { Status: ResolutionStatus.Ambiguous })
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Miller.Core/Resolver/CandidateEdge.cs
+++ b/src/Miller.Core/Resolver/CandidateEdge.cs
@@ -1,0 +1,31 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// A candidate cross-language bridge edge emitted by a leg, carrying everything the <see cref="BridgeScorer"/> needs and
+/// NO final score yet (design §4/§5). The trust contract: the scorer decides the §5 band from this payload ALONE — the
+/// typed <see cref="Signals"/>, the per-side <see cref="SourceRef"/>/<see cref="TargetRef"/> resolution outcomes, and the
+/// optional field-sets — with no leg-side precision logic and no re-query of the resolver. Built BEFORE any leg exists so
+/// the scorer's invariants are pinned against synthetic candidates first.
+/// </summary>
+/// <param name="Kind">The semantic edge kind (carried for rendering; the band is NOT derived from it).</param>
+/// <param name="SourceRef">
+/// The edge's source endpoint, carrying its <see cref="SymbolResolver"/> outcome so ambiguity is visible in the payload.
+/// </param>
+/// <param name="TargetRef">The edge's target endpoint, likewise carrying its resolution outcome.</param>
+/// <param name="Evidence">The edge-level locating evidence (<c>file:line</c> sites); may be empty.</param>
+/// <param name="Signals">
+/// The TYPED signals that fired for this edge (the closed <see cref="SignalRule"/> set). The scorer reads payloads
+/// (fieldCount/Jaccard, name tier, per-side resolution status), never bare rule names. Order is leg-defined.
+/// </param>
+/// <param name="SourceFieldSet">The source endpoint's field shape, when a leg captured it (the Jaccard corroborator input); null otherwise.</param>
+/// <param name="TargetFieldSet">The target endpoint's field shape, when captured; null otherwise.</param>
+public sealed record CandidateEdge(
+    BridgeKind Kind,
+    EdgeRef SourceRef,
+    EdgeRef TargetRef,
+    IReadOnlyList<Evidence> Evidence,
+    IReadOnlyList<Signal> Signals,
+    FieldSet? SourceFieldSet = null,
+    FieldSet? TargetFieldSet = null);

--- a/src/Miller.Core/Resolver/DtoEntityBridge.cs
+++ b/src/Miller.Core/Resolver/DtoEntityBridge.cs
@@ -1,0 +1,275 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// An AutoMapper <c>CreateMap&lt;A,B&gt;</c> use-site, already reduced from julie's <c>type_arguments</c> rows (design
+/// §4 Leg 2 PRIMARY; findings 28-2). The two type names come from the call's <c>type_arguments</c> grouped by
+/// <c>identifier_id</c> and read in ordinal order: ordinal 0 = copy-SOURCE, ordinal 1 = copy-DEST (a julie-tested
+/// invariant). <b>That ordinal encodes the COPY direction, NOT entity-vs-DTO</b> — an inbound
+/// <c>CreateMap&lt;CreateOrderRequest, Order&gt;</c> legitimately puts the DTO at ordinal 0, so the leg directs the
+/// edge source→dest and never assumes ordinal 0 is the entity (the design §8 trap).
+///
+/// <para>The ordinal-to-record reduction (grouping <c>type_arguments</c> by <c>identifier_id</c>, filtering to the
+/// <c>CreateMap</c> use-site with <c>kind='type_usage'</c>) is the graph builder's job — plan Task 8, out of this leg's
+/// scope. This is the already-reduced input the pure leg consumes. <see cref="HasReverseMap"/> is set by that builder
+/// when it detects a sibling <c>.ReverseMap()</c> on the same chain (julie captures no separate structured row for it),
+/// so the leg can emit the inverse edge.</para>
+/// </summary>
+/// <param name="SourceTypeName">The ordinal-0 type (copy-source) as written; resolved to a symbol by name.</param>
+/// <param name="DestTypeName">The ordinal-1 type (copy-dest) as written; resolved to a symbol by name.</param>
+/// <param name="FilePath">The CreateMap use-site file (workspace-relative), for the edge evidence.</param>
+/// <param name="Line">The 1-based use-site line, for the edge evidence (file:line).</param>
+/// <param name="HasReverseMap">True when a sibling <c>.ReverseMap()</c> was detected — the leg emits the inverse edge.</param>
+public sealed record CreateMapCandidate(
+    string SourceTypeName,
+    string DestTypeName,
+    string FilePath,
+    int Line,
+    bool HasReverseMap = false);
+
+/// <summary>
+/// A manual/projection mapping use-site (design §4 Leg 2 SECONDARY — WEAK / corroborator-only): a <c>ToDto</c> /
+/// <c>Select(x =&gt; new XDto{…})</c> projection that has NO structured copy-source→dest breadcrumb. The graph builder
+/// (plan Task 8) pairs the source entity to the dest DTO by name-overlap over <c>code_context</c>; the pure leg consumes
+/// the already-paired (source, dest) names and corroborates the pairing with a name-stem match plus a field-set Jaccard.
+/// Because there is no structural breadcrumb, the scorer can only ever land this at Medium — <b>never High</b> — and a
+/// 1-field shape can NOT anchor it (the <c>RevisionEntry↔DocumentRevisionDto</c> false-positive class, design §5/§8).
+/// </summary>
+/// <param name="SourceTypeName">The projection's source type (the entity) as written; resolved by name.</param>
+/// <param name="DestTypeName">The projection's dest type (the DTO) as written; resolved by name.</param>
+/// <param name="FilePath">The projection use-site file (workspace-relative), for the edge evidence.</param>
+/// <param name="Line">The 1-based use-site line, for the edge evidence (file:line).</param>
+public sealed record ProjectionCandidate(
+    string SourceTypeName,
+    string DestTypeName,
+    string FilePath,
+    int Line);
+
+/// <summary>
+/// The owner symbol plus the inputs <see cref="FieldSetExtractor.ExtractFields"/> needs to build its
+/// <see cref="FieldSet"/>: the owning type, its child symbols (properties/fields via <c>parent_id</c>, already scoped to
+/// this owner), and their annotations (e.g. <c>[JsonProperty]</c>). For a C# <c>record</c> the children may be empty —
+/// the extractor parses the positional params from the owner's signature instead.
+/// </summary>
+/// <param name="Owner">The owning type symbol whose field shape is being built.</param>
+/// <param name="Children">The owner's child symbols (already scoped by the caller via <c>parent_id</c>); may be empty.</param>
+/// <param name="Annotations">Annotations on the children (e.g. <c>[JsonProperty]</c>); may be empty.</param>
+public sealed record TypeFieldSource(
+    SymbolDetail Owner,
+    IReadOnlyList<SymbolDetail> Children,
+    IReadOnlyList<SymbolAnnotation> Annotations);
+
+/// <summary>
+/// The in-memory contract collections <see cref="DtoEntityBridge"/> consumes (design §4 Leg 2; plan Task 6). Pure value
+/// input — no DB, no I/O. The DB loader (plan Task 9) / graph builder (Task 8) builds these from julie rows; the leg
+/// never reads SQLite.
+/// </summary>
+/// <param name="CreateMaps">
+/// AutoMapper <c>CreateMap&lt;A,B&gt;</c> use-sites (Leg 2 PRIMARY breadcrumb): each yields a High-eligible source→dest
+/// edge, plus the inverse when <see cref="CreateMapCandidate.HasReverseMap"/> is set.
+/// </param>
+/// <param name="Projections">
+/// Manual/projection mappings (Leg 2 SECONDARY, corroborator-only): each yields at most a Medium name+field-set edge.
+/// </param>
+/// <param name="FieldSources">
+/// Per-owner-id field-set sources (<c>symbol id → TypeFieldSource</c>). The leg builds a side's <see cref="FieldSet"/>
+/// only when its resolved symbol id has an entry here; absent an entry it carries no field-set (the structural
+/// CreateMap breadcrumb still stands alone). PRIMARY CreateMap edges use it opportunistically (a richer corroborator);
+/// SECONDARY projections REQUIRE both sides to have a field-set or they cannot anchor.
+/// </param>
+public sealed record DtoEntityInput(
+    IReadOnlyList<CreateMapCandidate> CreateMaps,
+    IReadOnlyList<ProjectionCandidate> Projections,
+    IReadOnlyDictionary<string, TypeFieldSource>? FieldSources = null);
+
+/// <summary>
+/// Leg 2 of the cross-language resolver (design §4): builds candidate <see cref="BridgeKind.MapsTo"/> edges linking a C#
+/// DTO and the entity it maps to/from. PURE Miller.Core — it operates over the in-memory <see cref="DtoEntityInput"/>,
+/// resolves each type name via <see cref="SymbolResolver"/>, builds field-sets via <see cref="FieldSetExtractor"/>, and
+/// emits typed <see cref="CandidateEdge"/>s. It NEVER scores, bands, or re-implements confidence logic; every signal it
+/// emits is decidable by <see cref="BridgeScorer"/> from the candidate payload alone (the trust contract, design §5).
+///
+/// <para><b>PRIMARY — AutoMapper CreateMap (High-eligible).</b> A <c>CreateMap&lt;A,B&gt;</c> use-site emits a
+/// <see cref="SignalRule.CreateMap"/> structural breadcrumb on a source(ordinal 0)→dest(ordinal 1) edge. The ordinal is
+/// the COPY direction, NOT entity-vs-DTO, so an inbound map is not mislabeled. A sibling <c>.ReverseMap()</c>
+/// (<see cref="CreateMapCandidate.HasReverseMap"/>) emits the inverse edge. A corroborating <see cref="NameSignal"/> and
+/// a <see cref="FieldSetSignal"/> ride along when the stems fold / both field-sets are available.</para>
+///
+/// <para><b>SECONDARY — manual/projection mapping (Medium ceiling — never High).</b> A projection carries NO structural
+/// breadcrumb: the leg emits a <see cref="NameSignal"/> (when the stems fold) plus a <see cref="FieldSetSignal"/> (when
+/// both field-sets are available). The scorer's name-never-sole + 1-field-can't-anchor rules then decide whether this
+/// reaches Medium or is dropped — the leg never pre-judges (design §5).</para>
+/// </summary>
+public static class DtoEntityBridge
+{
+    /// <summary>
+    /// Build the DTO↔entity candidate edges from <paramref name="input"/>, resolving each type name through
+    /// <paramref name="resolver"/>. Returns one candidate per CreateMap (two when <c>ReverseMap</c>), plus one per
+    /// projection. An unresolved/ambiguous side is reflected in the candidate's <see cref="EdgeRef.Resolution"/> + a
+    /// <see cref="NameResolutionSignal"/> so the scorer (not the leg) applies the §5 drop/cap rules. The leg does NOT
+    /// score; it never returns a band.
+    /// </summary>
+    /// <param name="input">The in-memory CreateMap + projection breadcrumbs and per-owner field sources.</param>
+    /// <param name="resolver">The name resolver over the workspace's symbols.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="resolver"/> is null.</exception>
+    public static IReadOnlyList<CandidateEdge> Resolve(DtoEntityInput input, SymbolResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        var edges = new List<CandidateEdge>();
+
+        foreach (var map in input.CreateMaps)
+        {
+            edges.Add(BuildCreateMapEdge(map.SourceTypeName, map.DestTypeName, map, input, resolver));
+            if (map.HasReverseMap)
+                edges.Add(BuildCreateMapEdge(map.DestTypeName, map.SourceTypeName, map, input, resolver));
+        }
+
+        foreach (var projection in input.Projections)
+            edges.Add(BuildProjectionEdge(projection, input, resolver));
+
+        return edges;
+    }
+
+    /// <summary>
+    /// Build a PRIMARY CreateMap edge from <paramref name="sourceName"/>→<paramref name="destName"/> (the direction the
+    /// caller wants — forward for the declared map, swapped for the ReverseMap). Emits the CreateMap breadcrumb, both
+    /// sides' NameResolution metadata, an opportunistic field-set corroborator, and a name corroborator when the stems
+    /// fold.
+    /// </summary>
+    private static CandidateEdge BuildCreateMapEdge(
+        string sourceName, string destName, CreateMapCandidate map, DtoEntityInput input, SymbolResolver resolver)
+    {
+        var evidence = new Evidence(map.FilePath, map.Line);
+
+        var (sourceRef, sourceFields) = ResolveSide(sourceName, map.FilePath, input, resolver);
+        var (targetRef, targetFields) = ResolveSide(destName, map.FilePath, input, resolver);
+
+        var signals = new List<Signal>
+        {
+            new StructuralSignal(SignalRule.CreateMap, Present: true, evidence),
+            new NameResolutionSignal(EndpointSide.Source, sourceRef.Resolution.Status, sourceRef.Resolution.MatchCount, evidence),
+            new NameResolutionSignal(EndpointSide.Target, targetRef.Resolution.Status, targetRef.Resolution.MatchCount, evidence),
+        };
+
+        AddFieldSetCorroboratorIfAvailable(signals, sourceFields, targetFields, evidence);
+        AddNameCorroboratorIfStemsMatch(signals, sourceName, destName, evidence);
+
+        return new CandidateEdge(
+            BridgeKind.MapsTo,
+            sourceRef,
+            targetRef,
+            [evidence],
+            signals,
+            sourceFields,
+            targetFields);
+    }
+
+    /// <summary>
+    /// Build a SECONDARY projection edge (corroborator-only — never High): no structural breadcrumb, just the per-side
+    /// NameResolution metadata plus a name corroborator (when stems fold) and a field-set corroborator (when both
+    /// field-sets are available). The scorer decides whether these reach Medium or are dropped.
+    /// </summary>
+    private static CandidateEdge BuildProjectionEdge(
+        ProjectionCandidate projection, DtoEntityInput input, SymbolResolver resolver)
+    {
+        var evidence = new Evidence(projection.FilePath, projection.Line);
+
+        var (sourceRef, sourceFields) = ResolveSide(projection.SourceTypeName, projection.FilePath, input, resolver);
+        var (targetRef, targetFields) = ResolveSide(projection.DestTypeName, projection.FilePath, input, resolver);
+
+        var signals = new List<Signal>
+        {
+            new NameResolutionSignal(EndpointSide.Source, sourceRef.Resolution.Status, sourceRef.Resolution.MatchCount, evidence),
+            new NameResolutionSignal(EndpointSide.Target, targetRef.Resolution.Status, targetRef.Resolution.MatchCount, evidence),
+        };
+
+        AddFieldSetCorroboratorIfAvailable(signals, sourceFields, targetFields, evidence);
+        AddNameCorroboratorIfStemsMatch(signals, projection.SourceTypeName, projection.DestTypeName, evidence);
+
+        return new CandidateEdge(
+            BridgeKind.MapsTo,
+            sourceRef,
+            targetRef,
+            [evidence],
+            signals,
+            sourceFields,
+            targetFields);
+    }
+
+    /// <summary>
+    /// Resolve one side's type name to an <see cref="EdgeRef"/> and, when a field source is available for the resolved
+    /// symbol, build its <see cref="FieldSet"/> via <see cref="FieldSetExtractor"/> (handles C# record positional
+    /// params). The field-set is null when the side did not resolve to a single symbol or has no field source.
+    /// </summary>
+    private static (EdgeRef Ref, FieldSet? Fields) ResolveSide(
+        string typeName, string useSiteFile, DtoEntityInput input, SymbolResolver resolver)
+    {
+        var resolution = resolver.Resolve(typeName, preferFile: useSiteFile);
+
+        FieldSet? fields = null;
+        if (resolution.Status == ResolutionStatus.Resolved &&
+            resolution.SymbolId is not null &&
+            input.FieldSources is not null &&
+            input.FieldSources.TryGetValue(resolution.SymbolId, out var source))
+        {
+            fields = FieldSetExtractor.ExtractFields(source.Owner, source.Children, source.Annotations);
+        }
+
+        var edgeRef = new EdgeRef(
+            Display: LeafName(typeName),
+            SymbolId: resolution.SymbolId,
+            FilePath: useSiteFile,
+            Resolution: resolution);
+
+        return (edgeRef, fields);
+    }
+
+    /// <summary>
+    /// Add a <see cref="FieldSetSignal"/> corroborator when BOTH sides have a field-set, computed by
+    /// <see cref="FieldSetSimilarity.Compare"/> (Jaccard over field names + the anchoring min field count). The scorer
+    /// alone decides whether the count/Jaccard is sufficient to corroborate (a 1-field shape can't anchor) — the leg
+    /// always emits the real numbers and never pre-filters.
+    /// </summary>
+    private static void AddFieldSetCorroboratorIfAvailable(
+        List<Signal> signals, FieldSet? sourceFields, FieldSet? targetFields, Evidence evidence)
+    {
+        if (sourceFields is null || targetFields is null)
+            return;
+
+        signals.Add(FieldSetSimilarity.Compare(sourceFields, targetFields, evidence));
+    }
+
+    /// <summary>
+    /// Add a corroborating <see cref="NameSignal"/> when the two type names fold to the same canonical stem (e.g.
+    /// <c>Account</c> ⇄ <c>AccountDto</c>). Exact when the raw leaf names are already identical (case-folded);
+    /// <see cref="NameTier.Affix"/> when they only matched after suffix/singular-plural folding. This only RAISES an
+    /// already-anchored edge (it is never the sole signal — the scorer enforces that).
+    /// </summary>
+    private static void AddNameCorroboratorIfStemsMatch(
+        List<Signal> signals, string sourceName, string destName, Evidence evidence)
+    {
+        var sourceLeaf = LeafName(sourceName);
+        var destLeaf = LeafName(destName);
+        var sourceStem = NameNormalizer.Stem(sourceLeaf);
+        var destStem = NameNormalizer.Stem(destLeaf);
+        if (sourceStem.Length == 0 || destStem.Length == 0 || !string.Equals(sourceStem, destStem, StringComparison.Ordinal))
+            return;
+
+        var tier = string.Equals(sourceLeaf, destLeaf, StringComparison.OrdinalIgnoreCase)
+            ? NameTier.Exact
+            : NameTier.Affix;
+        signals.Add(new NameSignal(tier, evidence));
+    }
+
+    /// <summary>The leaf (simple) name of a possibly-qualified type name (<c>Core.Data.Account</c> → <c>Account</c>).</summary>
+    private static string LeafName(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+            return typeName;
+        int dot = typeName.LastIndexOf('.');
+        return (dot >= 0 && dot < typeName.Length - 1) ? typeName[(dot + 1)..] : typeName;
+    }
+}

--- a/src/Miller.Core/Resolver/EdgeRef.cs
+++ b/src/Miller.Core/Resolver/EdgeRef.cs
@@ -1,0 +1,42 @@
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// Which side of a candidate edge a per-side signal (notably <c>NameResolution</c>) belongs to. The scorer reads the
+/// <see cref="Source"/>/<see cref="Target"/> resolution status off the payload to enforce ambiguous-name-never-High
+/// without re-querying the resolver.
+/// </summary>
+public enum EndpointSide
+{
+    /// <summary>The edge's source ref (<see cref="CandidateEdge.SourceRef"/>).</summary>
+    Source,
+
+    /// <summary>The edge's target ref (<see cref="CandidateEdge.TargetRef"/>).</summary>
+    Target,
+}
+
+/// <summary>
+/// One endpoint of a candidate edge. Carries the <see cref="SymbolResolver"/> outcome (<see cref="Resolution"/>) so
+/// the candidate payload makes name ambiguity visible WITHOUT the scorer re-querying the resolver — the
+/// ambiguous-name-never-High and unresolved-no-edge rules (design §5) are decidable from this alone. A leg builds the
+/// ref from a name resolution; the chosen <see cref="SymbolId"/> mirrors <see cref="NameResolution.SymbolId"/> (set
+/// only when <see cref="ResolutionStatus.Resolved"/>).
+/// </summary>
+/// <param name="Display">
+/// The human-facing name of this endpoint as written at the use-site (e.g. <c>ApplicationUser</c>, <c>api/appsettings/{}</c>,
+/// or a DTO/entity type name) — what the <c>trace</c> tool renders. Never null; a leg always knows the textual name.
+/// </param>
+/// <param name="SymbolId">
+/// The resolved symbol id, or null when the name resolved <see cref="ResolutionStatus.Ambiguous"/> or
+/// <see cref="ResolutionStatus.Unresolved"/> (or this endpoint is a non-symbol node like a DB table / route).
+/// </param>
+/// <param name="FilePath">The endpoint symbol's file (workspace-relative) when known, for evidence; null otherwise.</param>
+/// <param name="Resolution">
+/// The <see cref="SymbolResolver"/> outcome for this side — the source of the per-side <c>NameResolution</c> signal and
+/// the scorer's ambiguity gate. For a non-symbol endpoint that needs no name resolution (a DB table named by EF
+/// convention, a literal route), a leg supplies a trivially <see cref="ResolutionStatus.Resolved"/> outcome.
+/// </param>
+public sealed record EdgeRef(
+    string Display,
+    string? SymbolId,
+    string? FilePath,
+    NameResolution Resolution);

--- a/src/Miller.Core/Resolver/EntityTableBridge.cs
+++ b/src/Miller.Core/Resolver/EntityTableBridge.cs
@@ -1,0 +1,244 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// A Dapper inline-SQL literal paired with the entity type it reads (design §4 Leg 3 secondary; findings 28-2). julie's
+/// <c>literals</c> carry no <c>identifier_id</c> and cannot join to <c>type_arguments</c> by a shared key, so the entity
+/// (<c>T</c>) is paired to the SQL literal by span-proximity within the same <c>containing_symbol_id</c> — that pairing
+/// is the graph builder's job (plan Task 8, out of this leg's scope). This record is the already-paired input the pure
+/// leg consumes: the leg parses the <c>FROM</c> table from <see cref="Literal"/> and links it to
+/// <see cref="EntityTypeName"/>. The leg NEVER fabricates a FROM — a literal with no <c>FROM</c> clause yields no edge.
+///
+/// <para>The evidence <see cref="FilePath"/>/<see cref="Line"/> are carried HERE rather than read off
+/// <see cref="LiteralRecord"/> because Miller's <see cref="LiteralRecord"/> surfaces only the byte <c>span</c> + the
+/// <c>containing_symbol_id</c> — it does not re-expose the <c>literals</c> row's own <c>file_path</c>/line columns —
+/// so the builder that pairs the literal to its entity resolves the use-site file:line into this evidence.</para>
+/// </summary>
+/// <param name="Literal">The <c>kind=sql</c> literal whose text may contain a <c>FROM &lt;table&gt;</c> clause.</param>
+/// <param name="EntityTypeName">The entity type (<c>T</c>) paired to this literal by span-proximity; resolved by name.</param>
+/// <param name="FilePath">The literal's use-site file (workspace-relative), for the edge evidence.</param>
+/// <param name="Line">The 1-based use-site line, for the edge evidence (file:line).</param>
+public sealed record DapperFromCandidate(LiteralRecord Literal, string EntityTypeName, string FilePath, int Line);
+
+/// <summary>
+/// The in-memory contract collections <see cref="EntityTableBridge"/> consumes (design §4 Leg 3; plan Task 5). Pure
+/// value input — no DB, no I/O. The DB loader (plan Task 9) builds these from julie rows; the leg never reads SQLite.
+/// </summary>
+/// <param name="DbSetProperties">
+/// The DbContext <c>DbSet&lt;T&gt;</c> properties (Leg 3 PRIMARY breadcrumb): table = property name, entity = generic arg.
+/// </param>
+/// <param name="DapperFromCandidates">
+/// Dapper inline-SQL literals already paired to their entity (Leg 3 SECONDARY, opportunistic): a real <c>FROM</c> clause
+/// in the literal anchors a table edge; no <c>FROM</c> ⇒ no edge.
+/// </param>
+public sealed record EntityTableInput(
+    IReadOnlyList<DbSetProperty> DbSetProperties,
+    IReadOnlyList<DapperFromCandidate> DapperFromCandidates);
+
+/// <summary>
+/// Leg 3 of the cross-language resolver (design §4): builds candidate <see cref="BridgeKind.StoredIn"/> edges linking a
+/// C# entity to its database table. PURE Miller.Core — it operates over the in-memory <see cref="EntityTableInput"/>,
+/// resolves the entity type name via <see cref="SymbolResolver"/>, and emits typed <see cref="CandidateEdge"/>s. It
+/// NEVER scores, bands, or re-implements confidence logic; every signal it emits is decidable by
+/// <see cref="BridgeScorer"/> from the candidate payload alone (the trust contract, design §5).
+///
+/// <para><b>PRIMARY — DbSet&lt;T&gt; property (High-eligible).</b> Table = the DbSet property name (EF convention,
+/// <see cref="DbSetProperty.TableName"/>); entity = the <c>DbSet&lt;T&gt;</c> generic arg
+/// (<see cref="DbSetProperty.EntityTypeName"/>). The verified trap (design §8 / findings 28-2): the DbSet use-site
+/// container points at the DbContext CLASS, never the entity — so the entity is ALWAYS taken from the property's generic
+/// arg, never from a use-site container. Emits <see cref="SignalRule.DbSetProperty"/> plus, when the entity stem and
+/// table stem fold together, a corroborating <see cref="NameSignal"/>.</para>
+///
+/// <para><b>SECONDARY — Dapper FROM literal (High-eligible ONLY with a real FROM).</b> Parses the table token after
+/// <c>FROM</c> in a <c>kind=sql</c> literal and emits <see cref="SignalRule.DapperFrom"/>. A literal with no <c>FROM</c>
+/// clause yields NO edge — the leg never guesses a table (design §8; most stored-proc literals are splitOn column lists,
+/// not <c>SELECT…FROM</c>).</para>
+///
+/// <para>The table side is a node named by EF convention / SQL text, not a code symbol, so its <see cref="EdgeRef"/> is
+/// trivially <see cref="ResolutionStatus.Resolved"/> with no symbol id, and the leg never fabricates a field-set for the
+/// table (a table has no symbol-derived field shape).</para>
+/// </summary>
+public static class EntityTableBridge
+{
+    /// <summary>
+    /// Build the entity↔table candidate edges from <paramref name="input"/>, resolving each entity type name through
+    /// <paramref name="resolver"/>. Returns one candidate per DbSet property and per Dapper literal that has a real
+    /// <c>FROM</c> clause; an unresolved/ambiguous entity is reflected in the candidate's <see cref="EdgeRef.Resolution"/>
+    /// + a <see cref="NameResolutionSignal"/> so the scorer (not the leg) applies the §5 drop/cap rules. The leg does NOT
+    /// score; it never returns a band.
+    /// </summary>
+    /// <param name="input">The in-memory DbSet + Dapper breadcrumbs.</param>
+    /// <param name="resolver">The name resolver over the workspace's symbols.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="resolver"/> is null.</exception>
+    public static IReadOnlyList<CandidateEdge> Resolve(EntityTableInput input, SymbolResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        var edges = new List<CandidateEdge>();
+
+        foreach (var dbSet in input.DbSetProperties)
+            edges.Add(BuildDbSetEdge(dbSet, resolver));
+
+        foreach (var dapper in input.DapperFromCandidates)
+        {
+            var edge = TryBuildDapperEdge(dapper, resolver);
+            if (edge is not null)
+                edges.Add(edge);
+        }
+
+        return edges;
+    }
+
+    /// <summary>
+    /// Build the PRIMARY edge for one <c>DbSet&lt;T&gt;</c> property: entity (resolved by name) —stored_in→ table
+    /// (= property name). Emits the DbSetProperty breadcrumb, the per-side NameResolution metadata, and a corroborating
+    /// NameSignal when the entity stem folds to the table stem.
+    /// </summary>
+    private static CandidateEdge BuildDbSetEdge(DbSetProperty dbSet, SymbolResolver resolver)
+    {
+        var evidence = new Evidence(dbSet.FilePath, dbSet.StartLine);
+
+        // Entity = the DbSet<T> generic arg (NEVER the use-site container). Resolve it by name.
+        var entityResolution = resolver.Resolve(dbSet.EntityTypeName, preferFile: dbSet.FilePath);
+        var entityRef = new EdgeRef(
+            Display: LeafName(dbSet.EntityTypeName),
+            SymbolId: entityResolution.SymbolId,
+            FilePath: dbSet.FilePath,
+            Resolution: entityResolution);
+
+        // Table = the DbSet property name (EF convention). A table is not a code symbol — trivially Resolved, no id.
+        var tableRef = TableRef(dbSet.TableName, dbSet.FilePath);
+
+        var signals = new List<Signal>
+        {
+            new StructuralSignal(SignalRule.DbSetProperty, Present: true, evidence),
+            new NameResolutionSignal(EndpointSide.Source, entityResolution.Status, entityResolution.MatchCount, evidence),
+        };
+
+        AddNameCorroboratorIfStemsMatch(signals, dbSet.EntityTypeName, dbSet.TableName, evidence);
+
+        return new CandidateEdge(
+            BridgeKind.StoredIn,
+            entityRef,
+            tableRef,
+            [evidence],
+            signals);
+    }
+
+    /// <summary>
+    /// Build the SECONDARY edge for a Dapper literal, or return null when the literal has no real <c>FROM</c> clause
+    /// (never guess a table). Emits the DapperFrom breadcrumb, the per-side NameResolution metadata, and a corroborating
+    /// NameSignal when the entity stem folds to the parsed table stem.
+    /// </summary>
+    private static CandidateEdge? TryBuildDapperEdge(DapperFromCandidate dapper, SymbolResolver resolver)
+    {
+        var table = ParseFromTable(dapper.Literal.LiteralText);
+        if (table is null)
+            return null;
+
+        var evidence = new Evidence(dapper.FilePath, dapper.Line);
+
+        var entityResolution = resolver.Resolve(dapper.EntityTypeName, preferFile: dapper.FilePath);
+        var entityRef = new EdgeRef(
+            Display: LeafName(dapper.EntityTypeName),
+            SymbolId: entityResolution.SymbolId,
+            FilePath: dapper.FilePath,
+            Resolution: entityResolution);
+
+        var tableRef = TableRef(table, dapper.FilePath);
+
+        var signals = new List<Signal>
+        {
+            new StructuralSignal(SignalRule.DapperFrom, Present: true, evidence),
+            new NameResolutionSignal(EndpointSide.Source, entityResolution.Status, entityResolution.MatchCount, evidence),
+        };
+
+        AddNameCorroboratorIfStemsMatch(signals, dapper.EntityTypeName, table, evidence);
+
+        return new CandidateEdge(
+            BridgeKind.StoredIn,
+            entityRef,
+            tableRef,
+            [evidence],
+            signals);
+    }
+
+    /// <summary>
+    /// A non-symbol table endpoint: named by EF convention or SQL text, it has no code symbol, so the ref is trivially
+    /// <see cref="ResolutionStatus.Resolved"/> with no symbol id (so the scorer's unresolved/ambiguous gates never fire
+    /// on the table side — the design §5 gates are about the entity name).
+    /// </summary>
+    private static EdgeRef TableRef(string tableName, string filePath) =>
+        new(tableName, SymbolId: null, FilePath: filePath, new NameResolution(ResolutionStatus.Resolved, null, 1));
+
+    /// <summary>
+    /// Add a corroborating <see cref="NameSignal"/> when the entity name and table name fold to the same canonical stem
+    /// (e.g. <c>AppSetting</c> ⇄ <c>AppSettings</c>). Exact when the raw leaf names are already identical (case-folded);
+    /// <see cref="NameTier.Affix"/> when they only matched after singular/plural + affix folding. This only RAISES an
+    /// already-anchored edge (the structural breadcrumb is the anchor); it is never the sole signal.
+    /// </summary>
+    private static void AddNameCorroboratorIfStemsMatch(List<Signal> signals, string entityName, string tableName, Evidence evidence)
+    {
+        var entityLeaf = LeafName(entityName);
+        var entityStem = NameNormalizer.Stem(entityLeaf);
+        var tableStem = NameNormalizer.Stem(tableName);
+        if (entityStem.Length == 0 || tableStem.Length == 0 || !string.Equals(entityStem, tableStem, StringComparison.Ordinal))
+            return;
+
+        var tier = string.Equals(entityLeaf, tableName, StringComparison.OrdinalIgnoreCase)
+            ? NameTier.Exact
+            : NameTier.Affix;
+        signals.Add(new NameSignal(tier, evidence));
+    }
+
+    /// <summary>
+    /// Parse the table token immediately after a top-level <c>FROM</c> keyword, with any schema qualifier stripped
+    /// (<c>dbo.AppSettings</c> → <c>AppSettings</c>), or null when there is no <c>FROM</c> clause. Matches <c>FROM</c>
+    /// only as a whole word so a column/identifier containing the substring never triggers it. JOINs are not parsed —
+    /// the design takes the FROM table only, never JOINs/multi-map.
+    /// </summary>
+    private static string? ParseFromTable(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+            return null;
+
+        // Tokenize on whitespace; find a standalone "from" (case-insensitive) and take the next token as the table.
+        var tokens = sql.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (int i = 0; i < tokens.Length - 1; i++)
+        {
+            if (!string.Equals(tokens[i], "FROM", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var table = StripSchemaAndDelimiters(tokens[i + 1]);
+            return table.Length == 0 ? null : table;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reduce a raw FROM token to a bare table name: drop a trailing statement terminator / list separator, take the
+    /// segment after the last <c>.</c> (drop the schema/database qualifier), and strip surrounding SQL identifier
+    /// delimiters (<c>[]</c>, <c>"</c>, backticks).
+    /// </summary>
+    private static string StripSchemaAndDelimiters(string token)
+    {
+        var t = token.Trim().TrimEnd(';', ',', ')');
+
+        int dot = t.LastIndexOf('.');
+        if (dot >= 0 && dot < t.Length - 1)
+            t = t[(dot + 1)..];
+
+        return t.Trim('[', ']', '"', '`');
+    }
+
+    /// <summary>The leaf (simple) name of a possibly-qualified type name (<c>Core.Data.Account</c> → <c>Account</c>).</summary>
+    private static string LeafName(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+            return typeName;
+        int dot = typeName.LastIndexOf('.');
+        return (dot >= 0 && dot < typeName.Length - 1) ? typeName[(dot + 1)..] : typeName;
+    }
+}

--- a/src/Miller.Core/Resolver/FieldSetExtractor.cs
+++ b/src/Miller.Core/Resolver/FieldSetExtractor.cs
@@ -1,0 +1,400 @@
+using System.Text;
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// Builds a type's <see cref="FieldSet"/> (the scorer's Jaccard corroborator, design §5) and unwraps endpoint return
+/// types to a named user type (the <c>responds→</c> edge, design §4 Leg 1). Pure and deterministic.
+///
+/// <para>Two field-set sources, because C# records differ from classes structurally:
+/// <list type="bullet">
+/// <item>class/interface: fields come from child symbols (<c>kind=property|field</c>) reached via <c>parent_id</c>;</item>
+/// <item>C# <c>record</c>: records have NO property children, so the fields are the positional params parsed from the
+/// declaration <c>signature</c> — a naive child query returns empty and would misfire the corroborator.</item>
+/// </list>
+/// A <c>[JsonProperty("x")]</c> annotation renames a field to its wire name so the field-set matches the JSON the TS
+/// side sees.</para>
+/// </summary>
+public static class FieldSetExtractor
+{
+    // Generic wrappers that the responds-> edge unwraps to reach the carried user type.
+    private static readonly string[] Wrappers =
+    [
+        "Task", "ValueTask", "ActionResult", "IActionResult", "IEnumerable", "IList", "List", "ICollection",
+        "IReadOnlyList", "IReadOnlyCollection", "IQueryable", "IAsyncEnumerable", "Collection",
+    ];
+
+    // C# primitive / framework value types that are NOT a named user DTO target for the responds-> edge.
+    private static readonly HashSet<string> Primitives = new(StringComparer.Ordinal)
+    {
+        "bool", "byte", "sbyte", "char", "decimal", "double", "float", "int", "uint", "long", "ulong", "short",
+        "ushort", "string", "object", "void", "Guid", "DateTime", "DateTimeOffset", "TimeSpan", "Boolean", "Int32",
+        "Int64", "Int16", "Double", "Single", "Decimal", "String", "Object", "Byte", "Char",
+    };
+
+    // Wrappers that, when reached as the final unwrapped token (no generic arg left), mean "no named user type".
+    private static readonly HashSet<string> BareNonTypes = new(StringComparer.Ordinal)
+    {
+        "ActionResult", "IActionResult", "Task", "ValueTask", "void",
+    };
+
+    /// <summary>
+    /// Build the <see cref="FieldSet"/> for <paramref name="owner"/>. For a C# <c>record</c>, parses positional params
+    /// from <paramref name="owner"/>'s signature; otherwise reads <paramref name="children"/> (the owner's child
+    /// symbols) for properties/fields. <paramref name="annotations"/> supply <c>[JsonProperty]</c> renames keyed by the
+    /// child symbol id.
+    /// </summary>
+    /// <param name="owner">The owning type symbol.</param>
+    /// <param name="children">The owner's child symbols (already scoped to this owner by the caller via parent_id).</param>
+    /// <param name="annotations">Annotations on the children (e.g. <c>[JsonProperty]</c>); may be empty.</param>
+    public static FieldSet ExtractFields(
+        SymbolDetail owner,
+        IReadOnlyList<SymbolDetail> children,
+        IReadOnlyList<SymbolAnnotation> annotations)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(children);
+        ArgumentNullException.ThrowIfNull(annotations);
+
+        return IsRecord(owner.Kind)
+            ? new FieldSet(owner.Id, ParseRecordParams(owner.Signature))
+            : new FieldSet(owner.Id, FromChildren(children, annotations));
+    }
+
+    /// <summary>
+    /// Unwrap a return-type signature to the named user type it carries, peeling generic wrappers by balanced bracket
+    /// depth (so <c>Task&lt;ActionResult&lt;X&gt;&gt;</c> and <c>Task&lt;ActionResult&gt;</c> are told apart — one
+    /// token, not a substring). Returns null when the result is a bare wrapper (<c>ActionResult</c>/<c>IActionResult</c>),
+    /// a primitive (<c>Task&lt;bool&gt;</c>), or otherwise not a named user type (so the <c>responds→</c> edge is dropped).
+    /// </summary>
+    /// <param name="returnType">The signature return type, e.g. <c>Task&lt;ActionResult&lt;AppSetting&gt;&gt;</c>.</param>
+    public static string? UnwrapReturnType(string returnType)
+    {
+        ArgumentNullException.ThrowIfNull(returnType);
+
+        var current = returnType.Trim();
+        // Peel one wrapper layer at a time. Each layer is "Wrapper<inner>"; inner is taken by balanced brackets.
+        while (true)
+        {
+            int open = current.IndexOf('<');
+            if (open < 0)
+                break; // no generic args left
+
+            var head = current[..open].Trim();
+            if (!IsWrapper(head))
+                break; // a generic user type like Page<X> — head IS the named type; stop and evaluate it below
+
+            var inner = BalancedInner(current, open);
+            if (inner is null)
+                break;
+            current = inner.Trim();
+
+            // A multi-arg generic inner (e.g. Dictionary<K,V>) is not a single carried DTO — give up.
+            if (TopLevelCommaCount(current) > 0)
+                return null;
+        }
+
+        // Strip any remaining nullable marker.
+        current = current.TrimEnd('?').Trim();
+
+        if (current.Length == 0)
+            return null;
+        if (BareNonTypes.Contains(current))
+            return null;
+        if (Primitives.Contains(current))
+            return null;
+
+        return current;
+    }
+
+    private static bool IsRecord(string kind)
+        => kind.Contains("record", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsWrapper(string head)
+    {
+        foreach (var w in Wrappers)
+        {
+            if (string.Equals(head, w, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>Properties/fields from the owner's children, in declaration order, with any JsonProperty rename applied.</summary>
+    private static IReadOnlyList<FieldMember> FromChildren(
+        IReadOnlyList<SymbolDetail> children, IReadOnlyList<SymbolAnnotation> annotations)
+    {
+        var renames = JsonPropertyRenames(annotations);
+        var fields = new List<FieldMember>();
+        foreach (var child in children)
+        {
+            if (!IsFieldKind(child.Kind))
+                continue;
+
+            var name = renames.TryGetValue(child.Id, out var wire) ? wire : child.Name;
+            var type = TypeFromMemberSignature(child.Signature);
+            fields.Add(new FieldMember(name, type));
+        }
+        return fields;
+    }
+
+    private static bool IsFieldKind(string kind)
+        => kind.Equals("property", StringComparison.OrdinalIgnoreCase)
+        || kind.Equals("field", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The declared type of a member from a signature like <c>int Id</c>, <c>string Email { get; set; }</c>, or
+    /// <c>public required string Name</c>. The member name is the LAST top-level token (after dropping any accessor
+    /// block / expression body / initializer), and the type is everything before it with leading modifiers stripped.
+    /// Tokenizing from the end (rather than locating the member name by substring) avoids the false hit when the name
+    /// is a substring of its own type (e.g. <c>OrderRef Order</c>) and handles modifier-laden declarations.
+    /// </summary>
+    private static string TypeFromMemberSignature(string signature)
+    {
+        var sig = signature.Trim();
+        if (sig.Length == 0)
+            return string.Empty;
+
+        // Drop a property accessor block / expression body / field initializer / terminator, e.g.
+        // "string Email { get; set; }" -> "string Email", "int Id => _id;" -> "int Id", "string Tag = \"x\"" -> "string Tag".
+        int cut = FirstTopLevelTerminator(sig);
+        if (cut >= 0)
+            sig = sig[..cut].Trim();
+
+        // The member name is the last top-level token; the type is everything before it (leading modifiers removed).
+        int lastSpace = LastTopLevelSpace(sig);
+        if (lastSpace <= 0)
+            return string.Empty; // only a single token (the name, or empty) — no separable declared type
+
+        return StripLeadingWords(sig[..lastSpace].Trim(), MemberModifiers);
+    }
+
+    /// <summary>Map child symbol id → JSON wire name parsed from a <c>[JsonProperty("x")]</c> raw_text.</summary>
+    private static Dictionary<string, string> JsonPropertyRenames(IReadOnlyList<SymbolAnnotation> annotations)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var a in annotations)
+        {
+            if (!a.AnnotationKey.Equals("jsonproperty", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var name = FirstStringArg(a.RawText);
+            if (name is not null)
+                map[a.SymbolId] = name;
+        }
+        return map;
+    }
+
+    /// <summary>The first double-quoted string argument in a raw attribute text, or null.</summary>
+    private static string? FirstStringArg(string rawText)
+    {
+        int start = rawText.IndexOf('"');
+        if (start < 0)
+            return null;
+        int end = rawText.IndexOf('"', start + 1);
+        if (end <= start)
+            return null;
+        return rawText[(start + 1)..end];
+    }
+
+    /// <summary>Parse a record's positional params from its signature into ordered (name, type) fields.</summary>
+    private static IReadOnlyList<FieldMember> ParseRecordParams(string signature)
+    {
+        var open = signature.IndexOf('(');
+        if (open < 0)
+            return [];
+        var inner = BalancedInner(signature, open);
+        if (inner is null || inner.Trim().Length == 0)
+            return [];
+
+        var fields = new List<FieldMember>();
+        foreach (var param in SplitTopLevel(inner))
+        {
+            var member = ParseParam(param);
+            if (member is not null)
+                fields.Add(member);
+        }
+        return fields;
+    }
+
+    /// <summary>One record param "Type Name" (modifiers / default values tolerated) → a field, or null if malformed.</summary>
+    private static FieldMember? ParseParam(string param)
+    {
+        var p = param.Trim();
+        if (p.Length == 0)
+            return null;
+
+        // Drop a default value: "int Page = 1" -> "int Page".
+        int eq = TopLevelIndexOf(p, '=');
+        if (eq >= 0)
+            p = p[..eq].Trim();
+
+        // The name is the last top-level token; the type is everything before it.
+        int lastSpace = LastTopLevelSpace(p);
+        if (lastSpace <= 0)
+            return null;
+
+        var type = p[..lastSpace].Trim();
+        var name = p[(lastSpace + 1)..].Trim();
+
+        // Strip leading parameter modifiers from the type ("params string[]" / "in Foo").
+        type = StripLeadingModifiers(type);
+
+        if (type.Length == 0 || name.Length == 0)
+            return null;
+        return new FieldMember(name, type);
+    }
+
+    // Parameter modifiers that can precede a record positional param's type.
+    private static readonly string[] ParamModifiers = ["params", "in", "out", "ref", "this", "readonly"];
+
+    // Member modifiers that can precede a property/field's type in a signature.
+    private static readonly string[] MemberModifiers =
+    [
+        "public", "private", "protected", "internal", "static", "readonly", "required", "virtual",
+        "override", "abstract", "sealed", "new", "volatile", "const", "extern", "unsafe", "async",
+    ];
+
+    private static string StripLeadingModifiers(string type) => StripLeadingWords(type, ParamModifiers);
+
+    /// <summary>Strip any leading space-delimited word in <paramref name="words"/> from the front of <paramref name="s"/>.</summary>
+    private static string StripLeadingWords(string s, string[] words)
+    {
+        var t = s;
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var w in words)
+            {
+                if (t.StartsWith(w + " ", StringComparison.Ordinal))
+                {
+                    t = t[(w.Length + 1)..].TrimStart();
+                    changed = true;
+                }
+            }
+        }
+        return t;
+    }
+
+    // ---- balanced-bracket helpers (treat <...> and (...) by depth) ---------------------------------------------
+
+    /// <summary>The substring between the bracket at <paramref name="open"/> and its matching close, or null.</summary>
+    private static string? BalancedInner(string s, int open)
+    {
+        char openCh = s[open];
+        char closeCh = openCh switch { '<' => '>', '(' => ')', '[' => ']', '{' => '}', _ => '\0' };
+        if (closeCh == '\0')
+            return null;
+
+        int depth = 0;
+        for (int i = open; i < s.Length; i++)
+        {
+            if (s[i] == openCh)
+                depth++;
+            else if (s[i] == closeCh)
+            {
+                depth--;
+                if (depth == 0)
+                    return s[(open + 1)..i];
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Split a param list on top-level commas (ignoring commas nested in &lt;&gt;/()/[]).</summary>
+    private static IEnumerable<string> SplitTopLevel(string s)
+    {
+        var parts = new List<string>();
+        var sb = new StringBuilder();
+        int depth = 0;
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '<' or '(' or '[':
+                    depth++;
+                    sb.Append(ch);
+                    break;
+                case '>' or ')' or ']':
+                    depth--;
+                    sb.Append(ch);
+                    break;
+                case ',' when depth == 0:
+                    parts.Add(sb.ToString());
+                    sb.Clear();
+                    break;
+                default:
+                    sb.Append(ch);
+                    break;
+            }
+        }
+        if (sb.Length > 0)
+            parts.Add(sb.ToString());
+        return parts;
+    }
+
+    private static int TopLevelCommaCount(string s)
+    {
+        int depth = 0, count = 0;
+        foreach (var ch in s)
+        {
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if (ch == ',' && depth == 0)
+                count++;
+        }
+        return count;
+    }
+
+    private static int TopLevelIndexOf(string s, char target)
+    {
+        int depth = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if (ch == target && depth == 0)
+                return i;
+        }
+        return -1;
+    }
+
+    private static int LastTopLevelSpace(string s)
+    {
+        int depth = 0, last = -1;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if ((ch == ' ' || ch == '\t') && depth == 0)
+                last = i;
+        }
+        return last;
+    }
+
+    /// <summary>The index of the first top-level accessor/body/initializer terminator (<c>{</c>, <c>=</c>, or <c>;</c>), or -1.</summary>
+    private static int FirstTopLevelTerminator(string s)
+    {
+        int depth = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char ch = s[i];
+            if (ch is '<' or '(' or '[')
+                depth++;
+            else if (ch is '>' or ')' or ']')
+                depth--;
+            else if (depth == 0 && ch is '{' or '=' or ';')
+                return i;
+        }
+        return -1;
+    }
+}

--- a/src/Miller.Core/Resolver/FieldSetSimilarity.cs
+++ b/src/Miller.Core/Resolver/FieldSetSimilarity.cs
@@ -1,0 +1,74 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// Computes the field-set overlap the scorer's <see cref="FieldSetSignal"/> corroborator carries (design §5). A leg
+/// builds the signal from two <see cref="FieldSet"/>s; this helper produces the Jaccard ratio over field NAMES and the
+/// anchoring field count (the smaller shape's count — so a 1-field/generic shape can be refused as a corroborator). Pure
+/// and deterministic; case-insensitive on field names so a <c>userId</c>↔<c>UserId</c> rename still overlaps.
+/// </summary>
+public static class FieldSetSimilarity
+{
+    /// <summary>
+    /// Build a <see cref="FieldSetSignal"/> from two field-sets. <see cref="FieldSetSignal.Jaccard"/> is the field-NAME
+    /// Jaccard (|A∩B| / |A∪B|, distinct names, case-insensitive); <see cref="FieldSetSignal.FieldCount"/> is the MIN of
+    /// the two distinct-name counts — the value the §5 "1-field can't anchor" rule reads (the smaller shape is what is
+    /// being corroborated, so a 1-field side caps the anchor at 1). When both shapes are empty the Jaccard is 0.
+    /// </summary>
+    /// <param name="a">One field-set (order irrelevant — the comparison is set-based).</param>
+    /// <param name="b">The other field-set.</param>
+    /// <param name="evidence">Optional <c>file:line</c> evidence for the resulting signal.</param>
+    public static FieldSetSignal Compare(FieldSet a, FieldSet b, Evidence? evidence = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+
+        var namesA = ToNameSet(a);
+        var namesB = ToNameSet(b);
+
+        int fieldCount = Math.Min(namesA.Count, namesB.Count);
+        double jaccard = Jaccard(namesA, namesB);
+
+        return new FieldSetSignal(fieldCount, jaccard, evidence);
+    }
+
+    /// <summary>The field-NAME Jaccard of two field-sets in [0,1]; 0 when their union is empty.</summary>
+    /// <param name="a">One field-set.</param>
+    /// <param name="b">The other field-set.</param>
+    /// <exception cref="ArgumentNullException">Either argument is null.</exception>
+    public static double Jaccard(FieldSet a, FieldSet b)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+        return Jaccard(ToNameSet(a), ToNameSet(b));
+    }
+
+    private static double Jaccard(HashSet<string> a, HashSet<string> b)
+    {
+        if (a.Count == 0 && b.Count == 0)
+            return 0.0;
+
+        int intersection = 0;
+        foreach (var name in a)
+        {
+            if (b.Contains(name))
+                intersection++;
+        }
+
+        int union = a.Count + b.Count - intersection;
+        return union == 0 ? 0.0 : (double)intersection / union;
+    }
+
+    /// <summary>The distinct (case-insensitive) field names of a field-set.</summary>
+    private static HashSet<string> ToNameSet(FieldSet fieldSet)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var field in fieldSet.Fields)
+        {
+            if (!string.IsNullOrWhiteSpace(field.Name))
+                set.Add(field.Name);
+        }
+        return set;
+    }
+}

--- a/src/Miller.Core/Resolver/NameNormalizer.cs
+++ b/src/Miller.Core/Resolver/NameNormalizer.cs
@@ -1,0 +1,109 @@
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// Folds a type name to a canonical, lowercased <b>stem</b> so an entity and its DTO/interface/plural collapse to the
+/// same key — the "safe finisher" of the cross-language resolver (design §4). It is NEVER the sole signal for an
+/// entity↔DTO or entity↔table edge; it only confirms a pairing a structural breadcrumb already proposed.
+///
+/// <para>The fold, in order: strip an interface/field affix prefix (<c>I</c> before a CamelCase word, or a leading
+/// <c>_</c>); strip ONE trailing role suffix (<c>Dto</c>/<c>Model</c>/<c>Request</c>/<c>Response</c>/<c>View</c>/
+/// <c>VM</c>/<c>Entity</c>) as a whole trailing token; fold plural→singular; lowercase. Each step is applied on the
+/// already-reduced string so combined cases (e.g. <c>IUserDto</c>, <c>IUsers</c>) reduce fully. Pure and
+/// deterministic.</para>
+/// </summary>
+public static class NameNormalizer
+{
+    // Trailing role suffixes, longest-first so "VM" never pre-empts a longer match and a whole token is removed.
+    // Compared case-insensitively but only stripped when they form the tail of the (still PascalCase) name.
+    private static readonly string[] Suffixes =
+    [
+        "Response", "Request", "Entity", "Model", "View", "Dto", "VM",
+    ];
+
+    /// <summary>
+    /// Reduce <paramref name="name"/> to its canonical stem. Blank/whitespace input yields <see cref="string.Empty"/>.
+    /// </summary>
+    /// <param name="name">The type name as written (e.g. <c>IUserDto</c>, <c>Categories</c>).</param>
+    /// <returns>The lowercased canonical stem (e.g. <c>user</c>, <c>category</c>).</returns>
+    public static string Stem(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var s = name.Trim();
+        if (s.Length == 0)
+            return string.Empty;
+
+        s = StripPrefix(s);
+        s = StripSuffix(s);
+        s = Singularize(s);
+        return s.ToLowerInvariant();
+    }
+
+    /// <summary>Strip a leading <c>_</c>, or a leading <c>I</c> that prefixes a CamelCase word (interface convention).</summary>
+    private static string StripPrefix(string s)
+    {
+        if (s.StartsWith('_'))
+            return s.TrimStart('_');
+
+        // "IUser"/"IUsers": leading 'I' followed by an uppercase letter => interface prefix. "Identity" keeps its 'I'
+        // (followed by a lowercase letter), and a bare "I" is left alone.
+        if (s.Length >= 2 && s[0] == 'I' && char.IsUpper(s[1]))
+            return s[1..];
+
+        return s;
+    }
+
+    /// <summary>Strip ONE trailing role suffix when it forms the tail token of the name (longest match wins).</summary>
+    private static string StripSuffix(string s)
+    {
+        foreach (var suffix in Suffixes)
+        {
+            if (s.Length <= suffix.Length)
+                continue;
+            if (!s.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Only a whole trailing token: the char before the suffix must be a boundary (uppercase start of the
+            // suffix region). This stops "Modeller" losing "Model" (next char 'l' is lowercase => not a token tail).
+            int tailStart = s.Length - suffix.Length;
+            if (char.IsUpper(s[tailStart]))
+                return s[..tailStart];
+        }
+        return s;
+    }
+
+    /// <summary>
+    /// Fold a likely English plural to its singular: <c>ies→y</c>; <c>(x|s|z|ch|sh)es→drop es</c>; trailing
+    /// <c>s</c>→drop (but not <c>ss</c>). Conservative: leaves a word it cannot confidently singularize unchanged.
+    /// </summary>
+    private static string Singularize(string s)
+    {
+        if (s.Length <= 1)
+            return s;
+
+        // "Categories" -> "Category"
+        if (s.EndsWith("ies", StringComparison.OrdinalIgnoreCase) && s.Length > 3)
+            return s[..^3] + "y";
+
+        // "Boxes"/"Buses"/"Quizzes"/"Matches"/"Dishes" -> drop "es"
+        if (s.EndsWith("es", StringComparison.OrdinalIgnoreCase) && s.Length > 2)
+        {
+            var stem = s[..^2];
+            char last = char.ToLowerInvariant(stem[^1]);
+            if (last is 'x' or 's' or 'z')
+                return stem;
+            if (stem.Length >= 2)
+            {
+                var lastTwo = stem[^2..].ToLowerInvariant();
+                if (lastTwo is "ch" or "sh")
+                    return stem;
+            }
+        }
+
+        // Plain trailing "s" (but not "ss" like "Address", and not a single-letter result).
+        if (s.EndsWith('s') && !s.EndsWith("ss", StringComparison.OrdinalIgnoreCase) && s.Length > 1)
+            return s[..^1];
+
+        return s;
+    }
+}

--- a/src/Miller.Core/Resolver/RouteBridge.cs
+++ b/src/Miller.Core/Resolver/RouteBridge.cs
@@ -1,0 +1,344 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// A TS/JS client HTTP call, already located by the graph builder (design §4 Leg 1; findings 28-2). The verified
+/// <c>literals</c> row carries the route text, the kind, the verbatim <c>carrier</c>, the language, the
+/// <c>containing_symbol_id</c> and a byte span — but NO file/line columns and no <c>identifier_id</c>. The graph
+/// builder (plan Task 8) is what selects the <c>kind=url</c> literals, resolves each one's use-site file:line for
+/// evidence, and reads the containing TS function's <c>test_role</c>; this record is the already-located input the
+/// pure leg consumes.
+///
+/// <para><b>The leg filters this to a real client call</b> (design §4 Leg 1): the literal must be <c>kind=url</c>,
+/// its <see cref="LiteralRecord.Language"/> must be a frontend/client language (NOT the endpoint language —
+/// julie stores FULL strings like <c>typescript</c>, so a short-code filter matches 0 rows), and its containing
+/// symbol must NOT be a <c>test_role</c> HttpClient call (on real data the 57 <c>csharp</c> url literals are all test
+/// HttpClient; only the 39 <c>typescript</c> ones are real calls). The verb is then derived from the carrier by
+/// <see cref="RouteNormalizer.FromClientCall"/> — verb-known for <c>axios.&lt;verb&gt;</c>/<c>&lt;Verb&gt;Async</c>,
+/// verb-unknown for <c>fetch</c>/<c>$fetch</c>/bare <c>axios</c>/etc. (never assumed GET).</para>
+/// </summary>
+/// <param name="Literal">
+/// The url literal: <see cref="LiteralRecord.LiteralText"/> is the route ({}-folded), <see cref="LiteralRecord.Carrier"/>
+/// is the verb source, <see cref="LiteralRecord.Language"/> drives the frontend-language filter.
+/// </param>
+/// <param name="TestRole">
+/// The containing TS function's <c>test_role</c> (from <c>symbols.metadata</c>), or null for production code. A present
+/// (test) role excludes the literal from the route bridge — it is a test HttpClient call, not a real client call.
+/// </param>
+/// <param name="FilePath">The call's use-site file (workspace-relative), for the edge evidence.</param>
+/// <param name="Line">The 1-based use-site line, for the edge evidence (file:line).</param>
+public sealed record TsClientCall(
+    LiteralRecord Literal,
+    TestRole? TestRole,
+    string FilePath,
+    int Line);
+
+/// <summary>
+/// A C# controller action endpoint, already reduced from julie's <c>symbol_annotations</c> + the parent class
+/// <c>[Route]</c> + the method <c>signature</c> (design §4 Leg 1; findings 28-2). The verb comes from the lowercased
+/// annotation key (<c>httpget</c>/<c>httppost</c>/…), the route arg from the annotation <c>raw_text</c>, and the
+/// <c>[controller]</c>/<c>[action]</c>/<c>[area]</c> tokens are expanded by <see cref="RouteNormalizer.FromEndpoint"/>
+/// using <see cref="ParentClassName"/>/<see cref="MethodName"/> BEFORE the class prefix is concatenated — the
+/// load-bearing token expansion (design §8 risk 3); without it every endpoint normalizes to <c>api/[controller]/…</c>
+/// and matches zero client routes, and a wrong expansion collides two controllers' <c>{id}</c> templates.
+///
+/// <para>The annotation-arg parsing (route out of <c>HttpGet("{id}")</c>), the <c>parent_id</c>→class join (71/71 on
+/// real data) for the class <c>[Route]</c> and the parent class name, and the <c>[FromBody]</c>/parameter-type read out
+/// of the method <c>signature</c> are the graph builder's job — plan Task 8, out of this leg's scope. This is the
+/// already-reduced input the pure leg consumes.</para>
+/// </summary>
+/// <param name="SymbolId">The endpoint method symbol's id (the resolved <c>—hits→</c> target).</param>
+/// <param name="VerbKey">The lowercased annotation key (<c>httpget</c>/<c>httppost</c>/…); the verb is read from it.</param>
+/// <param name="ClassRoute">The class <c>[Route(...)]</c> arg (e.g. <c>api/[controller]</c>), or null when absent.</param>
+/// <param name="MethodRoute">The method route arg (e.g. <c>{id}</c>), or null when the method declares none.</param>
+/// <param name="ParentClassName">The controller class name (e.g. <c>AppSettingsController</c>) — expands <c>[controller]</c>.</param>
+/// <param name="MethodName">The action method name (e.g. <c>GetById</c>) — expands <c>[action]</c> and is the endpoint display.</param>
+/// <param name="ReturnType">
+/// The method <c>signature</c> return type (e.g. <c>Task&lt;ActionResult&lt;AppSetting&gt;&gt;</c>); unwrapped by
+/// <see cref="FieldSetExtractor.UnwrapReturnType"/> to the response DTO for the <c>responds→</c> edge. May be empty.
+/// </param>
+/// <param name="RequestBodyType">
+/// The <c>[FromBody]</c>/request parameter type from the method <c>signature</c> (e.g. <c>CreateAppSettingRequest</c>)
+/// for the <c>consumes→</c> edge, or null when the method takes no request body.
+/// </param>
+/// <param name="FilePath">The endpoint's file (workspace-relative), for the edge evidence.</param>
+/// <param name="Line">The 1-based line of the endpoint declaration, for the edge evidence (file:line).</param>
+public sealed record ControllerEndpoint(
+    string SymbolId,
+    string VerbKey,
+    string? ClassRoute,
+    string? MethodRoute,
+    string ParentClassName,
+    string MethodName,
+    string ReturnType,
+    string? RequestBodyType,
+    string FilePath,
+    int Line);
+
+/// <summary>
+/// The in-memory contract collections <see cref="RouteBridge"/> consumes (design §4 Leg 1; plan Task 7). Pure value
+/// input — no DB, no I/O. The DB loader (plan Task 9) / graph builder (Task 8) builds these from julie rows; the leg
+/// never reads SQLite.
+/// </summary>
+/// <param name="ClientCalls">
+/// The TS/JS client HTTP calls (url literals already located by the builder): each that survives the frontend-language
+/// + non-test filter and matches an endpoint's (verb, route) yields a <see cref="BridgeKind.Hits"/> edge.
+/// </param>
+/// <param name="Endpoints">
+/// The C# controller endpoints: each yields a <see cref="BridgeKind.Hits"/> edge per matching client, plus a
+/// <see cref="BridgeKind.Responds"/> edge when its return type unwraps to a named DTO and a
+/// <see cref="BridgeKind.Consumes"/> edge when it declares a request body type.
+/// </param>
+public sealed record RouteBridgeInput(
+    IReadOnlyList<TsClientCall> ClientCalls,
+    IReadOnlyList<ControllerEndpoint> Endpoints);
+
+/// <summary>
+/// Leg 1 of the cross-language resolver (design §4): builds candidate edges linking a TS client HTTP call to the C#
+/// controller endpoint it hits (<see cref="BridgeKind.Hits"/>), and linking that endpoint to its response DTO
+/// (<see cref="BridgeKind.Responds"/>) and request DTO (<see cref="BridgeKind.Consumes"/>). PURE Miller.Core — it
+/// operates over the in-memory <see cref="RouteBridgeInput"/>, normalizes routes via <see cref="RouteNormalizer"/>,
+/// resolves DTO/endpoint names via <see cref="SymbolResolver"/>, unwraps return types via
+/// <see cref="FieldSetExtractor.UnwrapReturnType"/>, and emits typed <see cref="CandidateEdge"/>s. It NEVER scores,
+/// bands, or re-implements confidence logic; every signal it emits is decidable by <see cref="BridgeScorer"/> from the
+/// candidate payload alone (the trust contract, design §5).
+///
+/// <para><b>Hits (TS call ⇄ endpoint).</b> Both sides are normalized with <see cref="RouteNormalizer"/> — the client
+/// side via <see cref="RouteNormalizer.FromClientCall"/> (verb from the carrier, or verb-unknown), the endpoint side
+/// via <see cref="RouteNormalizer.FromEndpoint"/> (which expands <c>[controller]</c>/<c>[action]</c>/<c>[area]</c> using
+/// the parent class + method name BEFORE prefix concat). When the canonical routes are equal:
+/// <list type="bullet">
+/// <item>verb KNOWN on the client AND the verbs match ⇒ <see cref="SignalRule.RouteVerbMatch"/> (High-eligible);</item>
+/// <item>verb UNKNOWN on the client (fetch/$fetch/bare axios/etc.) ⇒ <see cref="SignalRule.RouteOnlyMatch"/> on route
+///   alone (Medium, never High; the scorer sets <c>IsVerbUnknown</c>). The verb is NEVER assumed GET;</item>
+/// <item>verb KNOWN on both but the verbs differ ⇒ NO edge (a real verb distinction, not a route-only fallback).</item>
+/// </list>
+/// The endpoint is a resolved symbol, so its <see cref="EdgeRef"/> is trivially <see cref="ResolutionStatus.Resolved"/>;
+/// the client side is a route node (no symbol), likewise trivially resolved. The collision guard (design §8 risk 3) is
+/// inherited from <see cref="RouteNormalizer"/>: two controllers' <c>{id}</c> templates normalize to distinct routes, so
+/// a client matches only its own controller — no false merge.</para>
+///
+/// <para><b>Responds (endpoint ⇄ response DTO) — PARTIAL.</b> The endpoint return type is unwrapped by balanced bracket
+/// depth (<see cref="FieldSetExtractor.UnwrapReturnType"/>) to a named user type (class/interface/record, incl. a
+/// collection element like <c>IProject</c>). A bare <c>ActionResult</c>/<c>IActionResult</c> or a primitive
+/// (<c>Task&lt;bool&gt;</c>) unwraps to null ⇒ NO Responds edge (and no penalty to the Hits match). When a name is
+/// recovered it is resolved by <see cref="SymbolResolver"/> and emitted as <see cref="SignalRule.ReturnTypeDto"/>.</para>
+///
+/// <para><b>Consumes (endpoint ⇄ request DTO).</b> The method's <c>[FromBody]</c>/request parameter type, when present,
+/// is resolved by name and emitted as <see cref="SignalRule.FromBodyDto"/>. No request type ⇒ no Consumes edge.</para>
+///
+/// <para>The responds/consumes edges describe the endpoint's shape and do NOT depend on any client matching it — an
+/// endpoint with no caller still yields them. An unresolved/ambiguous DTO name is reflected in the candidate's
+/// <see cref="EdgeRef.Resolution"/> + a <see cref="NameResolutionSignal"/> so the scorer (not the leg) applies the §5
+/// drop/cap rules.</para>
+/// </summary>
+public static class RouteBridge
+{
+    /// <summary>
+    /// Build the route-bridge candidate edges from <paramref name="input"/>, normalizing routes and resolving DTO names
+    /// through <paramref name="resolver"/>. Returns one <see cref="BridgeKind.Hits"/> edge per matching
+    /// (client, endpoint) pair, one <see cref="BridgeKind.Responds"/> edge per endpoint whose return type unwraps to a
+    /// named DTO, and one <see cref="BridgeKind.Consumes"/> edge per endpoint that declares a request body type. The leg
+    /// does NOT score; it never returns a band.
+    /// </summary>
+    /// <param name="input">The in-memory client calls + controller endpoints.</param>
+    /// <param name="resolver">The name resolver over the workspace's symbols.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="resolver"/> is null.</exception>
+    public static IReadOnlyList<CandidateEdge> Resolve(RouteBridgeInput input, SymbolResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        var edges = new List<CandidateEdge>();
+
+        // Normalize every real client call once (filter to frontend-language + non-test url literals first).
+        var normalizedCalls = new List<(TsClientCall Call, NormalizedRoute Route)>();
+        foreach (var call in input.ClientCalls)
+        {
+            if (!IsRealClientCall(call))
+                continue;
+            var route = RouteNormalizer.FromClientCall(call.Literal.Carrier, call.Literal.LiteralText);
+            normalizedCalls.Add((call, route));
+        }
+
+        foreach (var endpoint in input.Endpoints)
+        {
+            var endpointRoute = RouteNormalizer.FromEndpoint(
+                endpoint.VerbKey,
+                endpoint.ClassRoute,
+                endpoint.MethodRoute,
+                endpoint.ParentClassName,
+                endpoint.MethodName);
+
+            // Hits: each client whose normalized (verb, route) matches this endpoint.
+            foreach (var (call, callRoute) in normalizedCalls)
+            {
+                var hits = TryBuildHitsEdge(call, callRoute, endpoint, endpointRoute);
+                if (hits is not null)
+                    edges.Add(hits);
+            }
+
+            // Responds: the unwrapped return DTO (endpoint shape — independent of any client).
+            var responds = TryBuildRespondsEdge(endpoint, resolver);
+            if (responds is not null)
+                edges.Add(responds);
+
+            // Consumes: the request body DTO (endpoint shape — independent of any client).
+            var consumes = TryBuildConsumesEdge(endpoint, resolver);
+            if (consumes is not null)
+                edges.Add(consumes);
+        }
+
+        return edges;
+    }
+
+    /// <summary>
+    /// A real client call is a <c>kind=url</c> literal in a frontend/client language (NOT the C# endpoint language) and
+    /// NOT a <c>test_role</c> HttpClient call (design §4 Leg 1; findings 28-2). The language-agnostic phrasing of the
+    /// design's filter ("literal.language != the endpoint language") is implemented as "not the C# endpoint language":
+    /// the route bridge's endpoints are C#, so a <c>csharp</c> url literal is a test HttpClient call, never a client call.
+    /// </summary>
+    private static bool IsRealClientCall(TsClientCall call)
+    {
+        if (!string.Equals(call.Literal.Kind, "url", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (call.TestRole is { IsTest: true })
+            return false;
+        // The endpoint side is C#; a url literal in the endpoint language is a (test) HttpClient call, not a client call.
+        if (string.Equals(call.Literal.Language, "csharp", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Build a <see cref="BridgeKind.Hits"/> edge when the client and endpoint canonical routes are equal, or null when
+    /// they differ or a known client verb mismatches the endpoint verb. A verb-known match emits
+    /// <see cref="SignalRule.RouteVerbMatch"/>; a verb-unknown client matches on route alone and emits
+    /// <see cref="SignalRule.RouteOnlyMatch"/> (the verb is never assumed GET).
+    /// </summary>
+    private static CandidateEdge? TryBuildHitsEdge(
+        TsClientCall call, NormalizedRoute callRoute, ControllerEndpoint endpoint, NormalizedRoute endpointRoute)
+    {
+        if (!string.Equals(callRoute.Route, endpointRoute.Route, StringComparison.Ordinal))
+            return null;
+
+        SignalRule rule;
+        if (callRoute.VerbKnown)
+        {
+            // Verb known on the client: it must match the endpoint verb (and the endpoint verb must itself be known).
+            if (!endpointRoute.VerbKnown ||
+                !string.Equals(callRoute.Verb, endpointRoute.Verb, StringComparison.Ordinal))
+                return null;
+            rule = SignalRule.RouteVerbMatch;
+        }
+        else
+        {
+            // Verb unknown on the client: match on route alone (Medium, never High; never assumed GET).
+            rule = SignalRule.RouteOnlyMatch;
+        }
+
+        var callEvidence = new Evidence(call.FilePath, call.Line);
+        var endpointEvidence = new Evidence(endpoint.FilePath, endpoint.Line);
+
+        // The client side is a route node (no symbol); the endpoint side is the resolved method symbol. Both refs are
+        // trivially Resolved so the scorer's name gates do not fire on the route bridge's structural endpoints.
+        var clientRef = RouteNode(callRoute.Route, call.FilePath);
+        var endpointRef = new EdgeRef(
+            Display: endpointRoute.Route,
+            SymbolId: endpoint.SymbolId,
+            FilePath: endpoint.FilePath,
+            Resolution: new NameResolution(ResolutionStatus.Resolved, endpoint.SymbolId, 1));
+
+        var signals = new List<Signal>
+        {
+            new StructuralSignal(rule, Present: true, endpointEvidence),
+        };
+
+        return new CandidateEdge(
+            BridgeKind.Hits,
+            clientRef,
+            endpointRef,
+            [callEvidence, endpointEvidence],
+            signals);
+    }
+
+    /// <summary>
+    /// Build a <see cref="BridgeKind.Responds"/> edge when the endpoint return type unwraps (balanced bracket depth) to
+    /// a named user DTO, or null when it unwraps to a bare wrapper / primitive (no edge, no penalty). The recovered name
+    /// is resolved by <paramref name="resolver"/>; an unresolved/ambiguous name rides in the candidate for the scorer.
+    /// </summary>
+    private static CandidateEdge? TryBuildRespondsEdge(ControllerEndpoint endpoint, SymbolResolver resolver)
+    {
+        var dtoName = FieldSetExtractor.UnwrapReturnType(endpoint.ReturnType);
+        if (dtoName is null)
+            return null;
+
+        return BuildEndpointToDtoEdge(
+            BridgeKind.Responds, SignalRule.ReturnTypeDto, endpoint, dtoName, resolver);
+    }
+
+    /// <summary>
+    /// Build a <see cref="BridgeKind.Consumes"/> edge from the endpoint's <c>[FromBody]</c>/request parameter type, or
+    /// null when the endpoint declares no request body. The type is resolved by <paramref name="resolver"/>; an
+    /// unresolved/ambiguous name rides in the candidate for the scorer.
+    /// </summary>
+    private static CandidateEdge? TryBuildConsumesEdge(ControllerEndpoint endpoint, SymbolResolver resolver)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint.RequestBodyType))
+            return null;
+
+        return BuildEndpointToDtoEdge(
+            BridgeKind.Consumes, SignalRule.FromBodyDto, endpoint, endpoint.RequestBodyType, resolver);
+    }
+
+    /// <summary>
+    /// Build an endpoint→DTO edge (the shared shape of the responds/consumes edges): the endpoint is the resolved
+    /// source symbol; the DTO name is resolved by name into the target ref. Emits the structural breadcrumb
+    /// <paramref name="rule"/> plus the per-side <see cref="NameResolutionSignal"/> for the DTO so the scorer applies
+    /// the §5 unresolved/ambiguous rules from the payload alone.
+    /// </summary>
+    private static CandidateEdge BuildEndpointToDtoEdge(
+        BridgeKind kind, SignalRule rule, ControllerEndpoint endpoint, string dtoName, SymbolResolver resolver)
+    {
+        var evidence = new Evidence(endpoint.FilePath, endpoint.Line);
+
+        var endpointRef = new EdgeRef(
+            Display: endpoint.MethodName,
+            SymbolId: endpoint.SymbolId,
+            FilePath: endpoint.FilePath,
+            Resolution: new NameResolution(ResolutionStatus.Resolved, endpoint.SymbolId, 1));
+
+        var dtoResolution = resolver.Resolve(dtoName, preferFile: endpoint.FilePath);
+        var dtoRef = new EdgeRef(
+            Display: LeafName(dtoName),
+            SymbolId: dtoResolution.SymbolId,
+            FilePath: dtoResolution.SymbolId is not null ? endpoint.FilePath : null,
+            Resolution: dtoResolution);
+
+        var signals = new List<Signal>
+        {
+            new StructuralSignal(rule, Present: true, evidence),
+            new NameResolutionSignal(EndpointSide.Target, dtoResolution.Status, dtoResolution.MatchCount, evidence),
+        };
+
+        return new CandidateEdge(kind, endpointRef, dtoRef, [evidence], signals);
+    }
+
+    /// <summary>
+    /// A route endpoint of a Hits edge: a normalized route string, not a code symbol, so the ref is trivially
+    /// <see cref="ResolutionStatus.Resolved"/> with no symbol id (the route bridge's name gates are about the DTO
+    /// targets, not the route nodes).
+    /// </summary>
+    private static EdgeRef RouteNode(string route, string filePath) =>
+        new(route, SymbolId: null, FilePath: filePath, new NameResolution(ResolutionStatus.Resolved, null, 1));
+
+    /// <summary>The leaf (simple) name of a possibly-qualified type name (<c>Api.Dtos.AppSetting</c> → <c>AppSetting</c>).</summary>
+    private static string LeafName(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+            return typeName;
+        int dot = typeName.LastIndexOf('.');
+        return (dot >= 0 && dot < typeName.Length - 1) ? typeName[(dot + 1)..] : typeName;
+    }
+}

--- a/src/Miller.Core/Resolver/RouteNormalizer.cs
+++ b/src/Miller.Core/Resolver/RouteNormalizer.cs
@@ -1,0 +1,190 @@
+using System.Text.RegularExpressions;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// The normalized form of one HTTP call/endpoint route: a canonical route plus the HTTP verb when it is known. The
+/// route bridge matches a TS client call to a C# endpoint by comparing <see cref="Verb"/> + <see cref="Route"/>; a
+/// verb-unknown client call (<see cref="VerbKnown"/> false) matches on <see cref="Route"/> alone at reduced
+/// confidence — it is NEVER silently assumed to be GET.
+/// </summary>
+/// <param name="Verb">The canonical upper-case HTTP verb (e.g. <c>GET</c>), or null when the verb is unknown.</param>
+/// <param name="Route">The canonical route: lowercased, params folded to <c>{}</c>, no leading/trailing slash, no query.</param>
+/// <param name="VerbKnown">True when <see cref="Verb"/> was derivable; false for a verb-less carrier (route-only match).</param>
+public sealed record NormalizedRoute(string? Verb, string Route, bool VerbKnown);
+
+/// <summary>
+/// Canonicalizes HTTP routes on both sides of the call bridge (design §4 Leg 1). Two entry points:
+/// <see cref="FromClientCall"/> (TS/JS: verb from the carrier tail, or verb-unknown) and <see cref="FromEndpoint"/>
+/// (C#: ASP.NET <c>[controller]</c>/<c>[action]</c>/<c>[area]</c> token expansion BEFORE prefix concatenation, then
+/// the same canonicalization). Pure and deterministic.
+///
+/// <para><b>Token expansion is on the critical path</b> (design §8 risk 3): 21/23 MyraNext controllers declare
+/// <c>Route("api/[controller]")</c> literally. Without expansion every endpoint normalizes to <c>api/[controller]/…</c>
+/// and matches zero client routes; expanding it WRONG (dropping the controller segment) collides two controllers'
+/// <c>{id}</c> templates into one route. So <see cref="FromEndpoint"/> takes the parent class name and substitutes
+/// <c>[controller]</c> → class name minus trailing "Controller" (lowercased) before concatenating.</para>
+/// </summary>
+public static class RouteNormalizer
+{
+    // HTTP verbs we recognize as a carrier tail token or an annotation_key suffix.
+    private static readonly string[] HttpVerbs =
+    [
+        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
+    ];
+
+    // ${param} | {param} | :param  ->  {}. Compiled once; each alternative consumes one path segment placeholder.
+    // The :param alternative is bounded to an identifier run (not "everything up to the next /") so a trailing literal
+    // extension/suffix is preserved — "/files/:id.json" folds to "files/{}.json", matching the C# "{id}.json" side,
+    // which stops folding at the '}'. The over-broad ":[^/]+" form folded the extension away on only the client side.
+    private static readonly Regex ParamPattern = new(
+        @"\$\{[^}]*\}|\{[^}]*\}|:[A-Za-z_][A-Za-z0-9_]*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Normalize a TS/JS client HTTP call. The verb is read from <paramref name="carrier"/> ONLY when its tail token
+    /// is an HTTP verb (<c>axios.post</c> → POST) or a <c>&lt;Verb&gt;Async</c> method (<c>PostAsync</c> → POST).
+    /// Verb-less carriers (<c>fetch</c>, <c>$fetch</c>, <c>ofetch</c>, bare <c>axios</c>, <c>request</c>, <c>ky</c>,
+    /// <c>got</c>, <c>sendasync</c>) yield a verb-unknown result — never an assumed GET.
+    /// </summary>
+    /// <param name="carrier">The verbatim callee (<c>literals.carrier</c>), e.g. <c>axios.post</c> or <c>fetch</c>.</param>
+    /// <param name="literalText">The route literal (<c>literals.literal_text</c>), already interpolation-folded by julie.</param>
+    public static NormalizedRoute FromClientCall(string carrier, string literalText)
+    {
+        ArgumentNullException.ThrowIfNull(carrier);
+        ArgumentNullException.ThrowIfNull(literalText);
+
+        var verb = VerbFromCarrier(carrier);
+        var route = Canonicalize(literalText);
+        return new NormalizedRoute(verb, route, verb is not null);
+    }
+
+    /// <summary>
+    /// Normalize a C# controller endpoint. Expands ASP.NET route tokens using the controller's identity BEFORE
+    /// concatenating the class prefix with the method route, then canonicalizes. An absolute method route (leading
+    /// <c>/</c>) overrides the class prefix.
+    /// </summary>
+    /// <param name="verbKey">The lowercased annotation key (<c>httpget</c>/<c>httppost</c>/…); the verb suffix is read from it.</param>
+    /// <param name="classRoute">The class <c>[Route(...)]</c> argument (may be null/empty), e.g. <c>api/[controller]</c>.</param>
+    /// <param name="methodRoute">The method route arg (e.g. <c>{id}</c>), null/empty when the method has none.</param>
+    /// <param name="parentClassName">The controller class name (e.g. <c>AppSettingsController</c>) — expands <c>[controller]</c>.</param>
+    /// <param name="methodName">The action method name (e.g. <c>GetById</c>) — expands <c>[action]</c>.</param>
+    /// <param name="area">The MVC area name when present — expands <c>[area]</c>; defaults to empty.</param>
+    public static NormalizedRoute FromEndpoint(
+        string verbKey,
+        string? classRoute,
+        string? methodRoute,
+        string parentClassName,
+        string methodName,
+        string area = "")
+    {
+        ArgumentNullException.ThrowIfNull(verbKey);
+        ArgumentNullException.ThrowIfNull(parentClassName);
+        ArgumentNullException.ThrowIfNull(methodName);
+
+        var verb = VerbFromAnnotationKey(verbKey);
+
+        var controllerToken = ControllerToken(parentClassName);
+        var actionToken = methodName.ToLowerInvariant();
+        var areaToken = area.ToLowerInvariant();
+
+        string ExpandTokens(string route) => route
+            .Replace("[controller]", controllerToken, StringComparison.OrdinalIgnoreCase)
+            .Replace("[action]", actionToken, StringComparison.OrdinalIgnoreCase)
+            .Replace("[area]", areaToken, StringComparison.OrdinalIgnoreCase);
+
+        var method = methodRoute ?? string.Empty;
+
+        // Absolute override: a method route starting with '/' ignores the class prefix entirely.
+        string combined;
+        if (method.StartsWith('/'))
+        {
+            combined = ExpandTokens(method);
+        }
+        else
+        {
+            var prefix = ExpandTokens(classRoute ?? string.Empty);
+            var tail = ExpandTokens(method);
+            combined = Join(prefix, tail);
+        }
+
+        return new NormalizedRoute(verb, Canonicalize(combined), verb is not null);
+    }
+
+    /// <summary>Map an annotation key like <c>httpget</c> to <c>GET</c>, or null when it carries no verb.</summary>
+    private static string? VerbFromAnnotationKey(string verbKey)
+    {
+        var lower = verbKey.ToLowerInvariant();
+        foreach (var verb in HttpVerbs)
+        {
+            // "httpget" ends with "get"; a bare "get" matches too.
+            if (lower.EndsWith(verb, StringComparison.OrdinalIgnoreCase))
+                return verb;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Read the verb from a client carrier's tail token: the segment after the last '.' (axios.post → post) with a
+    /// trailing "Async" trimmed (PostAsync → post). Returns the canonical verb, or null when the tail is not a verb.
+    /// </summary>
+    private static string? VerbFromCarrier(string carrier)
+    {
+        var tail = carrier;
+        int dot = tail.LastIndexOf('.');
+        if (dot >= 0 && dot < tail.Length - 1)
+            tail = tail[(dot + 1)..];
+
+        if (tail.EndsWith("Async", StringComparison.OrdinalIgnoreCase) && tail.Length > "Async".Length)
+            tail = tail[..^"Async".Length];
+
+        foreach (var verb in HttpVerbs)
+        {
+            if (string.Equals(tail, verb, StringComparison.OrdinalIgnoreCase))
+                return verb;
+        }
+        return null;
+    }
+
+    /// <summary>The <c>[controller]</c> expansion: the class name minus a trailing "Controller", lowercased.</summary>
+    private static string ControllerToken(string parentClassName)
+    {
+        var name = parentClassName;
+        const string suffix = "Controller";
+        if (name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) && name.Length > suffix.Length)
+            name = name[..^suffix.Length];
+        return name.ToLowerInvariant();
+    }
+
+    /// <summary>Join a prefix and tail with exactly one '/', tolerating either side being empty or slash-padded.</summary>
+    private static string Join(string prefix, string tail)
+    {
+        var p = prefix.Trim('/');
+        var t = tail.Trim('/');
+        if (p.Length == 0)
+            return t;
+        if (t.Length == 0)
+            return p;
+        return p + "/" + t;
+    }
+
+    /// <summary>
+    /// The shared canonicalization: strip a query string, fold <c>${p}</c>/<c>{p}</c>/<c>:p</c> params to <c>{}</c>,
+    /// lowercase, and trim leading/trailing slashes. Order matters — params are folded before slash trimming so a
+    /// route that is only a param is preserved.
+    /// </summary>
+    private static string Canonicalize(string route)
+    {
+        var s = route.Trim();
+
+        // Strip query (and any fragment) — everything from the first '?' or '#'.
+        int cut = s.IndexOfAny(['?', '#']);
+        if (cut >= 0)
+            s = s[..cut];
+
+        s = ParamPattern.Replace(s, "{}");
+        s = s.ToLowerInvariant();
+        s = s.Trim('/');
+        return s;
+    }
+}

--- a/src/Miller.Core/Resolver/Signal.cs
+++ b/src/Miller.Core/Resolver/Signal.cs
@@ -1,0 +1,128 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>
+/// The closed set of scoring rules a candidate edge can carry, defined HERE (plan Task 4) BEFORE any leg emits so every
+/// design §5 band/invariant is decidable by the <see cref="BridgeScorer"/> from the candidate payload alone — no
+/// leg-side precision logic, no Task-5 retrofit. Each rule maps to a concrete <see cref="Signal"/> subtype.
+/// </summary>
+public enum SignalRule
+{
+    // ---- structural breadcrumbs (the §5 High anchors) ----------------------------------------------------------
+
+    /// <summary>An AutoMapper <c>CreateMap&lt;A,B&gt;</c> use-site fired (Leg 2). Explicit structural breadcrumb ⇒ High-eligible.</summary>
+    CreateMap,
+
+    /// <summary>A DbContext <c>DbSet&lt;T&gt;</c> property fired (Leg 3). Explicit structural breadcrumb ⇒ High-eligible.</summary>
+    DbSetProperty,
+
+    /// <summary>A (verb, route) endpoint match with a KNOWN verb after token expansion (Leg 1). High-eligible.</summary>
+    RouteVerbMatch,
+
+    /// <summary>A route-only match — the route lines up but the client verb was unknown (Leg 1). Medium, never High.</summary>
+    RouteOnlyMatch,
+
+    /// <summary>The endpoint return type unwrapped to a named user DTO (Leg 1 <c>responds→</c>). Structural breadcrumb.</summary>
+    ReturnTypeDto,
+
+    /// <summary>A request DTO recovered from a <c>[FromBody]</c>/parameter type (Leg 1 <c>consumes→</c>). Structural breadcrumb.</summary>
+    FromBodyDto,
+
+    /// <summary>A Dapper <c>FROM &lt;table&gt;</c> literal fired (Leg 3). High-eligible ONLY when a real FROM is present.</summary>
+    DapperFrom,
+
+    // ---- corroborators (never a sole anchor) -------------------------------------------------------------------
+
+    /// <summary>A field-set Jaccard overlap (carries fieldCount + Jaccard). NEVER a sole signal; only raises an existing edge.</summary>
+    FieldSetJaccard,
+
+    /// <summary>A canonical-name-stem match (carries the exact|affix tier). The "safe finisher"; never the sole High signal.</summary>
+    NameMatch,
+
+    // ---- per-side metadata (not itself a positive corroborator) ------------------------------------------------
+
+    /// <summary>
+    /// The <see cref="SymbolResolver"/> outcome for one edge side (carries endpoint + status + matchCount). Backs the
+    /// ambiguous-name-never-High and unresolved-no-edge rules; it is NOT a positive corroborator — it never raises a band.
+    /// </summary>
+    NameResolution,
+}
+
+/// <summary>
+/// A typed scoring signal on a candidate edge: <c>{rule, value, evidence}</c> with the value carried in the concrete
+/// subtype's payload, NOT as a bare rule name (design §5). The typed payload is what lets the scorer enforce
+/// "1-field can't anchor" (it reads <see cref="FieldSetSignal.FieldCount"/>) and "ambiguous-name never High" (it reads
+/// <see cref="NameResolutionSignal.Status"/>) from the candidate alone. Closed hierarchy — every variant is one of the
+/// sealed subclasses below.
+/// </summary>
+/// <param name="Rule">Which <see cref="SignalRule"/> this signal carries.</param>
+/// <param name="Evidence">A <c>file:line</c> the signal can be traced to, or null when the signal has no single site.</param>
+public abstract record Signal(SignalRule Rule, Evidence? Evidence);
+
+/// <summary>
+/// A structural breadcrumb signal carrying only a present/absent boolean + its evidence: the CreateMap, DbSetProperty,
+/// RouteVerbMatch, RouteOnlyMatch, ReturnTypeDto, FromBodyDto, or DapperFrom rules. <see cref="Present"/> is true when
+/// the breadcrumb actually fired; a leg only emits a present=false signal as a deliberate "considered-but-absent"
+/// record (the scorer treats a non-present structural signal as no anchor).
+/// </summary>
+/// <param name="Rule">The structural rule (must be one of the structural <see cref="SignalRule"/> values).</param>
+/// <param name="Present">True when the breadcrumb fired.</param>
+/// <param name="Evidence">The breadcrumb's <c>file:line</c>, or null.</param>
+public sealed record StructuralSignal(SignalRule Rule, bool Present, Evidence? Evidence = null)
+    : Signal(Rule, Evidence);
+
+/// <summary>
+/// A field-set overlap corroborator (<see cref="SignalRule.FieldSetJaccard"/>) carrying the overlap shape so the scorer
+/// can enforce the design §5 invariants from the payload: <see cref="FieldCount"/> (the smaller of the two compared
+/// shapes — a 1-field/generic shape can NOT anchor) and <see cref="Jaccard"/> (the field-name overlap ratio). This is
+/// NEVER a sole signal; it only raises an edge that already has a structural or name signal.
+/// </summary>
+/// <param name="FieldCount">
+/// The anchoring field count — the MIN of the two compared field-sets' counts. The scorer refuses a 1-field shape as a
+/// corroborator (a 1-field generic wrapper Jaccard-matches everything), so this is the value the §5 rule reads.
+/// </param>
+/// <param name="Jaccard">The field-name Jaccard similarity in [0,1] (|A∩B| / |A∪B|).</param>
+/// <param name="Evidence">The compared owner's <c>file:line</c>, or null.</param>
+public sealed record FieldSetSignal(int FieldCount, double Jaccard, Evidence? Evidence = null)
+    : Signal(SignalRule.FieldSetJaccard, Evidence);
+
+/// <summary>The tier of a canonical-name-stem match: an exact stem equality, or an equality only after affix folding.</summary>
+public enum NameTier
+{
+    /// <summary>The two names share the exact canonical stem (the stronger name tier).</summary>
+    Exact,
+
+    /// <summary>The names match only after affix folding (singular↔plural, role-suffix strip) — the weaker tier.</summary>
+    Affix,
+}
+
+/// <summary>
+/// A canonical-name-stem corroborator (<see cref="SignalRule.NameMatch"/>) carrying the match <see cref="Tier"/>
+/// (<see cref="NameTier.Exact"/> vs <see cref="NameTier.Affix"/>). The "safe finisher": pairs with a corroborator for
+/// Medium, but is never the sole signal for a High edge (design §4 finisher / §5 bands).
+/// </summary>
+/// <param name="Tier">Whether the stems matched exactly or only after affix folding.</param>
+/// <param name="Evidence">The matched name's <c>file:line</c>, or null.</param>
+public sealed record NameSignal(NameTier Tier, Evidence? Evidence = null)
+    : Signal(SignalRule.NameMatch, Evidence);
+
+/// <summary>
+/// A per-side <see cref="SymbolResolver"/> outcome (<see cref="SignalRule.NameResolution"/>): the
+/// <see cref="EndpointSide"/> it describes, its <see cref="ResolutionStatus"/>, and the candidate
+/// <see cref="MatchCount"/>. The <see cref="BridgeScorer"/> reads <see cref="Status"/> off the payload to enforce both
+/// resolution rules directly: an <see cref="ResolutionStatus.Ambiguous"/> side can never be High, and an
+/// <see cref="ResolutionStatus.Unresolved"/> side yields no edge. The scorer is the single enforcement point for both
+/// (a future builder MAY pre-filter an unresolved side as an optimization, but is not required to). It is metadata, not
+/// a positive corroborator — it never raises a band.
+/// </summary>
+/// <param name="Endpoint">Which edge side this resolution describes.</param>
+/// <param name="Status">The resolver's outcome for that side.</param>
+/// <param name="MatchCount">How many name candidates the resolver considered (0 unresolved, 1 resolved, ≥2 before tie-break).</param>
+/// <param name="Evidence">The use-site <c>file:line</c>, or null.</param>
+public sealed record NameResolutionSignal(
+    EndpointSide Endpoint,
+    ResolutionStatus Status,
+    int MatchCount,
+    Evidence? Evidence = null)
+    : Signal(SignalRule.NameResolution, Evidence);

--- a/src/Miller.Core/Resolver/SymbolResolver.cs
+++ b/src/Miller.Core/Resolver/SymbolResolver.cs
@@ -1,0 +1,169 @@
+using Miller.Core.Contracts;
+
+namespace Miller.Core.Resolver;
+
+/// <summary>The outcome status of resolving a type name to a symbol.</summary>
+public enum ResolutionStatus
+{
+    /// <summary>No candidate matched the name — the edge is dropped (no symbol to point at).</summary>
+    Unresolved,
+
+    /// <summary>Exactly one candidate matched (directly, or after a tie-break) — the edge resolves.</summary>
+    Resolved,
+
+    /// <summary>&gt;1 candidate matched with no usable tie-break — the caller lowers/drops; the edge is NEVER High.</summary>
+    Ambiguous,
+}
+
+/// <summary>
+/// The result of resolving a type name. Carries the <see cref="Status"/>, the chosen <see cref="SymbolId"/> (only when
+/// <see cref="ResolutionStatus.Resolved"/>; null otherwise — an ambiguous resolution NEVER picks one), and the
+/// <see cref="MatchCount"/> of name candidates considered (it backs the scorer's <c>NameResolution</c> signal so the
+/// ambiguous-name-never-High rule is decidable from the candidate payload alone).
+/// </summary>
+/// <param name="Status">The resolution outcome.</param>
+/// <param name="SymbolId">The resolved symbol id, or null when unresolved/ambiguous.</param>
+/// <param name="MatchCount">How many candidates matched the leaf name (0 unresolved, 1 resolved, ≥2 before tie-break).</param>
+public sealed record NameResolution(ResolutionStatus Status, string? SymbolId, int MatchCount);
+
+/// <summary>
+/// Resolves a <c>type_name</c> to a symbol by NAME over an in-memory symbol set (design §3). julie ships
+/// <c>target_symbol_id</c> NULL at extract (verified 0/1797 type_args, 0/24830 identifiers), so every cross-file leg
+/// (CreateMap, DbSet entity, response/request DTO) must do string-name resolution here. Pure: the symbol set is passed
+/// in; no DB, no I/O.
+///
+/// <para><b>Ambiguity policy (load-bearing precision guard):</b> a unique name resolves; a namespace or file/project
+/// hint can break a tie; but &gt;1 match with no usable hint is <see cref="ResolutionStatus.Ambiguous"/> — the resolver
+/// returns no symbol and the caller drops the edge or lowers its confidence, NEVER High. It never arbitrarily picks one
+/// of several same-named types.</para>
+/// </summary>
+public sealed class SymbolResolver
+{
+    // Leaf-name → candidates. Matching is by the type's simple (leaf) name; the qualifier disambiguates a tie.
+    private readonly IReadOnlyDictionary<string, List<SymbolDetail>> _byLeafName;
+
+    /// <summary>Build a resolver over <paramref name="symbols"/> (the resolvable type symbols of one workspace index).</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="symbols"/> is null.</exception>
+    public SymbolResolver(IReadOnlyCollection<SymbolDetail> symbols)
+    {
+        ArgumentNullException.ThrowIfNull(symbols);
+
+        var index = new Dictionary<string, List<SymbolDetail>>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+        {
+            if (string.IsNullOrWhiteSpace(symbol.Name))
+                continue;
+            if (!index.TryGetValue(symbol.Name, out var bucket))
+            {
+                bucket = [];
+                index[symbol.Name] = bucket;
+            }
+            bucket.Add(symbol);
+        }
+
+        // Deterministic candidate order within each bucket (by id) so a tie-break narrowing is stable.
+        foreach (var bucket in index.Values)
+            bucket.Sort(static (a, b) => string.CompareOrdinal(a.Id, b.Id));
+
+        _byLeafName = index;
+    }
+
+    /// <summary>
+    /// Resolve <paramref name="typeName"/> (possibly namespace-qualified, e.g. <c>Core.Reporting.Data.Account</c>) to a
+    /// symbol. Optional hints break a tie when several types share the leaf name: <paramref name="preferNamespace"/>
+    /// (the use-site's namespace) and <paramref name="preferFile"/> (the use-site's file, for a shared path-prefix
+    /// preference). A namespace embedded in a qualified <paramref name="typeName"/> is itself used as a hint.
+    /// </summary>
+    /// <param name="typeName">The type name to resolve; blank yields <see cref="ResolutionStatus.Unresolved"/>.</param>
+    /// <param name="preferNamespace">An optional namespace hint for tie-breaking, or null.</param>
+    /// <param name="preferFile">An optional use-site file hint for tie-breaking (shared leading path segment), or null.</param>
+    public NameResolution Resolve(string typeName, string? preferNamespace = null, string? preferFile = null)
+    {
+        ArgumentNullException.ThrowIfNull(typeName);
+
+        if (string.IsNullOrWhiteSpace(typeName))
+            return new NameResolution(ResolutionStatus.Unresolved, null, 0);
+
+        var (leaf, qualifier) = SplitQualified(typeName.Trim());
+
+        if (!_byLeafName.TryGetValue(leaf, out var candidates) || candidates.Count == 0)
+            return new NameResolution(ResolutionStatus.Unresolved, null, 0);
+
+        int matchCount = candidates.Count;
+        if (matchCount == 1)
+            return new NameResolution(ResolutionStatus.Resolved, candidates[0].Id, matchCount);
+
+        // >1 candidate: try the namespace hint (from the qualified type name first, then the explicit hint), then the
+        // file hint. A hint that narrows to exactly one wins; anything else stays ambiguous.
+        var narrowed = TieBreakByNamespace(candidates, qualifier)
+                       ?? TieBreakByNamespace(candidates, preferNamespace)
+                       ?? TieBreakByFile(candidates, preferFile);
+
+        if (narrowed is not null)
+            return new NameResolution(ResolutionStatus.Resolved, narrowed.Id, matchCount);
+
+        return new NameResolution(ResolutionStatus.Ambiguous, null, matchCount);
+    }
+
+    /// <summary>Split a possibly-qualified type name into its leaf name and the namespace qualifier (or null).</summary>
+    private static (string Leaf, string? Qualifier) SplitQualified(string typeName)
+    {
+        int dot = typeName.LastIndexOf('.');
+        if (dot <= 0 || dot >= typeName.Length - 1)
+            return (typeName, null);
+        return (typeName[(dot + 1)..], typeName[..dot]);
+    }
+
+    /// <summary>Narrow to the single candidate whose namespace equals the hint, or null if 0 or &gt;1 remain.</summary>
+    private static SymbolDetail? TieBreakByNamespace(List<SymbolDetail> candidates, string? ns)
+    {
+        if (string.IsNullOrEmpty(ns))
+            return null;
+
+        SymbolDetail? only = null;
+        foreach (var c in candidates)
+        {
+            if (c.Namespace is not null && string.Equals(c.Namespace, ns, StringComparison.Ordinal))
+            {
+                if (only is not null)
+                    return null; // >1 namespace match: still ambiguous, do not pick by id
+                only = c;
+            }
+        }
+        return only;
+    }
+
+    /// <summary>
+    /// Narrow by the use-site file's leading path segment: prefer the single candidate sharing the first path segment
+    /// (the project/service root) with <paramref name="preferFile"/>. Null if 0 or &gt;1 candidates share it.
+    /// </summary>
+    private static SymbolDetail? TieBreakByFile(List<SymbolDetail> candidates, string? preferFile)
+    {
+        if (string.IsNullOrEmpty(preferFile))
+            return null;
+
+        var hintRoot = FirstSegment(preferFile);
+        if (hintRoot.Length == 0)
+            return null;
+
+        SymbolDetail? only = null;
+        foreach (var c in candidates)
+        {
+            if (string.Equals(FirstSegment(c.FilePath), hintRoot, StringComparison.Ordinal))
+            {
+                if (only is not null)
+                    return null; // >1 share the project root: ambiguous
+                only = c;
+            }
+        }
+        return only;
+    }
+
+    /// <summary>The first path segment of a workspace-relative path (its project/service root), or empty.</summary>
+    private static string FirstSegment(string path)
+    {
+        var p = path.Replace('\\', '/').TrimStart('/');
+        int slash = p.IndexOf('/');
+        return slash < 0 ? p : p[..slash];
+    }
+}

--- a/src/Miller.Indexing/ExtractReport.cs
+++ b/src/Miller.Indexing/ExtractReport.cs
@@ -4,7 +4,7 @@ namespace Miller.Indexing;
 
 /// <summary>
 /// The flat JSON report julie-server emits on stdout for an <c>extract</c> operation (verified against
-/// julie v7.12.2's <c>report.rs</c>). <c>info</c> reuses the same shape: its counts arrive in the
+/// julie v7.13.0's <c>report.rs</c>). <c>info</c> reuses the same shape: its counts arrive in the
 /// <c>*_total</c> fields, not the scan counters. Note serde renames the Rust field <c>db</c> to
 /// <c>db_path</c> in the JSON, captured by the <see cref="JsonPropertyNameAttribute"/> on
 /// <see cref="DbPath"/>. Counts are unsigned (julie emits them as non-negative).
@@ -14,9 +14,9 @@ public sealed record ExtractReport(
     [property: JsonPropertyName("operation")] string Operation,
     [property: JsonPropertyName("db_path")] string DbPath,                          // serde renames `db`→`db_path`
     [property: JsonPropertyName("root")] string? Root,
-    [property: JsonPropertyName("schema_version")] int? SchemaVersion,              // expect 26
+    [property: JsonPropertyName("schema_version")] int? SchemaVersion,              // expect MillerExtractContract.ExpectedSchemaVersion (28)
     [property: JsonPropertyName("schema_state")] string? SchemaState,               // missing|older|current|newer
-    [property: JsonPropertyName("extract_contract_version")] int? ExtractContractVersion, // expect 1
+    [property: JsonPropertyName("extract_contract_version")] int? ExtractContractVersion, // expect MillerExtractContract.ExpectedExtractContractVersion (2)
     [property: JsonPropertyName("analysis_state")] string? AnalysisState,
     [property: JsonPropertyName("files_scanned")] ulong FilesScanned,
     [property: JsonPropertyName("symbols_extracted")] ulong SymbolsExtracted,

--- a/src/Miller.Indexing/IncompatibleExtractException.cs
+++ b/src/Miller.Indexing/IncompatibleExtractException.cs
@@ -2,7 +2,7 @@ namespace Miller.Indexing;
 
 /// <summary>
 /// Thrown by <see cref="JulieSchemaGate"/> (or the post-extract version cross-check) when a DB is not a
-/// compatible v7.12.2 julie extract: the schema_version or extract_contract_version differs from
+/// compatible v7.13.0 julie extract: the schema_version or extract_contract_version differs from
 /// <see cref="MillerExtractContract"/>, or a required table/key is missing. The message is actionable —
 /// it names the offending value and points the operator at the remedy (upgrade Miller, or re-run restore).
 /// </summary>

--- a/src/Miller.Indexing/IndexedSymbol.cs
+++ b/src/Miller.Indexing/IndexedSymbol.cs
@@ -1,3 +1,4 @@
+using Miller.Core.Contracts;
 using Miller.Core.Search;
 
 namespace Miller.Indexing;
@@ -20,7 +21,8 @@ public sealed record IndexedSymbol(
     int StartLine,      // 1-based (NULL start_line in the DB maps to 0)
     int EndLine,        // whole-symbol span end, 1-based (NULL end_line maps to 0); enables D5 diff→symbol mapping
     string? ParentId,   // julie parent_id (containment; M4)
-    bool IsTest = false) // julie's persisted symbols.metadata.is_test (cross-language, all 34 langs); see M2 §2 decision-4
+    bool IsTest = false,  // julie's persisted symbols.metadata.is_test (cross-language, all 34 langs); see M2 §2 decision-4
+    TestRole? TestRole = null) // julie's persisted symbols.metadata.test_role (cross-language); null = not a test (M4 Task 9)
 {
     /// <summary>
     /// Project to the Core scoring document. Drops the join keys (<see cref="SymbolId"/>/<see cref="ParentId"/>)

--- a/src/Miller.Indexing/JulieSchemaGate.cs
+++ b/src/Miller.Indexing/JulieSchemaGate.cs
@@ -81,7 +81,7 @@ internal static class JulieSchemaGate
         if (result is null || result is DBNull)
             throw new IncompatibleExtractException(
                 "DB is missing the 'extract_contract_version' key in external_extract_metadata; it is not a " +
-                $"v7.12.2 julie extract. Re-run restore + `extract scan` with the pinned julie-server " +
+                $"v{MillerExtractContract.PinnedJulieServerVersion} julie extract. Re-run restore + `extract scan` with the pinned julie-server " +
                 $"(v{MillerExtractContract.PinnedJulieServerVersion}).");
 
         string text = result.ToString() ?? string.Empty;

--- a/src/Miller.Indexing/MillerExtractContract.cs
+++ b/src/Miller.Indexing/MillerExtractContract.cs
@@ -8,9 +8,9 @@ namespace Miller.Indexing;
 /// </summary>
 internal static class MillerExtractContract
 {
-    // Miller pins julie-server v7.12.2 → schema 26 / extract_contract_version 1.
-    // Bumps to (28, 2) at M4 when the bridge-anchor extraction enrichment is consumed.
-    public const long ExpectedSchemaVersion = 26;
-    public const long ExpectedExtractContractVersion = 1;
-    public const string PinnedJulieServerVersion = "7.12.2";
+    // Miller pins julie-server v7.13.0 → schema 28 / extract_contract_version 2.
+    // Bumped to (28, 2) at M4 to consume the bridge-anchor extraction enrichment (type_arguments / literals).
+    public const long ExpectedSchemaVersion = 28;
+    public const long ExpectedExtractContractVersion = 2;
+    public const string PinnedJulieServerVersion = "7.13.0";
 }

--- a/src/Miller.Indexing/MillerRepositoryIndex.cs
+++ b/src/Miller.Indexing/MillerRepositoryIndex.cs
@@ -1,4 +1,5 @@
 using Miller.Core.Graph;
+using Miller.Core.Resolver;
 using Miller.Core.Search;
 
 namespace Miller.Indexing;
@@ -34,6 +35,15 @@ public sealed class MillerRepositoryIndex
     // index). Always non-null — Build(symbols) installs an edge-less graph (back-compat for search/inspect).
     private readonly SymbolGraph _graph;
 
+    // The M4 cross-language bridge graph (Task 8/9): built as part of the same immutable unit and published
+    // atomically alongside _graph (same churn argument — a bridge graph keyed on stale ids must never outlive its
+    // index). Always non-null — the search/inspect/edit Build paths install the empty bridge graph.
+    private readonly BridgeGraph _bridgeGraph;
+
+    // The empty bridge graph the non-M4 Build overloads install (no scored edges, no nodes). Shared + immutable.
+    private static readonly BridgeGraph EmptyBridgeGraph =
+        BridgeGraph.Build(Array.Empty<ScoredEdge>(), new Dictionary<string, BridgeNode>(StringComparer.Ordinal));
+
     private MillerRepositoryIndex(
         MillerSearchIndex index,
         IndexedSymbol[] byDocId,
@@ -43,7 +53,8 @@ public sealed class MillerRepositoryIndex
         Dictionary<string, List<IndexedSymbol>> byParentId,
         Dictionary<string, List<string>> byFileName,
         IReadOnlySet<string> knownExtensions,
-        SymbolGraph graph)
+        SymbolGraph graph,
+        BridgeGraph bridgeGraph)
     {
         _index = index;
         _byDocId = byDocId;
@@ -54,6 +65,7 @@ public sealed class MillerRepositoryIndex
         _byFileName = byFileName;
         KnownExtensions = knownExtensions;
         _graph = graph;
+        _bridgeGraph = bridgeGraph;
     }
 
     /// <summary>
@@ -64,6 +76,16 @@ public sealed class MillerRepositoryIndex
     /// pass-throughs over the raw id graph when you need full <see cref="IndexedSymbol"/>s.
     /// </summary>
     public SymbolGraph Graph => _graph;
+
+    /// <summary>
+    /// The M4 cross-language bridge graph travelling with this index (plan Task 8/9; design §3/§4). The undirected
+    /// scored-edge graph over TS/DTO/entity/table/endpoint nodes, built once as part of the same immutable unit so
+    /// it is published atomically by the holder's reference swap. An index built via a non-M4 <c>Build</c> overload
+    /// carries the EMPTY bridge graph (no edges, no nodes); only
+    /// <see cref="Build(IReadOnlyList{IndexedSymbol},IReadOnlyList{GraphEdge},BridgeGraph)"/> installs a populated
+    /// one (the production loader, Task 9).
+    /// </summary>
+    public BridgeGraph BridgeGraph => _bridgeGraph;
 
     /// <summary>Total number of indexed symbols.</summary>
     public int DocumentCount => _byDocId.Length;
@@ -86,16 +108,12 @@ public sealed class MillerRepositoryIndex
     /// DocIds are not the contiguous 0..n-1 ordinals this facade requires (a reader regression).
     /// </exception>
     public static MillerRepositoryIndex Build(IReadOnlyList<IndexedSymbol> symbols) =>
-        Build(symbols, Array.Empty<GraphEdge>());
+        Build(symbols, Array.Empty<GraphEdge>(), EmptyBridgeGraph);
 
     /// <summary>
-    /// Build the repository index AND its dependency graph (D9) from symbols produced by
-    /// <see cref="SqliteSymbolReader.Read"/> and the resolved edges produced by
-    /// <see cref="SymbolGraphReader.Read"/>, as ONE immutable unit. The reader assigns contiguous 0-based DocIds
-    /// in deterministic order, so the hydration array is indexed directly by DocId for O(1) <see cref="Resolve"/>;
-    /// this contract is validated, not assumed. Each symbol becomes a graph node carrying its
-    /// <see cref="IndexedSymbol.IsTest"/> flag (so <c>impact</c> can partition likely tests without a second
-    /// lookup); the graph applies its own edge hygiene (unknown-endpoint / self-loop drop, per-direction dedup).
+    /// Build the repository index AND its dependency graph (D9), with the EMPTY cross-language bridge graph.
+    /// Back-compat for the M1–M3/M5 build sites (search/inspect/edit/impact) that do not need the M4 bridge.
+    /// Delegates to <see cref="Build(IReadOnlyList{IndexedSymbol},IReadOnlyList{GraphEdge},BridgeGraph)"/>.
     /// </summary>
     /// <param name="symbols">The indexed symbols (contiguous 0-based DocIds).</param>
     /// <param name="edges">The resolved dependency edges (<see cref="SymbolGraphReader.Read"/>'s output).</param>
@@ -104,10 +122,32 @@ public sealed class MillerRepositoryIndex
     /// DocIds are not the contiguous 0..n-1 ordinals this facade requires (a reader regression).
     /// </exception>
     public static MillerRepositoryIndex Build(
-        IReadOnlyList<IndexedSymbol> symbols, IReadOnlyList<GraphEdge> edges)
+        IReadOnlyList<IndexedSymbol> symbols, IReadOnlyList<GraphEdge> edges) =>
+        Build(symbols, edges, EmptyBridgeGraph);
+
+    /// <summary>
+    /// Build the repository index, its dependency graph (D9), AND the M4 cross-language bridge graph (Task 8/9) as
+    /// ONE immutable unit. The reader assigns contiguous 0-based DocIds in deterministic order, so the hydration
+    /// array is indexed directly by DocId for O(1) <see cref="Resolve"/>; this contract is validated, not assumed.
+    /// Each symbol becomes a dependency-graph node carrying its <see cref="IndexedSymbol.IsTest"/> flag (so
+    /// <c>impact</c> can partition likely tests without a second lookup); the graph applies its own edge hygiene
+    /// (unknown-endpoint / self-loop drop, per-direction dedup). The supplied <paramref name="bridgeGraph"/> (built
+    /// by <see cref="Miller.Core.Graph.BridgeGraphBuilder"/> in the loader, Task 9) travels with the index and is
+    /// published atomically by the holder's reference swap.
+    /// </summary>
+    /// <param name="symbols">The indexed symbols (contiguous 0-based DocIds).</param>
+    /// <param name="edges">The resolved dependency edges (<see cref="SymbolGraphReader.Read"/>'s output).</param>
+    /// <param name="bridgeGraph">The M4 cross-language bridge graph to publish with this index.</param>
+    /// <exception cref="ArgumentNullException">Any argument is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// DocIds are not the contiguous 0..n-1 ordinals this facade requires (a reader regression).
+    /// </exception>
+    public static MillerRepositoryIndex Build(
+        IReadOnlyList<IndexedSymbol> symbols, IReadOnlyList<GraphEdge> edges, BridgeGraph bridgeGraph)
     {
         ArgumentNullException.ThrowIfNull(symbols);
         ArgumentNullException.ThrowIfNull(edges);
+        ArgumentNullException.ThrowIfNull(bridgeGraph);
 
         var byDocId = new IndexedSymbol[symbols.Count];
         var documents = new SearchableDocument[symbols.Count];
@@ -162,7 +202,7 @@ public sealed class MillerRepositoryIndex
 
         return new MillerRepositoryIndex(
             MillerSearchIndex.Build(documents), byDocId, bySymbolId, byName, byFilePath, byParentId,
-            byFileName, knownExtensions, SymbolGraph.Build(nodes, edges));
+            byFileName, knownExtensions, SymbolGraph.Build(nodes, edges), bridgeGraph);
 
         static void Add(Dictionary<string, List<IndexedSymbol>> map, string key, IndexedSymbol value)
         {

--- a/src/Miller.Indexing/RepositoryIndexLoader.cs
+++ b/src/Miller.Indexing/RepositoryIndexLoader.cs
@@ -26,7 +26,7 @@ public static class RepositoryIndexLoader
     /// <exception cref="ArgumentException"><paramref name="dbPath"/> is null/empty/whitespace.</exception>
     /// <exception cref="FileNotFoundException">The DB file does not exist.</exception>
     /// <exception cref="InvalidOperationException">The DB's directory is not writable (WAL sidecar trap).</exception>
-    /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.12.2 julie extract.</exception>
+    /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.13.0 julie extract.</exception>
     public static MillerRepositoryIndex Load(string dbPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);

--- a/src/Miller.Indexing/RepositoryIndexLoader.cs
+++ b/src/Miller.Indexing/RepositoryIndexLoader.cs
@@ -1,14 +1,23 @@
+using Miller.Core.Graph;
+
+// Miller.Indexing also defines its own inspect-detail record `SymbolDetail` (SymbolDetail.cs), so the Core bridge
+// contract must be aliased to disambiguate — an unqualified `SymbolDetail` here binds to the Indexing one.
+using CoreSymbolDetail = Miller.Core.Contracts.SymbolDetail;
+
 namespace Miller.Indexing;
 
 /// <summary>
-/// The SINGLE production build path (D9): read symbols + edges from a julie extract and build a
-/// <see cref="MillerRepositoryIndex"/> (index + dependency graph) as one immutable unit. Both the startup
-/// bootstrap and the freshness rebuild route through here, so the graph is always ready when the index is
-/// published (the holder's atomic reference swap, M3) — no build site can ship an index without its graph.
+/// The SINGLE production build path (D9): read symbols + edges + bridge breadcrumbs from a julie extract and build
+/// a <see cref="MillerRepositoryIndex"/> (index + dependency graph + M4 cross-language bridge graph) as one
+/// immutable unit. Both the startup bootstrap and the freshness rebuild route through here, so all three graphs are
+/// always ready when the index is published (the holder's atomic reference swap, M3) — no build site can ship an
+/// index without its graphs.
 ///
 /// <para>Order of operations: read symbols (<see cref="SqliteSymbolReader.Read"/>) → build the name→ids map
 /// from those symbols → read edges (<see cref="SymbolGraphReader.Read"/>, resolving identifier names through
-/// that map) → <see cref="MillerRepositoryIndex.Build(System.Collections.Generic.IReadOnlyList{IndexedSymbol},System.Collections.Generic.IReadOnlyList{Miller.Core.Graph.GraphEdge})"/>.
+/// that map) → read the bridge breadcrumbs (<see cref="SqliteBridgeReader.Read"/>) → project the symbols to Core
+/// <see cref="SymbolDetail"/>s and run <see cref="BridgeGraphBuilder.Build"/> →
+/// <see cref="MillerRepositoryIndex.Build(System.Collections.Generic.IReadOnlyList{IndexedSymbol},System.Collections.Generic.IReadOnlyList{Miller.Core.Graph.GraphEdge},Miller.Core.Graph.BridgeGraph)"/>.
 /// The name map is built once here (not via the not-yet-constructed index) so the edge resolver and the index
 /// agree on the exact symbol set: a name resolves only to symbols this extract actually indexed (the same
 /// bound the graph then enforces on edge endpoints).</para>
@@ -19,15 +28,22 @@ namespace Miller.Indexing;
 public static class RepositoryIndexLoader
 {
     /// <summary>
-    /// Read the julie extract at <paramref name="dbPath"/> and build the index + dependency graph as one unit.
+    /// Read the julie extract at <paramref name="dbPath"/> and build the index + dependency graph + bridge graph as
+    /// one immutable unit.
     /// </summary>
     /// <param name="dbPath">Path to the julie extract DB (opened <c>Mode=ReadOnly</c> by the readers).</param>
-    /// <returns>The immutable repository index with its populated dependency graph.</returns>
+    /// <param name="onBridgeGraphBuilt">
+    /// Optional measurement callback invoked with the wall-clock time the <see cref="BridgeGraphBuilder.Build"/> pass
+    /// took (plan Task 9 requires MEASURING the bridge-graph build cost — name resolution over the code-symbol set is
+    /// the cost driver). Miller.Indexing is logger-free by design, so the caller (the bootstrap/freshness services,
+    /// which hold an <c>ILogger</c>) supplies the sink. No caching/persistence is implemented — measure only.
+    /// </param>
+    /// <returns>The immutable repository index with its populated dependency + bridge graphs.</returns>
     /// <exception cref="ArgumentException"><paramref name="dbPath"/> is null/empty/whitespace.</exception>
     /// <exception cref="FileNotFoundException">The DB file does not exist.</exception>
     /// <exception cref="InvalidOperationException">The DB's directory is not writable (WAL sidecar trap).</exception>
     /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.13.0 julie extract.</exception>
-    public static MillerRepositoryIndex Load(string dbPath)
+    public static MillerRepositoryIndex Load(string dbPath, Action<TimeSpan>? onBridgeGraphBuilt = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
 
@@ -52,7 +68,59 @@ public static class RepositoryIndexLoader
                 ? ids
                 : (IReadOnlyList<string>)Array.Empty<string>());
 
-        // 4) Build the index + graph as one immutable unit.
-        return MillerRepositoryIndex.Build(symbols, edges);
+        // 4) Read the bridge breadcrumbs (type_arguments, literals, annotations, DbSet<T> properties) and build the
+        //    M4 cross-language bridge graph. Project the symbols to Core SymbolDetails first (the legs + resolver
+        //    consume those). MEASURE the build cost (plan Task 9) — do NOT add caching/persistence speculatively.
+        var bridgeData = SqliteBridgeReader.Read(dbPath);
+        var symbolDetails = ProjectToSymbolDetails(symbols);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var bridgeGraph = BridgeGraphBuilder.Build(
+            symbolDetails,
+            bridgeData.TypeArguments,
+            bridgeData.Literals,
+            bridgeData.Annotations,
+            bridgeData.DbSetProperties,
+            bridgeData.LiteralSites);
+        stopwatch.Stop();
+        onBridgeGraphBuilt?.Invoke(stopwatch.Elapsed);
+
+        // 5) Build the index + dependency graph + bridge graph as one immutable unit.
+        return MillerRepositoryIndex.Build(symbols, edges, bridgeGraph);
+    }
+
+    /// <summary>
+    /// Project the indexed symbols to the lean Core bridge <see cref="CoreSymbolDetail"/>s the bridge legs +
+    /// resolver consume. The <c>ParentClassName</c> is resolved by looking the symbol's
+    /// <see cref="IndexedSymbol.ParentId"/> up in the same symbol set (a method/property's declaring class name,
+    /// needed for Leg 1 <c>[controller]</c> expansion); the namespace is left null (not read into
+    /// <see cref="IndexedSymbol"/>) — the resolver tolerates that.
+    /// </summary>
+    private static IReadOnlyList<CoreSymbolDetail> ProjectToSymbolDetails(IReadOnlyList<IndexedSymbol> symbols)
+    {
+        // id -> simple name, for the ParentId -> ParentClassName lookup.
+        var nameById = new Dictionary<string, string>(symbols.Count, StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+            nameById[symbol.SymbolId] = symbol.Name;
+
+        var details = new List<CoreSymbolDetail>(symbols.Count);
+        foreach (var symbol in symbols)
+        {
+            string? parentClassName =
+                symbol.ParentId is { } pid && nameById.TryGetValue(pid, out var parentName)
+                    ? parentName
+                    : null;
+
+            details.Add(new CoreSymbolDetail(
+                Id: symbol.SymbolId,
+                Name: symbol.Name,
+                Kind: symbol.Kind,
+                FilePath: symbol.FilePath,
+                Signature: symbol.Signature ?? string.Empty,
+                Namespace: null,
+                TestRole: symbol.TestRole,
+                ParentClassName: parentClassName));
+        }
+        return details;
     }
 }

--- a/src/Miller.Indexing/SqliteBridgeReader.cs
+++ b/src/Miller.Indexing/SqliteBridgeReader.cs
@@ -1,0 +1,259 @@
+using Microsoft.Data.Sqlite;
+using Miller.Core.Contracts;
+using Miller.Core.Graph;
+
+namespace Miller.Indexing;
+
+/// <summary>
+/// The cross-language bridge read layer (plan Task 9; design SQLite-reader section). Opens a julie extract DB
+/// under the SAME D4 read-only discipline as <see cref="SqliteSymbolReader"/> (<see cref="SqliteReadOnlyAccess.Open"/>
+/// + <see cref="JulieSchemaGate"/>) and projects the four bridge-relevant tables into the RAW Miller.Core contract
+/// rows the <see cref="BridgeGraphBuilder"/> consumes. It performs NO leg transformation — that is Task 8's job; this
+/// reader only maps julie columns to records.
+///
+/// <para>The four sources (verified 28/2 column shapes — findings 28-2):
+/// <list type="bullet">
+/// <item><c>type_arguments</c> → <see cref="TypeArgument"/> (CreateMap grouping input), ordered by
+/// <c>identifier_id</c> then <c>ordinal</c> for deterministic grouping downstream.</item>
+/// <item><c>literals</c> → <see cref="LiteralRecord"/> (url client calls + sql), ordered by file then start_byte.
+/// The <c>literals</c> table HAS its own <c>file_path</c>/<c>start_line</c> columns (unlike the lean
+/// <see cref="LiteralRecord"/> which surfaces only span + containing-symbol id), so the reader ALSO returns the
+/// literal→(file,line) lookup the builder's literal-evidence seam needs (Task 8 deviation).</item>
+/// <item><c>symbol_annotations</c> → <see cref="SymbolAnnotation"/> (http-verb endpoints + class <c>[Route]</c>),
+/// ordered by <c>symbol_id</c> then <c>ordinal</c>.</item>
+/// <item>DbContext <c>DbSet&lt;T&gt;</c> properties → <see cref="DbSetProperty"/> (Leg 3 PRIMARY), parsed from
+/// <c>symbols</c> rows with <c>kind='property'</c> whose <c>signature</c> contains <c>DbSet&lt;…&gt;</c>: the property
+/// name IS the table name (EF convention), the generic arg IS the entity type.</item>
+/// </list></para>
+///
+/// <para>Sync by design: this is part of the single startup/rebuild pass (Microsoft.Data.Sqlite's async is
+/// synchronous internally), and it runs after <see cref="SqliteSymbolReader"/> on the same DB.</para>
+/// </summary>
+public static class SqliteBridgeReader
+{
+    /// <summary>
+    /// Read the four bridge tables from the julie extract at <paramref name="dbPath"/> into the raw Core contract
+    /// collections (plus the literal→file:line lookup for the builder's literal-evidence seam).
+    /// </summary>
+    /// <param name="dbPath">Path to the julie extract DB (opened <c>Mode=ReadOnly</c> by the shared D4 discipline).</param>
+    /// <returns>The raw bridge rows + literal-site lookup, ready for <see cref="BridgeGraphBuilder.Build"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="dbPath"/> is null/empty/whitespace.</exception>
+    /// <exception cref="FileNotFoundException">The DB file does not exist.</exception>
+    /// <exception cref="InvalidOperationException">The DB's directory is not writable (WAL sidecar trap).</exception>
+    /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.13.0 julie extract.</exception>
+    public static BridgeData Read(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+        using var connection = SqliteReadOnlyAccess.Open(dbPath);
+        JulieSchemaGate.Verify(connection);
+
+        var typeArguments = ReadTypeArguments(connection);
+        var (literals, literalSites) = ReadLiterals(connection);
+        var annotations = ReadAnnotations(connection);
+        var dbSetProperties = ReadDbSetProperties(connection);
+
+        return new BridgeData(typeArguments, literals, annotations, dbSetProperties, literalSites);
+    }
+
+    // ---- type_arguments ---------------------------------------------------------------------------------------
+
+    private static IReadOnlyList<TypeArgument> ReadTypeArguments(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        // identifier_id keys the CreateMap grouping; ordinal slots the args. Order by both so the builder's grouping
+        // (and any test asserting row order) is deterministic.
+        command.CommandText = """
+            SELECT identifier_id, ordinal, parent_arg_id, type_name, file_path
+            FROM type_arguments
+            WHERE identifier_id IS NOT NULL AND type_name IS NOT NULL
+            ORDER BY identifier_id, ordinal, id;
+            """;
+
+        var results = new List<TypeArgument>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string identifierId = reader.GetString(0);                                  // identifier_id  NOT NULL (filtered)
+            int ordinal = reader.IsDBNull(1) ? 0 : reader.GetInt32(1);                  // ordinal        nullable -> 0
+            string? parentArgId = reader.IsDBNull(2) ? null : reader.GetString(2);     // parent_arg_id  nullable
+            string typeName = reader.GetString(3);                                      // type_name      NOT NULL (filtered)
+            string filePath = reader.IsDBNull(4) ? string.Empty : reader.GetString(4); // file_path      nullable -> ""
+
+            results.Add(new TypeArgument(identifierId, ordinal, parentArgId, typeName, filePath));
+        }
+        return results;
+    }
+
+    // ---- literals ---------------------------------------------------------------------------------------------
+
+    private static (IReadOnlyList<LiteralRecord> Literals, IReadOnlyDictionary<LiteralRecord, LiteralSite> Sites)
+        ReadLiterals(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        // literals carries its OWN file_path + start_line (the lean LiteralRecord does not re-expose them), so we
+        // build the literal->(file,line) lookup the BridgeGraphBuilder's literal-evidence seam needs here.
+        command.CommandText = """
+            SELECT literal_text, kind, carrier, arg_position, language, containing_symbol_id,
+                   start_byte, end_byte, file_path, start_line
+            FROM literals
+            WHERE literal_text IS NOT NULL
+            ORDER BY file_path, start_byte, id;
+            """;
+
+        var literals = new List<LiteralRecord>();
+        // Reference-identity keyed: each LiteralRecord instance is unique per row, so a per-instance lookup is exact
+        // (two literals with identical field values still map to their own site).
+        var sites = new Dictionary<LiteralRecord, LiteralSite>(ReferenceEqualityComparer.Instance);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string literalText = reader.GetString(0);                                          // literal_text  NOT NULL (filtered)
+            string kind = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);            // kind          nullable -> ""
+            string carrier = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);         // carrier       nullable -> ""
+            int argPosition = reader.IsDBNull(3) ? 0 : reader.GetInt32(3);                     // arg_position  nullable -> 0
+            string language = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);         // language      nullable -> ""
+            string containingSymbolId = reader.IsDBNull(5) ? string.Empty : reader.GetString(5);// containing_symbol_id nullable -> ""
+            int startByte = reader.IsDBNull(6) ? 0 : reader.GetInt32(6);                       // start_byte    nullable -> 0
+            int endByte = reader.IsDBNull(7) ? 0 : reader.GetInt32(7);                         // end_byte      nullable -> 0
+            string filePath = reader.IsDBNull(8) ? string.Empty : reader.GetString(8);         // file_path     nullable -> ""
+            int startLine = reader.IsDBNull(9) ? 0 : reader.GetInt32(9);                        // start_line    nullable -> 0
+
+            var record = new LiteralRecord(
+                literalText, kind, carrier, argPosition, language, containingSymbolId,
+                new SourceSpan(startByte, endByte));
+            literals.Add(record);
+            sites[record] = new LiteralSite(filePath, startLine);
+        }
+        return (literals, sites);
+    }
+
+    // ---- symbol_annotations -----------------------------------------------------------------------------------
+
+    private static IReadOnlyList<SymbolAnnotation> ReadAnnotations(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        // Deterministic by (symbol_id, ordinal) — the UNIQUE(symbol_id, ordinal) pair (findings 28-2).
+        command.CommandText = """
+            SELECT symbol_id, ordinal, annotation, annotation_key, raw_text, carrier
+            FROM symbol_annotations
+            WHERE symbol_id IS NOT NULL
+            ORDER BY symbol_id, ordinal, id;
+            """;
+
+        var results = new List<SymbolAnnotation>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string symbolId = reader.GetString(0);                                          // symbol_id       NOT NULL (filtered)
+            int ordinal = reader.IsDBNull(1) ? 0 : reader.GetInt32(1);                       // ordinal         nullable -> 0
+            string annotation = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);    // annotation      nullable -> ""
+            string annotationKey = reader.IsDBNull(3) ? string.Empty : reader.GetString(3); // annotation_key  nullable -> ""
+            string rawText = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);       // raw_text        nullable -> ""
+            string carrier = reader.IsDBNull(5) ? string.Empty : reader.GetString(5);       // carrier         nullable -> ""
+
+            results.Add(new SymbolAnnotation(symbolId, ordinal, annotation, annotationKey, rawText, carrier));
+        }
+        return results;
+    }
+
+    // ---- DbSet<T> properties ----------------------------------------------------------------------------------
+
+    private static IReadOnlyList<DbSetProperty> ReadDbSetProperties(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        // EF convention (findings 28-2): a DbContext exposes `public DbSet<Entity> TableName { get; set; }`. The
+        // property NAME is the table; the generic arg of DbSet<…> in the signature is the entity. There is no
+        // [Table] attribute and no Dapper FROM on the stored-proc repos, so this property is Leg 3's sole anchor.
+        // Deterministic by (file_path, start_line, id).
+        command.CommandText = """
+            SELECT id, name, signature, file_path, start_line
+            FROM symbols
+            WHERE kind = 'property' AND name IS NOT NULL AND signature LIKE '%DbSet<%'
+            ORDER BY file_path, start_line, id;
+            """;
+
+        var results = new List<DbSetProperty>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string propertyId = reader.GetString(0);                                       // id          NOT NULL
+            string tableName = reader.GetString(1);                                        // name        NOT NULL (filtered) = table
+            string signature = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);    // signature   (filtered to contain DbSet<)
+            string filePath = reader.IsDBNull(3) ? string.Empty : reader.GetString(3);     // file_path   nullable -> ""
+            int startLine = reader.IsDBNull(4) ? 0 : reader.GetInt32(4);                    // start_line  nullable -> 0
+
+            string? entityType = ParseDbSetEntity(signature);
+            if (entityType is null)
+                continue; // a DbSet<…> with no parseable generic arg is not a usable entity↔table anchor
+
+            results.Add(new DbSetProperty(propertyId, tableName, entityType, filePath, startLine));
+        }
+        return results;
+    }
+
+    /// <summary>
+    /// Parse the entity type out of the FIRST <c>DbSet&lt;T&gt;</c> in a property signature. Returns the leaf type
+    /// name (no namespace) of the generic arg, or null when no balanced <c>DbSet&lt;…&gt;</c> is present. Handles a
+    /// namespaced arg (<c>DbSet&lt;Core.Data.ApplicationUser&gt;</c> → <c>ApplicationUser</c>) and tolerates trailing
+    /// generic depth (the inner arg's own brackets) by matching the balanced close.
+    /// </summary>
+    private static string? ParseDbSetEntity(string signature)
+    {
+        const string marker = "DbSet<";
+        int markerStart = signature.IndexOf(marker, StringComparison.Ordinal);
+        if (markerStart < 0)
+            return null;
+
+        int open = markerStart + marker.Length - 1; // index of the '<'
+        int depth = 0;
+        int argStart = open + 1;
+        for (int i = open; i < signature.Length; i++)
+        {
+            char ch = signature[i];
+            if (ch == '<')
+                depth++;
+            else if (ch == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    var arg = signature[argStart..i].Trim();
+                    return LeafTypeName(arg);
+                }
+            }
+        }
+        return null; // unbalanced <…> — not a usable signature
+    }
+
+    /// <summary>The leaf type name of a possibly-namespaced type arg (the run after the last top-level <c>.</c>).</summary>
+    private static string? LeafTypeName(string typeArg)
+    {
+        if (typeArg.Length == 0)
+            return null;
+        int lastDot = typeArg.LastIndexOf('.');
+        var leaf = lastDot >= 0 ? typeArg[(lastDot + 1)..] : typeArg;
+        leaf = leaf.Trim();
+        return leaf.Length == 0 ? null : leaf;
+    }
+}
+
+/// <summary>
+/// The RAW bridge rows + literal-site lookup read from a julie extract (plan Task 9). NOT leg inputs — the
+/// per-leg transformation is <see cref="BridgeGraphBuilder"/>'s job. <see cref="LiteralSites"/> is the
+/// literal-evidence seam the builder requires (Task 8 deviation): the <c>literals</c> table carries its own
+/// file/line, but the lean <see cref="LiteralRecord"/> does not re-expose them, so the reader returns the
+/// per-literal-instance lookup here.
+/// </summary>
+/// <param name="TypeArguments">The <c>type_arguments</c> rows (CreateMap grouping input).</param>
+/// <param name="Literals">The <c>literals</c> rows (url client calls + sql).</param>
+/// <param name="Annotations">The <c>symbol_annotations</c> rows (http-verb endpoints + class <c>[Route]</c>).</param>
+/// <param name="DbSetProperties">The DbContext <c>DbSet&lt;T&gt;</c> property breadcrumbs (Leg 3 PRIMARY).</param>
+/// <param name="LiteralSites">The per-literal-instance <c>literal → (file, line)</c> lookup (the literal-evidence seam).</param>
+public sealed record BridgeData(
+    IReadOnlyList<TypeArgument> TypeArguments,
+    IReadOnlyList<LiteralRecord> Literals,
+    IReadOnlyList<SymbolAnnotation> Annotations,
+    IReadOnlyList<DbSetProperty> DbSetProperties,
+    IReadOnlyDictionary<LiteralRecord, LiteralSite> LiteralSites);

--- a/src/Miller.Indexing/SqliteSymbolReader.cs
+++ b/src/Miller.Indexing/SqliteSymbolReader.cs
@@ -1,4 +1,5 @@
 using Microsoft.Data.Sqlite;
+using Miller.Core.Contracts;
 
 namespace Miller.Indexing;
 
@@ -59,6 +60,8 @@ public static class SqliteSymbolReader
             string? parentId = reader.IsDBNull(8) ? null : reader.GetString(8); // parent_id   nullable
             string? metadata = reader.IsDBNull(9) ? null : reader.GetString(9); // metadata    nullable (JSON)
 
+            var (isTest, testRole) = ParseTestSignals(metadata);
+
             results.Add(new IndexedSymbol(
                 DocId: docId++,
                 SymbolId: symbolId,
@@ -70,38 +73,56 @@ public static class SqliteSymbolReader
                 StartLine: startLine,
                 EndLine: endLine,
                 ParentId: parentId,
-                IsTest: ParseIsTest(metadata)));
+                IsTest: isTest,
+                TestRole: testRole));
         }
 
         return results;
     }
 
     /// <summary>
-    /// Read the cross-language test signal from julie's <c>symbols.metadata</c> JSON (decision-4). julie's
-    /// <c>test_detection.rs</c> writes <c>"is_test": true</c> into the metadata of test symbols across all 34
-    /// languages, ONLY when true (compact serde JSON). We parse just the <c>is_test</c> boolean.
+    /// Read the cross-language test signals from julie's <c>symbols.metadata</c> JSON (decision-4; M4 Task 9).
+    /// julie's <c>test_detection.rs</c> writes <c>"is_test": true</c> (only when true) AND, when known, a
+    /// <c>"test_role"</c> string (e.g. <c>unit</c>/<c>integration</c>/<c>e2e</c>) into the metadata of test symbols
+    /// across all 34+ languages (compact serde JSON). We parse both in ONE pass and surface the boolean plus the
+    /// optional <see cref="TestRole"/>.
     ///
-    /// Perf: ~90% of symbols are not tests and carry no <c>is_test</c> key, so we skip JSON parsing entirely
-    /// unless a cheap ordinal substring check matches — over ~565k startup rows that avoids ~half a million
-    /// parses. A malformed/absent/false value is <c>false</c> (the signal is advisory, never throws).
+    /// <para>Perf: ~90% of symbols are not tests and carry NEITHER key, so we skip JSON parsing entirely unless a
+    /// cheap ordinal substring check matches one of them — over ~565k startup rows that avoids ~half a million
+    /// parses. A malformed/absent value yields <c>(false, null)</c> (the signals are advisory, never throw).</para>
     /// </summary>
-    private static bool ParseIsTest(string? metadataJson)
+    private static (bool IsTest, TestRole? TestRole) ParseTestSignals(string? metadataJson)
     {
         if (string.IsNullOrEmpty(metadataJson)
-            || !metadataJson.Contains("\"is_test\"", StringComparison.Ordinal))
-            return false;
+            || (!metadataJson.Contains("\"is_test\"", StringComparison.Ordinal)
+                && !metadataJson.Contains("\"test_role\"", StringComparison.Ordinal)))
+            return (false, null);
 
         try
         {
             using var doc = System.Text.Json.JsonDocument.Parse(metadataJson);
-            return doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object
-                && doc.RootElement.TryGetProperty("is_test", out var v)
-                && v.ValueKind == System.Text.Json.JsonValueKind.True;
+            var root = doc.RootElement;
+            if (root.ValueKind != System.Text.Json.JsonValueKind.Object)
+                return (false, null);
+
+            bool isTest = root.TryGetProperty("is_test", out var isTestEl)
+                && isTestEl.ValueKind == System.Text.Json.JsonValueKind.True;
+
+            TestRole? testRole = null;
+            if (root.TryGetProperty("test_role", out var roleEl)
+                && roleEl.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                string? role = roleEl.GetString();
+                if (!string.IsNullOrWhiteSpace(role))
+                    testRole = new TestRole(role);
+            }
+
+            return (isTest, testRole);
         }
         catch (System.Text.Json.JsonException)
         {
             // julie writes well-formed JSON; tolerate a corrupt/hand-mangled value as "not a test".
-            return false;
+            return (false, null);
         }
     }
 

--- a/src/Miller.Indexing/SqliteSymbolReader.cs
+++ b/src/Miller.Indexing/SqliteSymbolReader.cs
@@ -24,7 +24,7 @@ public static class SqliteSymbolReader
     /// </summary>
     /// <exception cref="FileNotFoundException">The DB file does not exist.</exception>
     /// <exception cref="InvalidOperationException">The DB's directory is not writable (WAL sidecar trap).</exception>
-    /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.12.2 julie extract.</exception>
+    /// <exception cref="IncompatibleExtractException">The DB is not a compatible v7.13.0 julie extract.</exception>
     public static IReadOnlyList<IndexedSymbol> Read(string dbPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);

--- a/src/Miller.Server/Tools/TraceTool.cs
+++ b/src/Miller.Server/Tools/TraceTool.cs
@@ -1,0 +1,409 @@
+using System.Buffers;
+using System.ComponentModel;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Miller.Core.Graph;
+using Miller.Core.Resolver;
+using Miller.Indexing;
+using Miller.Server.Resolution;
+using Miller.Server.Telemetry;
+using ModelContextProtocol.Server;
+
+namespace Miller.Server.Tools;
+
+/// <summary>
+/// The <c>trace</c> tool (M4 Task 10): follow a thread of code through the repository. It has three modes over the two
+/// in-memory graphs Miller already builds — no DB, no embeddings:
+/// <list type="bullet">
+/// <item><b>auto</b> — the symbol's immediate neighbourhood (callers + callees) via the dependency
+///   <see cref="SymbolGraph.Reach"/> in <see cref="Direction.Both"/>, the same neighbour walk <c>context</c>/<c>impact</c>
+///   use.</item>
+/// <item><b>path</b> — the shortest dependency path from <c>target</c> to <c>to</c> via
+///   <see cref="SymbolGraph.ShortestPath"/> (Task 8); a clean message when the two are not connected within
+///   <c>depth</c>.</item>
+/// <item><b>bridge</b> — the cross-language structural chain (TS call → endpoint → DTO → entity → table) via
+///   <see cref="BridgeGraph.Walk"/> (Task 8) over the Task-9-populated <see cref="BridgeGraph"/>, rendering each scored
+///   bridge edge with its confidence band and score.</item>
+/// </list>
+///
+/// <para><b>Honesty flags are load-bearing.</b> A reduced-confidence bridge edge is never rendered as if it were
+/// certain: <see cref="ScoredEdge.IsVerbUnknown"/> renders <c>[verb-unknown]</c> (a route matched on path alone, the
+/// HTTP verb was not derivable) and <see cref="ScoredEdge.HasAmbiguousName"/> renders <c>[ambiguous]</c> (the name
+/// resolved to more than one symbol). The <c>full</c> format additionally lists the firing signals per edge.</para>
+///
+/// <para>This is the thin MCP/DI/telemetry shell; the pure, DB-free <see cref="Run"/> core (mirroring
+/// <see cref="ImpactTool.Run"/>) holds the correctness and is unit-tested directly. It reads the live
+/// <see cref="IndexHolder"/> per call (M3 step 10) so a freshness Swap is reflected on the next trace.</para>
+/// </summary>
+[McpServerToolType]
+public sealed class TraceTool
+{
+    private readonly IndexHolder _holder;
+    private readonly SmartTargetResolver _resolver;
+
+    /// <summary>Construct over the live index holder (production / freshness-aware). The <see cref="Run"/> core is
+    /// DB-free (it traverses the in-memory graphs), so it takes no WorkspaceContext.</summary>
+    /// <exception cref="ArgumentNullException">Any argument is null.</exception>
+    public TraceTool(IndexHolder holder, SmartTargetResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(holder);
+        ArgumentNullException.ThrowIfNull(resolver);
+        _holder = holder;
+        _resolver = resolver;
+    }
+
+    [McpServerTool(Name = "trace")]
+    [Description(
+        "Follow a thread of code through the repository. mode=auto shows a symbol's callers and callees; mode=path " +
+        "shows the shortest dependency path from target to 'to'; mode=bridge follows the cross-language chain " +
+        "(TS call to endpoint to DTO to entity to table) with a confidence band on each link. Reduced-confidence " +
+        "links are flagged [verb-unknown] / [ambiguous] — never trust an unflagged link more than a flagged one. " +
+        "Pass format=full to also see the signals behind each bridge link.")]
+    public string Trace(
+        [Description("A symbol name/id or a file path (smart-resolved) — where the trace starts.")]
+        string target,
+        [Description("Trace mode: auto (callers+callees) | path (shortest path to 'to') | bridge (cross-language chain). Default auto.")]
+        string mode = "auto",
+        [Description("For mode=path: the destination symbol name/id the path must reach. Ignored otherwise.")]
+        string? to = null,
+        [Description("How many hops to follow. Default 3.")] int depth = 3,
+        [Description("Max links/neighbours to return. Default 20.")] int limit = 20,
+        [Description("Output format: compact|full. full adds the firing signals per bridge link. Default compact.")]
+        string format = "compact")
+    {
+        var telemetry = TelemetryContext.Current;
+        try
+        {
+            bool full = string.Equals(format, "full", StringComparison.OrdinalIgnoreCase);
+            string output = Run(_holder.Current, _resolver,
+                target, mode, to, depth, limit, full,
+                out int emitted, out int nodesVisited);
+
+            if (telemetry is not null)
+            {
+                telemetry.SetTarget(target);
+                telemetry.ResultCount = emitted;
+                // D10 work proxy (bytes_examined ≈ nodes visited): the edges/neighbours the walk produced.
+                telemetry.BytesExamined = nodesVisited;
+                telemetry.Outcome = emitted == 0 ? TelemetryOutcome.Empty : TelemetryOutcome.Ok;
+            }
+            return output;
+        }
+        catch (Exception ex)
+        {
+            if (telemetry is not null)
+            {
+                telemetry.Outcome = TelemetryOutcome.Error;
+                telemetry.ErrorKind = ex.GetType().Name;
+            }
+            return $"trace failed: {ex.Message}";
+        }
+    }
+
+    private const string ModeAuto = "auto";
+    private const string ModePath = "path";
+    private const string ModeBridge = "bridge";
+
+    /// <summary>
+    /// The pure execution core (no MCP/DI/telemetry; no DB — the graphs are in-memory). Resolves the start
+    /// <paramref name="target"/> (smart-resolved; ambiguous / not-found render their own message), dispatches on
+    /// <paramref name="mode"/>, and renders compact (one line per link) or <paramref name="fullFormat"/> (also the
+    /// firing signals per bridge link). <paramref name="emitted"/> is the number of links/neighbours rendered (the
+    /// result-count KPI; a guard / not-found / empty walk yields 0). <paramref name="nodesVisited"/> is the work proxy
+    /// (links produced before truncation); guard / not-found paths leave it 0.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="index"/> or <paramref name="resolver"/> is null.</exception>
+    public static string Run(
+        MillerRepositoryIndex index, SmartTargetResolver resolver,
+        string target, string mode, string? to, int depth, int limit, bool fullFormat,
+        out int emitted, out int nodesVisited)
+    {
+        ArgumentNullException.ThrowIfNull(index);
+        ArgumentNullException.ThrowIfNull(resolver);
+        if (depth < 1) depth = 1;
+        if (limit < 1) limit = 1;
+        emitted = 0;
+        nodesVisited = 0;
+
+        string normalizedMode = (mode ?? ModeAuto).Trim().ToLowerInvariant();
+
+        return normalizedMode switch
+        {
+            ModeAuto => RunAuto(index, resolver, target, depth, limit, out emitted, out nodesVisited),
+            ModePath => RunPath(index, resolver, target, to, depth, limit, out emitted, out nodesVisited),
+            ModeBridge => RunBridge(index, resolver, target, depth, limit, fullFormat, out emitted, out nodesVisited),
+            _ => $"Unknown mode '{mode}'. Use one of: auto, path, bridge.",
+        };
+    }
+
+    // ---------- mode: auto (callers + callees neighbourhood) ----------
+
+    private static string RunAuto(
+        MillerRepositoryIndex index, SmartTargetResolver resolver, string target,
+        int depth, int limit, out int emitted, out int nodesVisited)
+    {
+        emitted = 0;
+        nodesVisited = 0;
+
+        if (!ResolveSymbol(index, resolver, target, out string seedId, out string? note))
+            return note!;
+
+        IReadOnlyList<ReachedNode> reached =
+            index.Graph.Reach([seedId], depth, limit, Direction.Both);
+        nodesVisited = reached.Count;
+
+        if (reached.Count == 0)
+            return $"No neighbours — nothing connects to '{target}' within {depth} hop(s).";
+
+        var seed = index.FindBySymbolId(seedId);
+        var sb = new StringBuilder();
+        sb.Append("# trace ").Append(seed is not null ? seed.Name : target)
+          .Append(" (auto, ").Append(reached.Count).Append(" neighbour(s))\n");
+        foreach (var node in reached)
+        {
+            var symbol = index.FindBySymbolId(node.Id);
+            if (symbol is null)
+                continue; // inconsistent build — drop rather than NRE
+            sb.Append(NeighbourLine(symbol, node.Hop)).Append('\n');
+            emitted++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // "Name  kind  file:line  (hop N)" — an auto-mode neighbour line.
+    private static string NeighbourLine(IndexedSymbol s, int hop) =>
+        $"{s.Name}  {s.Kind}  {s.FilePath}:{s.StartLine}  (hop {hop})";
+
+    // ---------- mode: path (shortest dependency path target -> to) ----------
+
+    private static string RunPath(
+        MillerRepositoryIndex index, SmartTargetResolver resolver, string target, string? to,
+        int depth, int limit, out int emitted, out int nodesVisited)
+    {
+        emitted = 0;
+        nodesVisited = 0;
+
+        if (string.IsNullOrWhiteSpace(to))
+            return "Usage: mode=path requires 'to' (the destination symbol to find a path to).";
+
+        if (!ResolveSymbol(index, resolver, target, out string fromId, out string? fromNote))
+            return fromNote!;
+        if (!ResolveSymbol(index, resolver, to, out string toId, out string? toNote))
+            return toNote!;
+
+        IReadOnlyList<string>? path = index.Graph.ShortestPath(fromId, toId, depth);
+        if (path is null)
+            return $"No path from '{target}' to '{to}' within {depth} hop(s).";
+
+        // The path is from..to inclusive (ShortestPath includes both endpoints). Hops = path.Count - 1.
+        nodesVisited = path.Count;
+        var sb = new StringBuilder();
+        sb.Append("# trace path ").Append(target).Append(" -> ").Append(to)
+          .Append(" (").Append(path.Count - 1).Append(" hop(s))\n");
+
+        int shown = 0;
+        for (int i = 0; i < path.Count && shown < limit; i++)
+        {
+            var symbol = index.FindBySymbolId(path[i]);
+            string label = symbol is not null
+                ? $"{symbol.Name}  {symbol.Kind}  {symbol.FilePath}:{symbol.StartLine}"
+                : path[i];
+            sb.Append(i == 0 ? "  " : "  -> ").Append(label).Append('\n');
+            shown++;
+            emitted++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // ---------- mode: bridge (cross-language scored chain) ----------
+
+    private static string RunBridge(
+        MillerRepositoryIndex index, SmartTargetResolver resolver, string target,
+        int depth, int limit, bool fullFormat, out int emitted, out int nodesVisited)
+    {
+        emitted = 0;
+        nodesVisited = 0;
+
+        // The bridge graph keys symbol-backed nodes by their symbol id, so resolve the target to a symbol id first.
+        // (A pure route/table node has no code symbol and is not a smart-resolvable start; symbols are the entry.)
+        if (!ResolveSymbol(index, resolver, target, out string startId, out string? note))
+            return note!;
+
+        // A symbol with no incident bridge edges is not on any cross-language thread — whether it is absent from the
+        // bridge node lookup entirely or present but edge-less, the honest answer is the same. Incident subsumes both.
+        if (index.BridgeGraph.Incident(startId).Count == 0)
+            return $"'{target}' is not on a cross-language bridge. trace bridge follows DTO/entity/table/route links; " +
+                   "this symbol has none.";
+
+        IReadOnlyList<ScoredEdge> edges = index.BridgeGraph.Walk(startId, depth);
+        nodesVisited = edges.Count;
+
+        // The start has direct incident edges (checked above), so an empty Walk means depth could not reach them.
+        if (edges.Count == 0)
+            return $"No bridge links from '{target}' within {depth} hop(s).";
+
+        var startNode = index.BridgeGraph.Node(startId);
+        var sb = new StringBuilder();
+        sb.Append("# trace bridge ").Append(startNode is not null ? startNode.Display : target)
+          .Append(" (").Append(Math.Min(edges.Count, limit)).Append(" link(s))\n");
+
+        int shown = 0;
+        foreach (var edge in edges)
+        {
+            if (shown >= limit)
+                break;
+            sb.Append(BridgeLine(index.BridgeGraph, edge)).Append('\n');
+            if (fullFormat)
+                AppendSignals(sb, edge);
+            shown++;
+            emitted++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // "<source> --<verb>--> <target>  [flags]  <score> (Band)" — one scored bridge link.
+    // The verb token is the human bridge-kind label; flags are the load-bearing honesty markers.
+    internal static string BridgeLine(BridgeGraph graph, ScoredEdge edge)
+    {
+        string source = EndpointDisplay(graph, edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source);
+        string targetDisplay = EndpointDisplay(graph, edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target);
+
+        var sb = new StringBuilder();
+        sb.Append(source).Append("  --").Append(KindLabel(edge.Edge.Kind)).Append("-->  ").Append(targetDisplay);
+
+        string flags = Flags(edge);
+        if (flags.Length > 0)
+            sb.Append("  ").Append(flags);
+
+        sb.Append("  ").Append(FormatScore(edge.Score)).Append(" (").Append(edge.Band).Append(')');
+        return sb.ToString();
+    }
+
+    // The honesty flags — NEVER omit a fired flag, or a reduced-confidence link reads as certain.
+    private static string Flags(ScoredEdge edge)
+    {
+        var parts = new List<string>(2);
+        if (edge.HasAmbiguousName)
+            parts.Add("[ambiguous]");
+        if (edge.IsVerbUnknown)
+            parts.Add("[verb-unknown]");
+        return string.Join(' ', parts);
+    }
+
+    // The display label for one endpoint: prefer the resolved node's Display (leaf type / table / route), else the
+    // EdgeRef's own Display (the raw ref text the leg recorded).
+    private static string EndpointDisplay(BridgeGraph graph, EdgeRef edgeRef, BridgeKind kind, EndpointSide side)
+    {
+        string? nodeId = BridgeGraph.NodeIdOf(edgeRef, kind, side);
+        if (nodeId is not null)
+        {
+            var node = graph.Node(nodeId);
+            if (node is not null && !string.IsNullOrWhiteSpace(node.Display))
+                return node.Display;
+        }
+        return string.IsNullOrWhiteSpace(edgeRef.Display) ? "?" : edgeRef.Display;
+    }
+
+    // The human label for a bridge kind, matching the design's vocabulary (name/CreateMap/DbSet/route/responds/consumes).
+    internal static string KindLabel(BridgeKind kind) => kind switch
+    {
+        BridgeKind.StoredIn => "DbSet",
+        BridgeKind.MapsTo => "CreateMap",
+        BridgeKind.Hits => "route",
+        BridgeKind.Responds => "responds",
+        BridgeKind.Consumes => "consumes",
+        BridgeKind.NameMatch => "name",
+        _ => kind.ToString().ToLowerInvariant(),
+    };
+
+    // The firing signals behind a bridge link (full format only): "    signals: Rule=Value, ...".
+    private static void AppendSignals(StringBuilder sb, ScoredEdge edge)
+    {
+        var signals = edge.Edge.Signals;
+        if (signals is null || signals.Count == 0)
+        {
+            sb.Append("    signals: (none)\n");
+            return;
+        }
+        sb.Append("    signals: ");
+        for (int i = 0; i < signals.Count; i++)
+        {
+            if (i > 0)
+                sb.Append(", ");
+            sb.Append(SignalLabel(signals[i]));
+        }
+        sb.Append('\n');
+    }
+
+    // A signal rendered with its typed payload — enough to see WHY the edge scored as it did. The Signal hierarchy is
+    // a closed set of sealed subtypes (Signal.cs); switch on the concrete type to surface the load-bearing payload
+    // (a structural breadcrumb's present/absent, a field-set's count+Jaccard, a name match's tier, a resolution status).
+    private static string SignalLabel(Signal signal) => signal switch
+    {
+        StructuralSignal s => $"{s.Rule}={(s.Present ? "present" : "absent")}",
+        FieldSetSignal s =>
+            $"FieldSetJaccard(count={s.FieldCount}, jaccard={s.Jaccard.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)})",
+        NameSignal s => $"NameMatch={s.Tier}",
+        NameResolutionSignal s => $"NameResolution({s.Endpoint}={s.Status}, matches={s.MatchCount})",
+        _ => signal.Rule.ToString(),
+    };
+
+    // A stable, culture-invariant 2-decimal score so the rendered text (and its tests) are deterministic.
+    private static string FormatScore(double score) =>
+        score.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+
+    // ---------- shared target resolution ----------
+
+    /// <summary>
+    /// Smart-resolve <paramref name="target"/> to a single symbol id. Returns true with <paramref name="symbolId"/>
+    /// set on a unique symbol resolution; false with a rendered <paramref name="note"/> on a file / ambiguous /
+    /// not-found resolution (trace is a symbol-anchored walk — a file is not a graph start).
+    /// </summary>
+    private static bool ResolveSymbol(
+        MillerRepositoryIndex index, SmartTargetResolver resolver, string target,
+        out string symbolId, out string? note)
+    {
+        symbolId = string.Empty;
+        note = null;
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            note = "trace: a target symbol is required.";
+            return false;
+        }
+
+        switch (resolver.Resolve(target))
+        {
+            case TargetResolution.Symbol sym:
+                symbolId = sym.Value.SymbolId;
+                return true;
+
+            case TargetResolution.File:
+                note = $"'{target}' is a file. trace starts from a single symbol — pass a symbol name or id.";
+                return false;
+
+            case TargetResolution.Candidates cands:
+                note = RenderCandidatesNote(cands.Matches);
+                return false;
+
+            case TargetResolution.NotFound nf:
+                note = $"'{nf.Target}' not found. Try search to locate it.";
+                return false;
+
+            default:
+                note = "trace: unrecognized target resolution.";
+                return false;
+        }
+    }
+
+    private static string RenderCandidatesNote(IReadOnlyList<IndexedSymbol> matches)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Multiple candidates — pass a more specific target:\n");
+        foreach (var s in matches)
+            sb.Append(s.Name).Append("  ").Append(s.Kind).Append("  ")
+              .Append(s.FilePath).Append(':').Append(s.StartLine).Append('\n');
+        return sb.ToString().TrimEnd('\n');
+    }
+}

--- a/tests/Miller.Tests/Contracts/TestRoleTests.cs
+++ b/tests/Miller.Tests/Contracts/TestRoleTests.cs
@@ -1,0 +1,51 @@
+using Miller.Core.Contracts;
+using Xunit;
+
+namespace Miller.Tests.Contracts;
+
+/// <summary>
+/// Pins <see cref="TestRole.IsTest"/> — the single predicate M4 uses to exclude test-role HttpClient url literals from
+/// the route bridge. Verified against julie's <c>TestRole</c> enum (<c>julie-extractors/src/base/kinds.rs</c>): the
+/// variants are exactly <c>test_case</c>, <c>parameterized_test</c>, <c>fixture_setup</c>, <c>fixture_teardown</c>,
+/// <c>test_container</c>, and julie writes a role ONLY for test symbols. So every present role is a test role; the
+/// predicate is "has a non-blank role", NOT a "contains test" substring (which would wrongly drop the fixture roles).
+/// </summary>
+public sealed class TestRoleTests
+{
+    [Theory]
+    // The full verified julie role vocabulary (kinds.rs as_str) — all are test code.
+    [InlineData("test_case")]
+    [InlineData("parameterized_test")]
+    [InlineData("fixture_setup")]       // would be missed by a naive "contains test" substring
+    [InlineData("fixture_teardown")]    // would be missed by a naive "contains test" substring
+    [InlineData("test_container")]
+    public void IsTest_TrueForEveryJulieRole(string role)
+    {
+        Assert.True(new TestRole(role).IsTest);
+    }
+
+    [Theory]
+    // A future role julie might add is still a test role (julie only writes the field for test symbols).
+    [InlineData("some_future_role")]
+    [InlineData("mock_setup")]
+    public void IsTest_TrueForAnyPresentRole(string role)
+    {
+        Assert.True(new TestRole(role).IsTest);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsTest_FalseForBlankValue(string role)
+    {
+        // Defensive: a blank role is not a test signal (julie never writes one; a null TestRole models absence).
+        Assert.False(new TestRole(role).IsTest);
+    }
+
+    [Fact]
+    public void Value_IsCarriedVerbatim()
+    {
+        // The contract preserves julie's raw role string (not mapped to a C# enum), so unknown future roles survive.
+        Assert.Equal("fixture_setup", new TestRole("fixture_setup").Value);
+    }
+}

--- a/tests/Miller.Tests/Graph/BridgeGraphBuilderTests.cs
+++ b/tests/Miller.Tests/Graph/BridgeGraphBuilderTests.cs
@@ -1,0 +1,301 @@
+using Miller.Core.Contracts;
+using Miller.Core.Graph;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Graph;
+
+/// <summary>
+/// Tests for <see cref="BridgeGraphBuilder"/> (plan Task 8): the per-leg reductions (CreateMap grouping with ordinal
+/// direction, controller-endpoint reduction with the [FromBody] honesty guard, TsClientCall reduction) plus the
+/// end-to-end run legs to scorer to graph. Pure, in-memory fixtures; no DB.
+///
+/// <para>Every fixture uses ONLY the verified lean contracts:
+/// <c>TypeArgument(IdentifierId, Ordinal, ParentArgId, TypeName, FilePath)</c> and
+/// <c>SymbolDetail(Id, Name, Kind, FilePath, Signature, Namespace, TestRole, ParentClassName)</c>. The endpoint
+/// class <c>[Route]</c> join is by <see cref="SymbolDetail.ParentClassName"/> (the contract carries no parent symbol
+/// id), and the Dapper-FROM secondary anchor is not expressible (the contract carries no per-arg containing-symbol id
+/// or span), so the entity-table edge here is exercised via the <c>DbSet&lt;T&gt;</c> PRIMARY breadcrumb.</para>
+/// </summary>
+public sealed class BridgeGraphBuilderTests
+{
+    private static SymbolDetail Type(string id, string name, string kind = "class", string? ns = null, string file = "src/X.cs") =>
+        new(id, name, kind, file, Signature: name, Namespace: ns, TestRole: null, ParentClassName: null);
+
+    private static SymbolDetail Method(string id, string name, string signature, string parentClassName, string file) =>
+        new(id, name, "method", file, signature, Namespace: "Api.Controllers", TestRole: null, ParentClassName: parentClassName);
+
+    private static TypeArgument Arg(string identifierId, int ordinal, string typeName, string file = "src/Profile.cs") =>
+        new(IdentifierId: identifierId, Ordinal: ordinal, ParentArgId: null, TypeName: typeName, FilePath: file);
+
+    private static DbSetProperty DbSet(string table, string entity, string file = "src/Db.cs", int line = 10) =>
+        new("prop:" + table, table, entity, file, line);
+
+    [Fact]
+    public void CreateMap_chain_resolves_UserDto_to_ApplicationUser_to_table_with_High_edges()
+    {
+        var symbols = new List<SymbolDetail>
+        {
+            Type("sym-userdto", "UserDto", "class", "Api.Dtos", "src/Dtos/UserDto.cs"),
+            Type("sym-appuser", "ApplicationUser", "class", "Domain", "src/Domain/User.cs"),
+        };
+
+        var typeArgs = new List<TypeArgument>
+        {
+            Arg("cm1", 0, "UserDto"),
+            Arg("cm1", 1, "ApplicationUser"),
+        };
+
+        var dbSets = new List<DbSetProperty> { DbSet("ApplicationUsers", "ApplicationUser") };
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArgs, literals: [], annotations: [], dbSetProperties: dbSets);
+
+        var fromDto = graph.Walk("sym-userdto", maxDepth: 5);
+        Assert.Contains(fromDto, e => e.Edge.Kind == BridgeKind.MapsTo && e.Band == ConfidenceBand.High);
+
+        var fromEntity = graph.Walk("sym-appuser", maxDepth: 5);
+        Assert.Contains(fromEntity, e => e.Edge.Kind == BridgeKind.StoredIn && e.Band == ConfidenceBand.High);
+
+        Assert.Equal(2, graph.Walk("sym-userdto", maxDepth: 5).Count);
+    }
+
+    [Fact]
+    public void CreateMap_edge_direction_is_source_to_dest_not_flipped()
+    {
+        var symbols = new List<SymbolDetail>
+        {
+            Type("sym-req", "CreateOrderRequest", "class", "Api.Requests"),
+            Type("sym-order", "Order", "class", "Domain"),
+        };
+
+        var typeArgs = new List<TypeArgument>
+        {
+            Arg("cm1", 0, "CreateOrderRequest"),
+            Arg("cm1", 1, "Order"),
+        };
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArgs, [], [], []);
+
+        var edge = graph.Incident("sym-req").Single(e => e.Edge.Kind == BridgeKind.MapsTo);
+        Assert.Equal("sym-req", edge.Edge.SourceRef.SymbolId);
+        Assert.Equal("sym-order", edge.Edge.TargetRef.SymbolId);
+    }
+
+    [Fact]
+    public void CreateMap_ignores_nested_generic_args_and_partial_and_oversized_groups()
+    {
+        var symbols = new List<SymbolDetail>
+        {
+            Type("sym-a", "A"),
+            Type("sym-b", "B"),
+        };
+
+        var typeArgs = new List<TypeArgument>
+        {
+            Arg("cm1", 0, "A"),
+            Arg("cm1", 1, "B"),
+            new(IdentifierId: "cm1", Ordinal: 0, ParentArgId: "outer", TypeName: "Nested", FilePath: "src/Profile.cs"),
+            Arg("cm2", 0, "OnlySource"),
+            Arg("cm3", 0, "K"),
+            Arg("cm3", 1, "V"),
+            Arg("cm3", 2, "W"),
+        };
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArgs, [], [], []);
+
+        Assert.Single(graph.Incident("sym-a"), e => e.Edge.Kind == BridgeKind.MapsTo);
+    }
+
+    [Fact]
+    public void Ambiguous_entity_name_yields_no_High_edge()
+    {
+        var symbols = new List<SymbolDetail>
+        {
+            Type("sym-userdto", "UserDto", "class", "Api.Dtos", "api/Dtos/UserDto.cs"),
+            Type("sym-appuser-1", "ApplicationUser", "class", "Domain.A", "domainA/User.cs"),
+            Type("sym-appuser-2", "ApplicationUser", "class", "Domain.B", "domainB/User.cs"),
+        };
+
+        var typeArgs = new List<TypeArgument>
+        {
+            Arg("cm1", 0, "UserDto", "shared/Profile.cs"),
+            Arg("cm1", 1, "ApplicationUser", "shared/Profile.cs"),
+        };
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArgs, [], [], []);
+
+        var dtoEdges = graph.Incident("sym-userdto");
+        Assert.All(dtoEdges, e => Assert.NotEqual(ConfidenceBand.High, e.Band));
+    }
+
+    [Fact]
+    public void DbSet_property_resolves_an_entity_to_table_StoredIn_edge()
+    {
+        var symbols = new List<SymbolDetail> { Type("sym-appsetting", "AppSetting", "class", "Domain") };
+        var dbSets = new List<DbSetProperty> { DbSet("AppSettings", "AppSetting") };
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArguments: [], literals: [], annotations: [], dbSetProperties: dbSets);
+
+        Assert.Contains(graph.Incident("sym-appsetting"), e => e.Edge.Kind == BridgeKind.StoredIn);
+    }
+
+    [Fact]
+    public void DbSet_entity_is_taken_from_the_generic_arg_not_the_property_name()
+    {
+        var symbols = new List<SymbolDetail>
+        {
+            Type("sym-appsetting", "AppSetting", "class", "Domain"),
+            Type("sym-plural", "AppSettings", "class", "Domain"),
+        };
+        var dbSets = new List<DbSetProperty> { DbSet("AppSettings", "AppSetting") };
+
+        var graph = BridgeGraphBuilder.Build(symbols, [], [], [], dbSets);
+
+        Assert.Contains(graph.Incident("sym-appsetting"), e => e.Edge.Kind == BridgeKind.StoredIn);
+        Assert.DoesNotContain(graph.Incident("sym-plural"), e => e.Edge.Kind == BridgeKind.StoredIn);
+    }
+
+    [Fact]
+    public void Controller_endpoint_reduction_builds_the_expanded_route_and_hits_edge()
+    {
+        var classSym = Type("sym-class", "AppSettingsController", "class", "Api.Controllers", "api/AppSettingsController.cs");
+        var methodSym = Method("sym-get", "Get", "Task<ActionResult<AppSetting>> Get(int id)",
+            "AppSettingsController", "api/AppSettingsController.cs");
+        var dto = Type("sym-appsetting", "AppSetting", "class", "Domain");
+        var tsFn = Type("sym-tsfn", "fetchAppSetting", "function", file: "web/api.ts");
+
+        var symbols = new List<SymbolDetail> { classSym, methodSym, dto, tsFn };
+
+        var annotations = new List<SymbolAnnotation>
+        {
+            new(SymbolId: "sym-class", Ordinal: 0, Annotation: "Route", AnnotationKey: "route",
+                RawText: "Route(\"api/[controller]\")", Carrier: "Route"),
+            new(SymbolId: "sym-get", Ordinal: 0, Annotation: "HttpGet", AnnotationKey: "httpget",
+                RawText: "HttpGet(\"{id}\")", Carrier: "HttpGet"),
+        };
+
+        var literal = MakeLiteral("/api/appsettings/{}", kind: "url", language: "typescript",
+            carrier: "axios.get", containingSymbolId: "sym-tsfn", spanStart: 0);
+
+        var graph = BridgeGraphBuilder.Build(symbols, typeArguments: [], literals: [literal], annotations: annotations, dbSetProperties: []);
+
+        var endpointEdges = graph.Incident("sym-get");
+        Assert.Contains(endpointEdges, e => e.Edge.Kind == BridgeKind.Hits && e.Band == ConfidenceBand.High);
+        Assert.Contains(endpointEdges, e => e.Edge.Kind == BridgeKind.Responds);
+    }
+
+    [Fact]
+    public void FromBody_honesty_a_route_primitive_param_does_not_produce_a_Consumes_edge()
+    {
+        var classSym = Type("sym-class", "ItemsController", "class", "Api.Controllers", "api/ItemsController.cs");
+        var methodSym = Method("sym-get", "GetById", "Task<ActionResult<Item>> GetById(int id)",
+            "ItemsController", "api/ItemsController.cs");
+        var dto = Type("sym-item", "Item", "class", "Domain");
+
+        var symbols = new List<SymbolDetail> { classSym, methodSym, dto };
+
+        var annotations = new List<SymbolAnnotation>
+        {
+            new("sym-class", 0, "Route", "route", "Route(\"api/[controller]\")", "Route"),
+            new("sym-get", 0, "HttpGet", "httpget", "HttpGet(\"{id}\")", "HttpGet"),
+        };
+
+        var graph = BridgeGraphBuilder.Build(symbols, [], [], annotations, []);
+
+        Assert.DoesNotContain(graph.Incident("sym-get"), e => e.Edge.Kind == BridgeKind.Consumes);
+    }
+
+    [Fact]
+    public void FromBody_a_complex_param_on_a_POST_produces_a_Consumes_edge()
+    {
+        var classSym = Type("sym-class", "ItemsController", "class", "Api.Controllers", "api/ItemsController.cs");
+        var methodSym = Method("sym-post", "Create", "Task<ActionResult<Item>> Create(CreateItemRequest request)",
+            "ItemsController", "api/ItemsController.cs");
+        var dto = Type("sym-item", "Item", "class", "Domain");
+        var req = Type("sym-req", "CreateItemRequest", "class", "Api.Requests");
+
+        var symbols = new List<SymbolDetail> { classSym, methodSym, dto, req };
+
+        var annotations = new List<SymbolAnnotation>
+        {
+            new("sym-class", 0, "Route", "route", "Route(\"api/[controller]\")", "Route"),
+            new("sym-post", 0, "HttpPost", "httppost", "HttpPost", "HttpPost"),
+        };
+
+        var graph = BridgeGraphBuilder.Build(symbols, [], [], annotations, []);
+
+        var consumes = graph.Incident("sym-post").Single(e => e.Edge.Kind == BridgeKind.Consumes);
+        Assert.Equal("sym-req", consumes.Edge.TargetRef.SymbolId);
+    }
+
+    [Fact]
+    public void Csharp_test_httpclient_literal_does_not_produce_a_hits_edge()
+    {
+        var classSym = Type("sym-class", "AppSettingsController", "class", "Api.Controllers", "api/AppSettingsController.cs");
+        var methodSym = Method("sym-get", "Get", "Task<ActionResult<AppSetting>> Get()",
+            "AppSettingsController", "api/AppSettingsController.cs");
+        var dto = Type("sym-appsetting", "AppSetting", "class", "Domain");
+        var symbols = new List<SymbolDetail> { classSym, methodSym, dto };
+
+        var annotations = new List<SymbolAnnotation>
+        {
+            new("sym-class", 0, "Route", "route", "Route(\"api/[controller]\")", "Route"),
+            new("sym-get", 0, "HttpGet", "httpget", "HttpGet", "HttpGet"),
+        };
+
+        var literal = MakeLiteral("/api/appsettings", kind: "url", language: "csharp",
+            carrier: "GetAsync", containingSymbolId: "sym-test", spanStart: 0);
+
+        var graph = BridgeGraphBuilder.Build(symbols, [], [literal], annotations, []);
+
+        Assert.DoesNotContain(graph.Incident("sym-get"), e => e.Edge.Kind == BridgeKind.Hits);
+    }
+
+    [Fact]
+    public void Builder_accepts_a_reader_supplied_literal_site_lookup()
+    {
+        var classSym = Type("sym-class", "AppSettingsController", "class", "Api.Controllers", "api/AppSettingsController.cs");
+        var methodSym = Method("sym-get", "Get", "Task<ActionResult<AppSetting>> Get()",
+            "AppSettingsController", "api/AppSettingsController.cs");
+        var dto = Type("sym-appsetting", "AppSetting", "class", "Domain");
+        var tsFn = Type("sym-tsfn", "fetchAppSettings", "function", file: "web/api.ts");
+        var symbols = new List<SymbolDetail> { classSym, methodSym, dto, tsFn };
+
+        var annotations = new List<SymbolAnnotation>
+        {
+            new("sym-class", 0, "Route", "route", "Route(\"api/[controller]\")", "Route"),
+            new("sym-get", 0, "HttpGet", "httpget", "HttpGet", "HttpGet"),
+        };
+
+        var literal = MakeLiteral("/api/appsettings", kind: "url", language: "typescript",
+            carrier: "axios.get", containingSymbolId: "sym-tsfn", spanStart: 0);
+
+        var sites = new Dictionary<LiteralRecord, LiteralSite> { [literal] = new("web/api.ts", 42) };
+
+        var graph = BridgeGraphBuilder.Build(symbols, [], [literal], annotations, [], sites);
+
+        Assert.Contains(graph.Incident("sym-get"), e => e.Edge.Kind == BridgeKind.Hits);
+    }
+
+    [Fact]
+    public void Build_null_collections_throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => BridgeGraphBuilder.Build(null!, [], [], [], []));
+        Assert.Throws<ArgumentNullException>(() => BridgeGraphBuilder.Build([], null!, [], [], []));
+        Assert.Throws<ArgumentNullException>(() => BridgeGraphBuilder.Build([], [], null!, [], []));
+        Assert.Throws<ArgumentNullException>(() => BridgeGraphBuilder.Build([], [], [], null!, []));
+        Assert.Throws<ArgumentNullException>(() => BridgeGraphBuilder.Build([], [], [], [], null!));
+    }
+
+    private static LiteralRecord MakeLiteral(
+        string text, string kind, string language = "csharp", string carrier = "axios.get",
+        string containingSymbolId = "sym", int spanStart = 0)
+        => new(
+            LiteralText: text,
+            Kind: kind,
+            Carrier: carrier,
+            ArgPosition: 0,
+            Language: language,
+            ContainingSymbolId: containingSymbolId,
+            Span: new SourceSpan(spanStart, spanStart + text.Length));
+}

--- a/tests/Miller.Tests/Graph/BridgeGraphTests.cs
+++ b/tests/Miller.Tests/Graph/BridgeGraphTests.cs
@@ -1,0 +1,185 @@
+using Miller.Core.Contracts;
+using Miller.Core.Graph;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Graph;
+
+/// <summary>
+/// Tests for <see cref="BridgeGraph"/> (plan Task 8): immutable undirected adjacency over <see cref="ScoredEdge"/>s, a
+/// deterministic BFS <see cref="BridgeGraph.Walk"/> with reach-order, depth-bounded, de-duplicated edges, and node
+/// connectivity across a multi-leg chain. Built from synthetic scored edges so the graph is tested in isolation from
+/// the legs/scorer.
+/// </summary>
+public sealed class BridgeGraphTests
+{
+    // A symbol-backed edge endpoint (its node id IS the symbol id).
+    private static EdgeRef Sym(string symbolId, string display) =>
+        new(display, symbolId, $"{display}.cs", new NameResolution(ResolutionStatus.Resolved, symbolId, 1));
+
+    // A non-symbol edge endpoint (its node id is synthesized from kind + display).
+    private static EdgeRef NonSym(string display) =>
+        new(display, SymbolId: null, FilePath: null, new NameResolution(ResolutionStatus.Resolved, null, 1));
+
+    private static ScoredEdge Edge(BridgeKind kind, EdgeRef source, EdgeRef target, double score = 0.95)
+    {
+        var candidate = new CandidateEdge(
+            kind, source, target,
+            Evidence: [],
+            Signals: [new StructuralSignal(StructuralRuleFor(kind), Present: true)]);
+        return new ScoredEdge(candidate, score, ConfidenceBand.High, IsMultiSignal: false, HasAmbiguousName: false, IsVerbUnknown: false);
+    }
+
+    private static SignalRule StructuralRuleFor(BridgeKind kind) => kind switch
+    {
+        BridgeKind.MapsTo => SignalRule.CreateMap,
+        BridgeKind.StoredIn => SignalRule.DbSetProperty,
+        BridgeKind.Hits => SignalRule.RouteVerbMatch,
+        BridgeKind.Responds => SignalRule.ReturnTypeDto,
+        BridgeKind.Consumes => SignalRule.FromBodyDto,
+        _ => SignalRule.NameMatch,
+    };
+
+    private static IReadOnlyDictionary<string, BridgeNode> NodesFor(params ScoredEdge[] edges)
+    {
+        var nodes = new Dictionary<string, BridgeNode>(StringComparer.Ordinal);
+        foreach (var edge in edges)
+        {
+            AddNode(nodes, edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source);
+            AddNode(nodes, edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target);
+        }
+        return nodes;
+    }
+
+    private static void AddNode(Dictionary<string, BridgeNode> nodes, EdgeRef edgeRef, BridgeKind kind, EndpointSide side)
+    {
+        var id = BridgeGraph.NodeIdOf(edgeRef, kind, side);
+        if (id is null || nodes.ContainsKey(id))
+            return;
+        nodes[id] = new BridgeNode(id, BridgeGraph.NodeKindFor(kind, side), edgeRef.Display, edgeRef.FilePath, 0);
+    }
+
+    // The data-model chain: UserDto --MapsTo--> ApplicationUser --StoredIn--> ApplicationUsers (table).
+    private static (BridgeGraph Graph, string DtoId, string EntityId, string TableId) BuildChain()
+    {
+        var dto = Sym("sym-userdto", "UserDto");
+        var entity = Sym("sym-appuser", "ApplicationUser");
+        var entityAsSource = Sym("sym-appuser", "ApplicationUser");
+        var table = NonSym("ApplicationUsers");
+
+        var mapEdge = Edge(BridgeKind.MapsTo, dto, entity, 0.95);
+        var tableEdge = Edge(BridgeKind.StoredIn, entityAsSource, table, 0.97);
+
+        var nodes = NodesFor(mapEdge, tableEdge);
+        var graph = BridgeGraph.Build([mapEdge, tableEdge], nodes);
+
+        var tableId = BridgeGraph.NodeIdOf(table, BridgeKind.StoredIn, EndpointSide.Target)!;
+        return (graph, "sym-userdto", "sym-appuser", tableId);
+    }
+
+    [Fact]
+    public void Build_registers_every_endpoint_node_and_drops_edges_with_unknown_endpoints()
+    {
+        var (graph, dtoId, entityId, tableId) = BuildChain();
+
+        Assert.True(graph.Contains(dtoId));
+        Assert.True(graph.Contains(entityId));
+        Assert.True(graph.Contains(tableId));
+        Assert.False(graph.Contains("nope"));
+    }
+
+    [Fact]
+    public void Build_drops_an_edge_whose_endpoint_is_absent_from_the_node_lookup()
+    {
+        var dto = Sym("sym-userdto", "UserDto");
+        var entity = Sym("sym-appuser", "ApplicationUser");
+        var edge = Edge(BridgeKind.MapsTo, dto, entity);
+
+        // Node lookup deliberately omits the entity node -> the edge cannot connect and is dropped.
+        var partialNodes = new Dictionary<string, BridgeNode>(StringComparer.Ordinal)
+        {
+            ["sym-userdto"] = new("sym-userdto", BridgeNodeKind.CsDto, "UserDto", "UserDto.cs", 0),
+        };
+
+        var graph = BridgeGraph.Build([edge], partialNodes);
+
+        Assert.Empty(graph.Incident("sym-userdto"));
+        Assert.Empty(graph.Walk("sym-userdto", maxDepth: 5));
+    }
+
+    [Fact]
+    public void Walk_reaches_the_whole_chain_in_reach_order()
+    {
+        var (graph, dtoId, _, _) = BuildChain();
+
+        var walked = graph.Walk(dtoId, maxDepth: 5);
+
+        // Two edges traversed: MapsTo (hop 1 from the DTO) then StoredIn (hop 2 via the entity).
+        Assert.Equal(2, walked.Count);
+        Assert.Equal(BridgeKind.MapsTo, walked[0].Edge.Kind);
+        Assert.Equal(BridgeKind.StoredIn, walked[1].Edge.Kind);
+    }
+
+    [Fact]
+    public void Walk_respects_maxDepth()
+    {
+        var (graph, dtoId, _, _) = BuildChain();
+
+        var oneHop = graph.Walk(dtoId, maxDepth: 1);
+
+        // Only the first edge (DTO -> entity) is within one hop; the entity -> table edge is at depth 2.
+        Assert.Single(oneHop);
+        Assert.Equal(BridgeKind.MapsTo, oneHop[0].Edge.Kind);
+    }
+
+    [Fact]
+    public void Walk_from_the_table_end_reaches_back_to_the_dto_undirected()
+    {
+        var (graph, _, _, tableId) = BuildChain();
+
+        var walked = graph.Walk(tableId, maxDepth: 5);
+
+        Assert.Equal(2, walked.Count);
+        Assert.Equal(BridgeKind.StoredIn, walked[0].Edge.Kind); // nearest to the table
+        Assert.Equal(BridgeKind.MapsTo, walked[1].Edge.Kind);
+    }
+
+    [Fact]
+    public void Walk_deduplicates_an_edge_even_when_both_endpoints_are_reached()
+    {
+        // A triangle: a -> b, b -> c, a -> c. Walking from a must emit each of the 3 edges exactly once.
+        var a = Sym("a", "A");
+        var b = Sym("b", "B");
+        var c = Sym("c", "C");
+        var ab = Edge(BridgeKind.MapsTo, a, b);
+        var bc = Edge(BridgeKind.MapsTo, b, c);
+        var ac = Edge(BridgeKind.MapsTo, a, c);
+
+        var graph = BridgeGraph.Build([ab, bc, ac], NodesFor(ab, bc, ac));
+
+        var walked = graph.Walk("a", maxDepth: 5);
+
+        Assert.Equal(3, walked.Count);
+        Assert.Equal(3, walked.Select(e => $"{e.Edge.SourceRef.SymbolId}->{e.Edge.TargetRef.SymbolId}").Distinct().Count());
+    }
+
+    [Fact]
+    public void Walk_returns_empty_for_an_unknown_start_or_nonpositive_depth()
+    {
+        var (graph, dtoId, _, _) = BuildChain();
+
+        Assert.Empty(graph.Walk("unknown", maxDepth: 5));
+        Assert.Empty(graph.Walk(dtoId, maxDepth: 0));
+    }
+
+    [Fact]
+    public void Build_preserves_the_scored_edge_score_and_band_verbatim()
+    {
+        var (graph, dtoId, _, _) = BuildChain();
+
+        var mapEdge = graph.Incident(dtoId).Single();
+
+        Assert.Equal(0.95, mapEdge.Score, precision: 5);
+        Assert.Equal(ConfidenceBand.High, mapEdge.Band);
+    }
+}

--- a/tests/Miller.Tests/Graph/SymbolGraphShortestPathTests.cs
+++ b/tests/Miller.Tests/Graph/SymbolGraphShortestPathTests.cs
@@ -1,0 +1,120 @@
+using Miller.Core.Graph;
+using Xunit;
+
+namespace Miller.Tests.Graph;
+
+/// <summary>
+/// Tests for <see cref="SymbolGraph.ShortestPath"/> (plan Task 8): BFS + parent reconstruction over the forward
+/// (dependency) adjacency, deterministic id-sorted tie-break consistent with <see cref="SymbolGraph.Reach"/>, null on
+/// an unreachable goal / missing endpoint / depth cut-off.
+/// </summary>
+public sealed class SymbolGraphShortestPathTests
+{
+    private static GraphNode N(string id) => new(id, IsTest: false);
+    private static GraphEdge E(string from, string to) => new(from, to, "calls");
+
+    [Fact]
+    public void ShortestPath_returns_ordered_ids_along_the_chain()
+    {
+        // a -> b -> c -> d (a linear dependency chain)
+        var graph = SymbolGraph.Build(
+            [N("a"), N("b"), N("c"), N("d")],
+            [E("a", "b"), E("b", "c"), E("c", "d")]);
+
+        var path = graph.ShortestPath("a", "d", maxDepth: 10);
+
+        Assert.NotNull(path);
+        Assert.Equal(["a", "b", "c", "d"], path);
+    }
+
+    [Fact]
+    public void ShortestPath_picks_the_fewest_hops_when_a_shortcut_exists()
+    {
+        // a -> b -> c -> d AND a -> d (direct). Shortest is the 1-hop direct edge.
+        var graph = SymbolGraph.Build(
+            [N("a"), N("b"), N("c"), N("d")],
+            [E("a", "b"), E("b", "c"), E("c", "d"), E("a", "d")]);
+
+        var path = graph.ShortestPath("a", "d", maxDepth: 10);
+
+        Assert.Equal(["a", "d"], path);
+    }
+
+    [Fact]
+    public void ShortestPath_same_node_yields_single_node_path_even_at_zero_depth()
+    {
+        var graph = SymbolGraph.Build([N("a")], []);
+
+        Assert.Equal(["a"], graph.ShortestPath("a", "a", maxDepth: 0));
+        Assert.Equal(["a"], graph.ShortestPath("a", "a", maxDepth: 5));
+    }
+
+    [Fact]
+    public void ShortestPath_returns_null_when_goal_is_unreachable()
+    {
+        // a -> b ; c isolated. No path a -> c.
+        var graph = SymbolGraph.Build(
+            [N("a"), N("b"), N("c")],
+            [E("a", "b")]);
+
+        Assert.Null(graph.ShortestPath("a", "c", maxDepth: 10));
+    }
+
+    [Fact]
+    public void ShortestPath_respects_the_reverse_direction_of_an_edge()
+    {
+        // Forward adjacency is a -> b only; b does NOT reach a.
+        var graph = SymbolGraph.Build([N("a"), N("b")], [E("a", "b")]);
+
+        Assert.Equal(["a", "b"], graph.ShortestPath("a", "b", maxDepth: 5));
+        Assert.Null(graph.ShortestPath("b", "a", maxDepth: 5));
+    }
+
+    [Fact]
+    public void ShortestPath_returns_null_when_the_goal_is_beyond_maxDepth()
+    {
+        // a -> b -> c -> d needs 3 hops; a depth cap of 2 cannot reach d.
+        var graph = SymbolGraph.Build(
+            [N("a"), N("b"), N("c"), N("d")],
+            [E("a", "b"), E("b", "c"), E("c", "d")]);
+
+        Assert.Null(graph.ShortestPath("a", "d", maxDepth: 2));
+        Assert.Equal(["a", "b", "c", "d"], graph.ShortestPath("a", "d", maxDepth: 3));
+    }
+
+    [Fact]
+    public void ShortestPath_returns_null_when_an_endpoint_is_not_in_the_graph()
+    {
+        var graph = SymbolGraph.Build([N("a"), N("b")], [E("a", "b")]);
+
+        Assert.Null(graph.ShortestPath("a", "zzz", maxDepth: 5)); // unknown goal
+        Assert.Null(graph.ShortestPath("zzz", "b", maxDepth: 5)); // unknown start
+    }
+
+    [Fact]
+    public void ShortestPath_tie_break_is_deterministic_by_neighbour_id()
+    {
+        // Two equal-length 2-hop paths to "z": via "m" and via "p". BFS visits neighbours of "a" in id order
+        // (m before p), so the parent of "z" is set from "m" first — the path goes a -> m -> z.
+        var graph = SymbolGraph.Build(
+            [N("a"), N("m"), N("p"), N("z")],
+            [E("a", "p"), E("a", "m"), E("m", "z"), E("p", "z")]);
+
+        var path = graph.ShortestPath("a", "z", maxDepth: 5);
+
+        Assert.Equal(["a", "m", "z"], path);
+    }
+
+    [Fact]
+    public void ShortestPath_terminates_and_is_correct_on_a_cycle()
+    {
+        // a -> b -> c -> a (cycle) plus c -> d. Visited tracking must terminate; a -> d is 3 hops.
+        var graph = SymbolGraph.Build(
+            [N("a"), N("b"), N("c"), N("d")],
+            [E("a", "b"), E("b", "c"), E("c", "a"), E("c", "d")]);
+
+        var path = graph.ShortestPath("a", "d", maxDepth: 10);
+
+        Assert.Equal(["a", "b", "c", "d"], path);
+    }
+}

--- a/tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs
+++ b/tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs
@@ -17,7 +17,7 @@ public sealed class ExtractReportParsingTests
           "status": "changed", "operation": "update",
           "workspace_id": "ws-abc-123",
           "db_path": "/abs/.miller/symbols.db", "root": "/abs/repo",
-          "schema_version": 26, "schema_state": "current", "extract_contract_version": 1,
+          "schema_version": 28, "schema_state": "current", "extract_contract_version": 2,
           "revision": 7, "analyzed_revision": 6, "analysis_state": "stale",
           "files_scanned": 0, "files_updated": 1, "files_deleted": 0,
           "symbols_extracted": 5, "files_total": 12, "symbols_total": 134,
@@ -32,7 +32,7 @@ public sealed class ExtractReportParsingTests
           "status": "unchanged", "operation": "update",
           "workspace_id": "ws-abc-123",
           "db_path": "/abs/.miller/symbols.db", "root": "/abs/repo",
-          "schema_version": 26, "extract_contract_version": 1,
+          "schema_version": 28, "extract_contract_version": 2,
           "revision": 6, "files_scanned": 0, "files_updated": 0, "files_deleted": 0,
           "symbols_extracted": 0, "files_total": 12, "symbols_total": 134,
           "relationships_total": 40, "identifiers_total": 512, "types_total": 9,
@@ -46,7 +46,7 @@ public sealed class ExtractReportParsingTests
           "status": "deleted", "operation": "delete",
           "workspace_id": "ws-abc-123",
           "db_path": "/abs/.miller/symbols.db", "root": "/abs/repo",
-          "schema_version": 26, "extract_contract_version": 1,
+          "schema_version": 28, "extract_contract_version": 2,
           "revision": 8, "files_scanned": 0, "files_updated": 0, "files_deleted": 1,
           "symbols_extracted": 0, "files_total": 11, "symbols_total": 129,
           "relationships_total": 38, "identifiers_total": 500, "types_total": 9,
@@ -60,7 +60,7 @@ public sealed class ExtractReportParsingTests
           "status": "not_found", "operation": "delete",
           "workspace_id": "ws-abc-123",
           "db_path": "/abs/.miller/symbols.db", "root": "/abs/repo",
-          "schema_version": 26, "extract_contract_version": 1,
+          "schema_version": 28, "extract_contract_version": 2,
           "revision": 8, "files_scanned": 0, "files_updated": 0, "files_deleted": 0,
           "symbols_extracted": 0, "files_total": 11, "symbols_total": 129,
           "relationships_total": 38, "identifiers_total": 500, "types_total": 9,
@@ -73,7 +73,7 @@ public sealed class ExtractReportParsingTests
           "status": "failed", "operation": "update",
           "workspace_id": "ws-abc-123",
           "db_path": "/abs/.miller/symbols.db", "root": "/abs/repo",
-          "schema_version": 26, "extract_contract_version": 1,
+          "schema_version": 28, "extract_contract_version": 2,
           "revision": 6, "files_scanned": 0, "files_updated": 0, "files_deleted": 0,
           "symbols_extracted": 0, "files_total": 12, "symbols_total": 134,
           "relationships_total": 40, "identifiers_total": 512, "types_total": 9,
@@ -141,7 +141,7 @@ public sealed class ExtractReportParsingTests
         // must default gracefully so the existing scan parse path is unaffected.
         const string scanJson = """
             { "status": "scanned", "operation": "scan", "db_path": "/abs/db", "root": "/abs/r",
-              "schema_version": 26, "extract_contract_version": 1,
+              "schema_version": 28, "extract_contract_version": 2,
               "files_scanned": 3, "symbols_extracted": 9, "files_total": 3, "symbols_total": 9,
               "relationships_total": 0, "identifiers_total": 0, "types_total": 0, "errors": [] }
             """;

--- a/tests/Miller.Tests/Indexing/FreshnessReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/FreshnessReaderTests.cs
@@ -25,7 +25,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void LatestRevision_ReturnsMaxForTheWorkspace()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(1, Ws), new Rev(2, Ws), new Rev(3, Ws) });
         using var reader = new FreshnessReader(fx.DbPath);
 
@@ -36,7 +36,7 @@ public sealed class FreshnessReaderTests
     public void LatestRevision_IsScopedByWorkspaceId_DoesNotLeakAcrossWorkspaces()
     {
         // Two workspaces in one DB: each must see only its own MAX, never the other's higher revision.
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(2, Ws), new Rev(9, Other) });
         using var reader = new FreshnessReader(fx.DbPath);
 
@@ -47,7 +47,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void LatestRevision_UnknownWorkspace_ReturnsZero()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(5, Ws) });
         using var reader = new FreshnessReader(fx.DbPath);
 
@@ -59,7 +59,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void LatestRevision_EmptyTable_ReturnsZero()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws); // no revision rows
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws); // no revision rows
         using var reader = new FreshnessReader(fx.DbPath);
 
         Assert.Equal(0, reader.LatestRevision(Ws));
@@ -68,7 +68,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void ChangedSince_ReturnsOnlyRowsAfterTheGivenRevision_ForTheWorkspace()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(1, Ws), new Rev(2, Ws), new Rev(3, Ws) },
             fileChanges: new[]
             {
@@ -90,7 +90,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void ChangedSince_AtLatestRevision_ReturnsEmpty()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(1, Ws), new Rev(2, Ws) },
             fileChanges: new[] { new Fc(1, Ws, "a.cs", "added"), new Fc(2, Ws, "b.cs", "modified") });
         using var reader = new FreshnessReader(fx.DbPath);
@@ -101,7 +101,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void ChangedSince_ParsesAllThreeChangeKinds()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(1, Ws) },
             fileChanges: new[]
             {
@@ -125,7 +125,7 @@ public sealed class FreshnessReaderTests
         // Mode=ReadOnly connection with NO open explicit transaction. A separate writer connection commits a
         // brand-new revision row; the reader's NEXT LatestRevision call on its EXISTING connection observes the
         // bump. If the reader pinned a transaction snapshot (or required a reopen), this would still read 1.
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws,
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws,
             revisions: new[] { new Rev(1, Ws) });
         using var reader = new FreshnessReader(fx.DbPath);
 
@@ -161,7 +161,7 @@ public sealed class FreshnessReaderTests
     [Fact]
     public void LatestRevision_NullWorkspaceId_Throws()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoSymbols, workspaceId: Ws);
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, NoSymbols, workspaceId: Ws);
         using var reader = new FreshnessReader(fx.DbPath);
         Assert.Throws<ArgumentNullException>(() => reader.LatestRevision(null!));
     }

--- a/tests/Miller.Tests/Indexing/JulieDbFixture.cs
+++ b/tests/Miller.Tests/Indexing/JulieDbFixture.cs
@@ -206,6 +206,13 @@ internal sealed class JulieDbFixture : IDisposable
             // symbols/identifiers only) so a FreshnessReader can open against any fixture.
             Exec(conn, CanonicalRevisionsDdl);
             Exec(conn, RevisionFileChangesDdl);
+            // The M4 bridge tables are always created so the SqliteBridgeReader — now on the single production
+            // RepositoryIndexLoader.Load path (D9) — can open against ANY fixture. Without them every loader /
+            // rebuilder / freshness-swap test that routes through Load crashes on "no such table: type_arguments".
+            // Empty by default (no bridge breadcrumbs) → an empty bridge graph, exactly like a scan-only extract.
+            Exec(conn, TypeArgumentsDdl);
+            Exec(conn, LiteralsDdl);
+            Exec(conn, SymbolAnnotationsDdl);
             if (createSchemaVersionTable) Exec(conn, SchemaVersionDdl);
             if (createMetadataTable) Exec(conn, MetadataDdl);
 
@@ -730,6 +737,59 @@ internal sealed class JulieDbFixture : IDisposable
             confidence REAL DEFAULT 1.0,
             metadata TEXT,
             created_at INTEGER DEFAULT 0
+        );
+        """;
+
+    // ---- M4 bridge tables (verbatim from julie v7.13.0 schema.rs; findings 28-2) ------------------------
+    // The SqliteBridgeReader is now on the single production RepositoryIndexLoader.Load path (D9), so these are
+    // always created — empty by default — and every loader/rebuilder/freshness-swap test that routes through Load
+    // can open against ANY fixture (without them: "no such table: type_arguments"). The reader selects:
+    //   type_arguments(identifier_id, ordinal, parent_arg_id, type_name, file_path, id);
+    //   literals(literal_text, kind, carrier, arg_position, language, containing_symbol_id, start_byte, end_byte, file_path, start_line, id);
+    //   symbol_annotations(symbol_id, ordinal, annotation, annotation_key, raw_text, carrier, id).
+
+    private const string TypeArgumentsDdl = """
+        CREATE TABLE IF NOT EXISTS type_arguments (
+            id TEXT PRIMARY KEY,
+            identifier_id TEXT NOT NULL,
+            parent_arg_id TEXT,
+            ordinal INTEGER NOT NULL,
+            type_name TEXT NOT NULL,
+            target_symbol_id TEXT,
+            file_path TEXT NOT NULL,
+            language TEXT NOT NULL,
+            last_indexed INTEGER
+        );
+        """;
+
+    private const string LiteralsDdl = """
+        CREATE TABLE IF NOT EXISTS literals (
+            id TEXT PRIMARY KEY,
+            literal_text TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            carrier TEXT,
+            arg_position INTEGER NOT NULL,
+            language TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            start_line INTEGER,
+            end_line INTEGER,
+            start_byte INTEGER,
+            end_byte INTEGER,
+            containing_symbol_id TEXT,
+            confidence REAL
+        );
+        """;
+
+    private const string SymbolAnnotationsDdl = """
+        CREATE TABLE IF NOT EXISTS symbol_annotations (
+            id TEXT PRIMARY KEY,
+            symbol_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            annotation TEXT NOT NULL,
+            annotation_key TEXT,
+            raw_text TEXT,
+            carrier TEXT,
+            UNIQUE (symbol_id, ordinal)
         );
         """;
 

--- a/tests/Miller.Tests/Indexing/JulieDbFixture.cs
+++ b/tests/Miller.Tests/Indexing/JulieDbFixture.cs
@@ -1,11 +1,12 @@
 using System.Globalization;
 using Microsoft.Data.Sqlite;
+using Miller.Indexing;
 
 namespace Miller.Tests.Indexing;
 
 /// <summary>
-/// Synthesizes a tiny SQLite file matching julie v7.12.2's verified extract schema (schema_version 26,
-/// extract_contract_version 1). This is Miller's READ-CONTRACT harness — it is NOT a re-test of julie's
+/// Synthesizes a tiny SQLite file matching julie v7.13.0's verified extract schema (schema_version 28,
+/// extract_contract_version 2). This is Miller's READ-CONTRACT harness — it is NOT a re-test of julie's
 /// extraction (julie owns that). The DDL is transcribed verbatim from julie's <c>src/database/schema.rs</c>
 /// (see docs/findings/julie-contract-verified.md §1), so the reader is exercised against the real column
 /// set, NULL discipline, and self-FK that a live extract produces.
@@ -15,6 +16,24 @@ namespace Miller.Tests.Indexing;
 internal sealed class JulieDbFixture : IDisposable
 {
     private readonly string _dir;
+
+    /// <summary>
+    /// The schema_version / extract_contract_version this Miller build is pinned to, sourced from
+    /// <see cref="MillerExtractContract"/>. Fixtures that just need a *valid* extract pass these (NOT
+    /// literals) so a julie re-pin needs no per-test edits — only the one constants file changes.
+    /// </summary>
+    public static readonly long PinnedSchema = MillerExtractContract.ExpectedSchemaVersion;
+
+    /// <summary>The pinned contract version as the TEXT julie stores in external_extract_metadata.</summary>
+    public static readonly string PinnedContract =
+        MillerExtractContract.ExpectedExtractContractVersion.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Pin-relative schema version as a string for "names the value" assertions: delta 0 == the pin,
+    /// +1 == a future (newer) schema, -1 == an older one.
+    /// </summary>
+    public static string SchemaText(long delta = 0) =>
+        (PinnedSchema + delta).ToString(CultureInfo.InvariantCulture);
 
     /// <summary>Absolute path to the synthesized julie extract <c>.db</c> file.</summary>
     public string DbPath { get; }
@@ -356,10 +375,10 @@ internal sealed class JulieDbFixture : IDisposable
     }
 
     /// <summary>
-    /// The canonical fixture: schema 26 / contract '1' with ~12 realistic rows — mixed kinds/languages,
+    /// The canonical fixture: schema 28 / contract '2' with ~12 realistic rows — mixed kinds/languages,
     /// some NULL signatures, at least one NULL start_line, parent/child pairs via parent_id, distinct files.
     /// </summary>
-    public static JulieDbFixture CreateDefault() => Create(26, "1", DefaultRows);
+    public static JulieDbFixture CreateDefault() => Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, DefaultRows);
 
     // ----- M2 inspect/ExtractReader fixture -----
 
@@ -440,7 +459,7 @@ internal sealed class JulieDbFixture : IDisposable
             ["auth/UserService.cs"] = UserServiceContent,
         };
 
-        return Create(26, "1", rows, identifiers: identifiers, fileContent: content, workspaceId: "ws-inspect-001");
+        return Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, rows, identifiers: identifiers, fileContent: content, workspaceId: "ws-inspect-001");
     }
 
     // ----- M6 edit/ReadEditSpan + ReadIdentifierSites fixture -----
@@ -550,7 +569,7 @@ internal sealed class JulieDbFixture : IDisposable
             ["unicode/Café.cs"] = CafeContent,
         };
 
-        return Create(26, "1", rows, identifiers: identifiers, fileContent: content, workspaceId: "ws-edit-001");
+        return Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, rows, identifiers: identifiers, fileContent: content, workspaceId: "ws-edit-001");
     }
 
     /// <summary>Realistic MD5-hex symbol ids (32 lowercase hex chars), per julie's id scheme (treated as opaque).</summary>
@@ -730,7 +749,7 @@ internal sealed class JulieDbFixture : IDisposable
         );
         """;
 
-    // --- M3 freshness DDL transcribed verbatim from the PINNED julie-server v7.12.2 (schema 26) live DB ---
+    // --- M3 freshness DDL transcribed verbatim from the PINNED julie-server v7.13.0 (schema 28) live DB ---
     // (dumped via `.schema` against a real `extract scan` output; see m3-design.md verified-fact 1/5).
 
     private const string CanonicalRevisionsDdl = """

--- a/tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs
+++ b/tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs
@@ -56,9 +56,9 @@ public sealed class JulieExtractRunnerTests
           "operation": "scan",
           "db_path": "/abs/work/.miller/symbols.db",
           "root": "/abs/work/repo",
-          "schema_version": 26,
+          "schema_version": 28,
           "schema_state": "current",
-          "extract_contract_version": 1,
+          "extract_contract_version": 2,
           "analysis_state": "missing",
           "files_scanned": 12,
           "symbols_extracted": 134,
@@ -80,9 +80,9 @@ public sealed class JulieExtractRunnerTests
         Assert.Equal("scan", report.Operation);
         Assert.Equal("/abs/work/.miller/symbols.db", report.DbPath); // serde renamed `db` -> `db_path`
         Assert.Equal("/abs/work/repo", report.Root);
-        Assert.Equal(26, report.SchemaVersion);
+        Assert.Equal(28, report.SchemaVersion);
         Assert.Equal("current", report.SchemaState);
-        Assert.Equal(1, report.ExtractContractVersion);
+        Assert.Equal(2, report.ExtractContractVersion);
         Assert.Equal(12u, report.FilesScanned);
         Assert.Equal(134u, report.SymbolsExtracted);
         Assert.Empty(report.Errors);
@@ -94,9 +94,9 @@ public sealed class JulieExtractRunnerTests
           "operation": "info",
           "db_path": "/abs/work/.miller/symbols.db",
           "root": null,
-          "schema_version": 26,
+          "schema_version": 28,
           "schema_state": "current",
-          "extract_contract_version": 1,
+          "extract_contract_version": 2,
           "analysis_state": "missing",
           "files_scanned": 0,
           "symbols_extracted": 0,
@@ -131,9 +131,9 @@ public sealed class JulieExtractRunnerTests
           "operation": "scan",
           "db_path": "/abs/work/.miller/symbols.db",
           "root": "/abs/work/repo",
-          "schema_version": 26,
+          "schema_version": 28,
           "schema_state": "current",
-          "extract_contract_version": 1,
+          "extract_contract_version": 2,
           "analysis_state": "missing",
           "files_scanned": 0,
           "symbols_extracted": 0,
@@ -213,7 +213,7 @@ public sealed class JulieExtractRunnerTests
         // `delete` of an absent file → status "not_found", exit 0. Tolerant, NOT a failure.
         const string notFound = """
             { "status": "not_found", "operation": "delete", "db_path": "/abs/db", "root": "/abs/r",
-              "schema_version": 26, "extract_contract_version": 1,
+              "schema_version": 28, "extract_contract_version": 2,
               "files_scanned": 0, "symbols_extracted": 0, "files_total": 0, "symbols_total": 0,
               "relationships_total": 0, "identifiers_total": 0, "types_total": 0, "errors": [] }
             """;
@@ -254,8 +254,8 @@ public sealed class JulieExtractRunnerTests
               "operation": "scan",
               "DB_Path": "/abs/work/.miller/symbols.db",
               "root": "/abs/work/repo",
-              "Schema_Version": 26,
-              "Extract_Contract_Version": 1,
+              "Schema_Version": 28,
+              "Extract_Contract_Version": 2,
               "files_scanned": 0,
               "symbols_extracted": 0,
               "files_total": 0,
@@ -271,8 +271,8 @@ public sealed class JulieExtractRunnerTests
 
         Assert.Equal("scanned", report.Status);                       // "Status" bound case-insensitively
         Assert.Equal("/abs/work/.miller/symbols.db", report.DbPath);  // "DB_Path" bound to db_path
-        Assert.Equal(26, report.SchemaVersion);                       // "Schema_Version" bound to schema_version
-        Assert.Equal(1, report.ExtractContractVersion);               // "Extract_Contract_Version" bound
+        Assert.Equal(28, report.SchemaVersion);                       // "Schema_Version" bound to schema_version
+        Assert.Equal(2, report.ExtractContractVersion);               // "Extract_Contract_Version" bound
     }
 
     // ---- (4) post-extract version cross-check (D5; julie self-rejects only a NEWER DB, so Miller gates) ----
@@ -287,16 +287,16 @@ public sealed class JulieExtractRunnerTests
     public void VerifyReport_AtPinnedSchemaAndContract_DoesNotThrow()
     {
         // No throw == compatible. A throw fails the test.
-        ExtractVersionMismatch.VerifyReport(ReportWith(26, 1));
+        ExtractVersionMismatch.VerifyReport(ReportWith((int)MillerExtractContract.ExpectedSchemaVersion, (int)MillerExtractContract.ExpectedExtractContractVersion));
     }
 
     [Fact]
     public void VerifyReport_NewerSchema_ThrowsNamingValueAndPointingAtUpgrade()
     {
         var ex = Assert.Throws<IncompatibleExtractException>(() =>
-            ExtractVersionMismatch.VerifyReport(ReportWith(27, 1)));
-        Assert.Contains("27", ex.Message);
-        Assert.Contains("26", ex.Message);
+            ExtractVersionMismatch.VerifyReport(ReportWith((int)MillerExtractContract.ExpectedSchemaVersion + 1, (int)MillerExtractContract.ExpectedExtractContractVersion)));
+        Assert.Contains(JulieDbFixture.SchemaText(1), ex.Message);
+        Assert.Contains(JulieDbFixture.SchemaText(), ex.Message);
         Assert.Contains("newer", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("upgrade Miller", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -306,7 +306,7 @@ public sealed class JulieExtractRunnerTests
     {
         // Contract 0 < expected 1: julie would NOT self-reject this; Miller's cross-check must.
         var ex = Assert.Throws<IncompatibleExtractException>(() =>
-            ExtractVersionMismatch.VerifyReport(ReportWith(26, 0)));
+            ExtractVersionMismatch.VerifyReport(ReportWith((int)MillerExtractContract.ExpectedSchemaVersion, (int)MillerExtractContract.ExpectedExtractContractVersion - 1)));
         Assert.Contains("extract_contract_version", ex.Message);
         Assert.Contains("restore", ex.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs
+++ b/tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs
@@ -75,7 +75,7 @@ public sealed class JulieExtractRunnerUpdateDeleteTests
 
     private const string ChangedJson = """
         { "status": "changed", "operation": "update", "workspace_id": "ws-1",
-          "db_path": "/abs/db", "root": "/abs/r", "schema_version": 26, "extract_contract_version": 1,
+          "db_path": "/abs/db", "root": "/abs/r", "schema_version": 28, "extract_contract_version": 2,
           "revision": 5, "files_scanned": 0, "files_updated": 1, "files_deleted": 0,
           "symbols_extracted": 3, "files_total": 2, "symbols_total": 8,
           "relationships_total": 0, "identifiers_total": 0, "types_total": 0, "errors": [] }
@@ -93,7 +93,7 @@ public sealed class JulieExtractRunnerUpdateDeleteTests
 
     private const string FailedUpdateJson = """
         { "status": "failed", "operation": "update", "workspace_id": "ws-1",
-          "db_path": "/abs/db", "root": "/abs/r", "schema_version": 26, "extract_contract_version": 1,
+          "db_path": "/abs/db", "root": "/abs/r", "schema_version": 28, "extract_contract_version": 2,
           "revision": 4, "files_scanned": 0, "files_updated": 0, "files_deleted": 0,
           "symbols_extracted": 0, "files_total": 0, "symbols_total": 0,
           "relationships_total": 0, "identifiers_total": 0, "types_total": 0,

--- a/tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs
+++ b/tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using Miller.Indexing;
 using Xunit;
@@ -5,14 +6,26 @@ using Xunit;
 namespace Miller.Tests.Indexing;
 
 /// <summary>
-/// Pins the D5 compatibility gate. The gate runs BEFORE any read and must reject anything that is not a
-/// v7.12.2 julie extract (schema 26 / contract 1) with a typed, actionable error — silently misreading a
-/// future/older schema is the failure mode this prevents. Every failure test asserts the message NAMES the
-/// offending value so an operator can act on it.
+/// Pins the D5 compatibility gate. The gate runs BEFORE any read and must reject anything that is not the
+/// pinned julie extract (schema <see cref="MillerExtractContract.ExpectedSchemaVersion"/> / contract
+/// <see cref="MillerExtractContract.ExpectedExtractContractVersion"/>) with a typed, actionable error —
+/// silently misreading a future/older schema is the failure mode this prevents. Every failure test asserts
+/// the message NAMES the offending value so an operator can act on it.
+///
+/// Versions here are expressed RELATIVE to the pin (pin, pin±1), sourced from
+/// <see cref="MillerExtractContract"/>, so a julie re-pin needs NO edits to this file — only the one
+/// constants file changes. (This is why the M4 26/1→28/2 bump did not have to touch these assertions.)
 /// </summary>
 public sealed class JulieSchemaGateTests
 {
     private static readonly IReadOnlyList<JulieDbFixture.SymbolRow> NoRows = Array.Empty<JulieDbFixture.SymbolRow>();
+
+    private static readonly long PinSchema = MillerExtractContract.ExpectedSchemaVersion;
+    private static readonly long PinContract = MillerExtractContract.ExpectedExtractContractVersion;
+    private static readonly string PinContractStr = S(PinContract);
+    private static readonly string PinnedVer = MillerExtractContract.PinnedJulieServerVersion;
+
+    private static string S(long v) => v.ToString(CultureInfo.InvariantCulture);
 
     private static SqliteConnection OpenReadOnly(string dbPath)
     {
@@ -25,22 +38,22 @@ public sealed class JulieSchemaGateTests
     [Fact]
     public void Verify_AtPinnedSchemaAndContract_DoesNotThrow()
     {
-        using var fx = JulieDbFixture.Create(26, "1", NoRows);
+        using var fx = JulieDbFixture.Create(PinSchema, PinContractStr, NoRows);
         using var conn = OpenReadOnly(fx.DbPath);
 
-        // No exception == compatible. Calling it is the assertion; an throw would fail the test.
+        // No exception == compatible. Calling it is the assertion; a throw would fail the test.
         JulieSchemaGate.Verify(conn);
     }
 
     [Fact]
     public void Verify_NewerSchema_ThrowsNamingTheValueAndPointsAtUpgrade()
     {
-        using var fx = JulieDbFixture.Create(27, "1", NoRows);
+        using var fx = JulieDbFixture.Create(PinSchema + 1, PinContractStr, NoRows);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
-        Assert.Contains("27", ex.Message);                 // names the offending schema version
-        Assert.Contains("26", ex.Message);                 // names what Miller expects
+        Assert.Contains(S(PinSchema + 1), ex.Message);     // names the offending schema version
+        Assert.Contains(S(PinSchema), ex.Message);         // names what Miller expects
         Assert.Contains("newer", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("upgrade Miller", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -48,24 +61,24 @@ public sealed class JulieSchemaGateTests
     [Fact]
     public void Verify_NewerContract_ThrowsNamingTheValueAndPointsAtUpgrade()
     {
-        using var fx = JulieDbFixture.Create(26, "2", NoRows);
+        using var fx = JulieDbFixture.Create(PinSchema, S(PinContract + 1), NoRows);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
-        Assert.Contains("2", ex.Message);                  // offending contract value
-        Assert.Contains("1", ex.Message);                  // expected contract
+        Assert.Contains(S(PinContract + 1), ex.Message);   // offending contract value
+        Assert.Contains(PinContractStr, ex.Message);       // expected contract
         Assert.Contains("newer", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void Verify_OlderSchema_ThrowsPointingAtRestore()
     {
-        using var fx = JulieDbFixture.Create(25, "1", NoRows);
+        using var fx = JulieDbFixture.Create(PinSchema - 1, PinContractStr, NoRows);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
-        Assert.Contains("25", ex.Message);
-        Assert.Contains("v7.12.2", ex.Message);            // older path names the pinned julie-server
+        Assert.Contains(S(PinSchema - 1), ex.Message);
+        Assert.Contains($"v{PinnedVer}", ex.Message);      // older path names the pinned julie-server
         Assert.Contains("restore", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -74,18 +87,20 @@ public sealed class JulieSchemaGateTests
     {
         // A non-julie / corrupt DB: no schema_version table at all. COALESCE(MAX(version),0) can't even
         // run, so the gate must detect the missing table and reject (fail-fast on non-julie DBs).
-        using var fx = JulieDbFixture.Create(null, "1", NoRows, createSchemaVersionTable: false);
+        using var fx = JulieDbFixture.Create(null, PinContractStr, NoRows, createSchemaVersionTable: false);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
         Assert.Contains("schema_version", ex.Message);
-        Assert.Contains("not a v7.12.2 julie extract", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"not a v{PinnedVer} julie extract", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void Verify_MissingMetadataTable_ThrowsNamingTheTable()
     {
-        using var fx = JulieDbFixture.Create(26, null, NoRows, createMetadataTable: false);
+        // Schema is at the pin (so the schema check passes); the metadata table is absent, so the gate must
+        // fail on the missing table next.
+        using var fx = JulieDbFixture.Create(PinSchema, null, NoRows, createMetadataTable: false);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
@@ -96,8 +111,9 @@ public sealed class JulieSchemaGateTests
     public void Verify_MissingContractKey_ThrowsNamingTheKey()
     {
         // The metadata table exists but the extract_contract_version row is absent (contractValue null
-        // with the table present). The SELECT returns no row → treated as incompatible (older/missing).
-        using var fx = JulieDbFixture.Create(26, null, NoRows, createMetadataTable: true);
+        // with the table present). Schema is at the pin so we reach the contract check; the SELECT returns
+        // no row → treated as incompatible (older/missing).
+        using var fx = JulieDbFixture.Create(PinSchema, null, NoRows, createMetadataTable: true);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));
@@ -109,7 +125,7 @@ public sealed class JulieSchemaGateTests
     {
         // Metadata values are TEXT; a present-but-garbage value (not parseable as an integer) must be
         // rejected by the gate's long.TryParse branch, naming the offending value so the operator can act.
-        using var fx = JulieDbFixture.Create(26, "abc", NoRows);
+        using var fx = JulieDbFixture.Create(PinSchema, "abc", NoRows);
         using var conn = OpenReadOnly(fx.DbPath);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => JulieSchemaGate.Verify(conn));

--- a/tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs
+++ b/tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs
@@ -1,0 +1,759 @@
+using Miller.Core.Graph;
+using Miller.Core.Resolver;
+using Miller.Indexing;
+using Miller.Server.Resolution;
+using Miller.Server.Tools;
+using Xunit;
+
+namespace Miller.Tests.Indexing;
+
+/// <summary>
+/// M4 Phase D SHIPPABLE GATE (design §7 layers 5+6, §9 final two checkboxes). Drives the REAL
+/// <c>julie-server extract</c> over throwaway polyglot fixtures, builds the index + cross-language bridge
+/// graph through the single production path (<see cref="RepositoryIndexLoader.Load"/>), and asserts against
+/// the actual <see cref="BridgeGraph"/> — not a mock.
+///
+/// <para>Two probes:</para>
+/// <list type="number">
+///   <item><b>Disciplined fixture</b> (<see cref="DisciplinedFixture_AllThreeLegs_KnownBridgeSet"/>): a
+///   by-construction-known bridge set across all three buildable legs (entity→table via DbSet, DTO↔entity via
+///   CreateMap, route via axios verb + [controller] expansion). Asserts WHICH entity→table, WHICH CreateMap
+///   pair, WHICH route, with the expected score bands from the real scorer.</item>
+///   <item><b>Honesty probe</b> (<see cref="HonestyProbe_UndisciplinedFixture_GuardsHold_PrecisionAndRecall"/>):
+///   a deliberately undisciplined fixture. Computes precision, proves corroborator-only + ambiguous-name-never-High
+///   from the scored payload, and measures recall PER LEG against the buildable ground truth (Dapper-FROM excluded
+///   from the denominator — it is not buildable on the lean contract; see <see cref="BridgeGraphBuilder"/>).</item>
+/// </list>
+///
+/// <para>Subprocess + extraction will not fit the &lt;10s default budget, so this is
+/// <c>[Trait("Category","Scale")]</c> and EXCLUDED by the default fast suite. The single launch signal is
+/// <see cref="ScaleTestSupport.RequireJulieServer"/>: if <c>.tools/julie-server</c> is absent the test SKIPS
+/// (never fails) with an actionable message. No private locator — the
+/// <see cref="Conventions.ScaleTraitConventionTests"/> drift guard keys on this one signal.</para>
+/// </summary>
+[Trait("Category", "Scale")]
+public sealed class LiveBridgeTraceTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public LiveBridgeTraceTests(ITestOutputHelper output) => _output = output;
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Probe 1: disciplined polyglot fixture — a known, enumerable bridge set across all three legs.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DisciplinedFixture_AllThreeLegs_KnownBridgeSet()
+    {
+        string binary = ScaleTestSupport.RequireJulieServer();
+        using var work = new TempWorkspace();
+        WriteDisciplinedFixture(work.Repo);
+
+        var index = ExtractAndLoad(binary, work);
+        var graph = index.BridgeGraph;
+
+        // ── Leg 3 (entity→table): EF DbSet<AppSetting> property "AppSettings" ⇒ AppSetting StoredIn AppSettings.
+        // The DbSet always supplies a DbSetProperty structural breadcrumb ⇒ High band (BridgeScorer §5).
+        string appSettingId = FindSymbolId(index, "AppSetting", "class");
+        var storedIn = SingleEdgeOfKind(graph, appSettingId, BridgeKind.StoredIn);
+        Assert.Equal("AppSetting", EndpointDisplayOf(graph, storedIn, EndpointSide.Source));
+        Assert.Equal("AppSettings", EndpointDisplayOf(graph, storedIn, EndpointSide.Target));
+        Assert.Equal(ConfidenceBand.High, storedIn.Band);
+        // NEGATIVE (design §7): the table side is the DbSet PROPERTY name, NOT the DbContext class AppDbContext.
+        string appSettingsTableId = BridgeGraph.SynthesizeId(BridgeNodeKind.DbTable, "AppSettings");
+        Assert.True(graph.Contains(appSettingsTableId), "entity must bridge to the table node");
+        Assert.DoesNotContain(
+            graph.Walk(appSettingId, 2),
+            e => string.Equals(EndpointDisplayOf(graph, e, EndpointSide.Target), "AppDbContext", StringComparison.Ordinal));
+
+        // ── Leg 2 (DTO↔entity): CreateMap<AppSetting, AppSettingDto>() ⇒ MapsTo edge between the two C# shapes.
+        // CreateMap alone = a structural breadcrumb ⇒ High band. Both sides resolve (unique names) so not ambiguous.
+        string dtoId = FindSymbolId(index, "AppSettingDto", "class");
+        var mapsTo = SingleEdgeOfKind(graph, dtoId, BridgeKind.MapsTo);
+        Assert.Equal(ConfidenceBand.High, mapsTo.Band);
+        Assert.False(mapsTo.HasAmbiguousName, "AppSetting/AppSettingDto are unique names; the map must not be ambiguous");
+        var mapNames = new[]
+        {
+            EndpointDisplayOf(graph, mapsTo, EndpointSide.Source),
+            EndpointDisplayOf(graph, mapsTo, EndpointSide.Target),
+        };
+        Assert.Contains("AppSetting", mapNames);
+        Assert.Contains("AppSettingDto", mapNames);
+
+        // ── Leg 1 (route): TS axios.get('/api/appsettings/{id}') ⇒ Hits the [controller]-expanded GET endpoint.
+        // axios.get is a verb-KNOWN carrier ⇒ RouteVerbMatch structural breadcrumb ⇒ High band, NOT verb-unknown.
+        string handlerId = FindSymbolId(index, "GetById", "method");
+        var hits = SingleEdgeOfKind(graph, handlerId, BridgeKind.Hits);
+        Assert.Equal("GetById", EndpointDisplayOf(graph, hits, EndpointSide.Target));
+        Assert.False(hits.IsVerbUnknown, "axios.get supplies a known verb; this route edge must not be verb-unknown");
+        Assert.False(hits.HasAmbiguousName);
+        Assert.Equal(ConfidenceBand.High, hits.Band);
+        // The client side is the normalized route — the [controller] token expanded to "appsettings", {id} → {}.
+        string routeDisplay = EndpointDisplayOf(graph, hits, EndpointSide.Source);
+        Assert.Contains("appsettings", routeDisplay, StringComparison.OrdinalIgnoreCase);
+
+        // ── End-to-end render proof: the entity→table bridge must render through the real TraceTool.Run with its band.
+        var resolver = new SmartTargetResolver(index);
+        string rendered = TraceTool.Run(
+            index, resolver, target: "AppSetting", mode: "bridge", to: null, depth: 3, limit: 20,
+            fullFormat: false, out int emitted, out _);
+        Assert.True(emitted > 0, "trace bridge over AppSetting must emit at least the StoredIn link");
+        Assert.Contains("AppSetting  --DbSet-->  AppSettings", rendered);
+        Assert.Contains("(High)", rendered);
+
+        _output.WriteLine("DISCIPLINED FIXTURE — known bridge set verified:");
+        _output.WriteLine($"  Leg3 StoredIn: AppSetting -> AppSettings   band={storedIn.Band} score={Fmt(storedIn.Score)}");
+        _output.WriteLine($"  Leg2 MapsTo:   {mapNames[0]} <-> {mapNames[1]}   band={mapsTo.Band} score={Fmt(mapsTo.Score)}");
+        _output.WriteLine($"  Leg1 Hits:     {routeDisplay} -> GetById   band={hits.Band} score={Fmt(hits.Score)} verbUnknown={hits.IsVerbUnknown}");
+        _output.WriteLine("  Rendered (trace bridge AppSetting):");
+        _output.WriteLine(rendered);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Probe 2: honesty probe — undisciplined fixture. Precision + per-leg recall + guard proofs.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HonestyProbe_UndisciplinedFixture_GuardsHold_PrecisionAndRecall()
+    {
+        string binary = ScaleTestSupport.RequireJulieServer();
+        using var work = new TempWorkspace();
+        WriteUndisciplinedFixture(work.Repo);
+
+        var index = ExtractAndLoad(binary, work);
+        var graph = index.BridgeGraph;
+
+        // Enumerate every distinct surviving bridge edge (undirected; one entry per edge signature).
+        var allEdges = EnumerateDistinctEdges(index, graph);
+
+        // ── GROUND TRUTH (by construction). The buildable-correct bridges in the undisciplined fixture are:
+        //   Leg 3 (entity→table): Customer DbSet "Customers" ⇒ Customer StoredIn Customers.            [detectable]
+        //   Leg 2 (DTO↔entity):   CreateMap<Customer, CustomerDto>() ⇒ Customer MapsTo CustomerDto.     [detectable]
+        //   Leg 1 (route):        axios.post('/api/orders') ⇒ Hits CreateOrder (POST, verb-known).      [detectable]
+        // Dapper-FROM is NOT buildable on the lean contract (BridgeGraphBuilder passes DapperFromCandidates:[]),
+        // so it is EXCLUDED from every recall denominator below — stated explicitly per the honesty requirement.
+        //
+        // Traps that must NOT produce a confident-wrong edge:
+        //   (a) Ambiguous duplicate type name "Account" (Billing.Account + Crm.Account) + CreateMap<Billing.Account,
+        //       AccountDto>(): the entity side resolves to >1 symbol ⇒ NEVER High (capped/flagged or dropped).
+        //   (b) A 1-field wrapper pair (IdHolder vs IdHolderDto, share only "Id", no CreateMap) ⇒ NEVER an edge.
+        //   (c) A verb-less fetch carrier fetch('/api/reports'): any route edge it forms must be verb-unknown.
+        //   (d) A C# test HttpClient url literal ("/api/secret" in a [Fact]) ⇒ EXCLUDED (language + test_role filter).
+        //   (e) An inbound CreateMap<UpdateCustomerRequest, Customer>(): a real structural edge; the Request must NOT
+        //       be mislabeled as the entity (ordinal = copy direction, never reordered to entity-vs-DTO).
+
+        // ── PRECISION. Classify every emitted edge correct/incorrect against the ground truth + trap rules.
+        int truePositives = 0;
+        int falsePositives = 0;
+        var verdicts = new List<string>();
+        foreach (var edge in allEdges)
+        {
+            var (ok, why) = ClassifyHonesty(graph, edge);
+            if (ok) truePositives++; else falsePositives++;
+            verdicts.Add($"  [{(ok ? "TP" : "FP")}] {DescribeEdge(graph, edge)}  band={edge.Band} score={Fmt(edge.Score)} ambiguous={edge.HasAmbiguousName} verbUnknown={edge.IsVerbUnknown}  ({why})");
+        }
+        int detected = truePositives + falsePositives;
+        double precision = detected == 0 ? 1.0 : (double)truePositives / detected;
+
+        // ── GUARD 1: corroborator-only / 1-field wrapper never anchors. IdHolder<->IdHolderDto share exactly one
+        // field ("Id") and have no CreateMap; the field-set-only branch is never even built by the production builder
+        // (it passes Projections:[]), and the scorer's MinAnchoringFieldCount=2 would refuse it anyway. No edge.
+        string? idHolderId = FindSymbolIdOrNull(index, "IdHolder", "class");
+        if (idHolderId is not null)
+        {
+            Assert.DoesNotContain(graph.Walk(idHolderId, 3),
+                e => EdgeTouchesDisplay(graph, e, "IdHolderDto"));
+        }
+        // And no surviving edge anywhere may be field-set-anchored with <2 shared fields (proven from the payload).
+        foreach (var edge in allEdges)
+        {
+            bool structurallyAnchored = edge.Edge.Signals.Any(s =>
+                s is StructuralSignal { Present: true } st && st.Rule != SignalRule.RouteOnlyMatch);
+            var fs = edge.Edge.Signals.OfType<FieldSetSignal>().FirstOrDefault();
+            // A field-set may only RIDE ALONG on a structurally-anchored edge, and only when it carries >=2 fields.
+            if (fs is not null)
+                Assert.True(structurallyAnchored && fs.FieldCount >= 2,
+                    $"a FieldSetSignal must ride on a structural anchor with >=2 fields, saw count={fs.FieldCount}, anchored={structurallyAnchored}");
+        }
+
+        // ── GUARD 2: ambiguous-name-never-High. Any edge flagged ambiguous (HasAmbiguousName) OR carrying a
+        // NameResolutionSignal with Status=Ambiguous must NOT be High (proven from the payload, not a rule name).
+        foreach (var edge in allEdges)
+        {
+            bool ambiguousByPayload =
+                edge.HasAmbiguousName
+                || edge.Edge.Signals.OfType<NameResolutionSignal>().Any(n => n.Status == ResolutionStatus.Ambiguous);
+            if (ambiguousByPayload)
+                Assert.NotEqual(ConfidenceBand.High, edge.Band);
+        }
+        // The ambiguous "Account" CreateMap specifically: Billing.Account/Crm.Account collide, so the entity side
+        // resolves ambiguously. Whatever Account-touching edge survives must never be a High edge.
+        foreach (var edge in allEdges.Where(e =>
+                     EdgeTouchesDisplay(graph, e, "Account") || EdgeTouchesDisplay(graph, e, "AccountDto")))
+        {
+            if (edge.HasAmbiguousName)
+                Assert.NotEqual(ConfidenceBand.High, edge.Band);
+        }
+        // ANTI-VACUITY: the guard above is only meaningful if the ambiguity actually fired this run. If a future
+        // julie-server build stopped resolving "Account" to >1 symbol (e.g. emitted fully-qualified names), every
+        // edge would be unambiguous and the guard would pass while testing nothing. Pin that at least one surviving
+        // edge really carries an ambiguous signal, so the guard cannot silently lose its teeth.
+        int ambiguousEdgeCount = allEdges.Count(e =>
+            e.HasAmbiguousName
+            || e.Edge.Signals.OfType<NameResolutionSignal>().Any(n => n.Status == ResolutionStatus.Ambiguous));
+        Assert.True(ambiguousEdgeCount >= 1,
+            "the ambiguous-name guard is vacuous: no surviving edge carried an ambiguous signal. The Account "
+            + "collision (Billing.Account/Crm.Account) must produce at least one ambiguous-flagged edge for Guard 2 "
+            + "to mean anything — if julie-server stopped flagging it, this fixture no longer exercises the guard.");
+
+        // ── GUARD 3: the C# test HttpClient literal "/api/secret" must NOT form a route bridge (language + test filter).
+        Assert.DoesNotContain(allEdges, e =>
+            EdgeTouchesDisplay(graph, e, "/api/secret") || EdgeTouchesDisplay(graph, e, "api/secret"));
+
+        // ── GUARD 4: the verb-less fetch carrier must never be assumed GET. Any /api/reports route edge that exists
+        // must be verb-unknown. (It may also simply not match an endpoint and produce no edge — both are honest.)
+        foreach (var edge in allEdges.Where(e =>
+                     EdgeTouchesDisplay(graph, e, "/api/reports") || EdgeTouchesDisplay(graph, e, "api/reports")))
+            Assert.True(edge.IsVerbUnknown, "a verb-less fetch carrier route edge must be verb-unknown, never assumed GET");
+
+        // ── RECALL PER LEG (detected / detectable; Dapper-FROM excluded from the denominator).
+        bool leg3Detected = allEdges.Any(e =>
+            e.Edge.Kind == BridgeKind.StoredIn
+            && EdgeTouchesDisplay(graph, e, "Customer")
+            && EdgeTouchesDisplay(graph, e, "Customers"));
+        bool leg2Detected = allEdges.Any(e =>
+            e.Edge.Kind == BridgeKind.MapsTo
+            && EdgeTouchesDisplay(graph, e, "Customer")
+            && EdgeTouchesDisplay(graph, e, "CustomerDto"));
+        bool leg1Detected = allEdges.Any(e =>
+            e.Edge.Kind == BridgeKind.Hits
+            && EdgeTouchesDisplay(graph, e, "CreateOrder"));
+
+        double recallLeg1 = leg1Detected ? 1.0 : 0.0; // denominator 1 (POST /api/orders -> CreateOrder)
+        double recallLeg2 = leg2Detected ? 1.0 : 0.0; // denominator 1 (CreateMap<Customer,CustomerDto>)
+        double recallLeg3 = leg3Detected ? 1.0 : 0.0; // denominator 1 (Customer DbSet "Customers")
+
+        // ── Acceptance assertions. Guards above are hard; here we pin the measured numbers don't regress below bar.
+        Assert.True(precision >= 0.75,
+            $"honesty-probe precision {Fmt(precision)} below the 0.75 acceptance floor. Verdicts:\n{string.Join("\n", verdicts)}");
+        Assert.True(leg3Detected, "Leg 3 ground-truth bridge (Customer -> Customers) must be detected (recall > 0)");
+        Assert.True(leg2Detected, "Leg 2 ground-truth bridge (Customer <-> CustomerDto) must be detected (recall > 0)");
+        Assert.True(leg1Detected, "Leg 1 ground-truth bridge (POST /api/orders -> CreateOrder) must be detected (recall > 0)");
+
+        // ── Emit the MEASURED numbers (copied verbatim into the design-doc appendix).
+        _output.WriteLine("=== M4 PHASE D HONESTY PROBE (measured) ===");
+        _output.WriteLine($"edges emitted (distinct): {detected}   TP={truePositives}  FP={falsePositives}");
+        _output.WriteLine($"PRECISION (all legs): {Fmt(precision)}");
+        _output.WriteLine($"RECALL Leg1 (route):          {Fmt(recallLeg1)}  (detected {(leg1Detected ? 1 : 0)}/1)");
+        _output.WriteLine($"RECALL Leg2 (DTO<->entity):   {Fmt(recallLeg2)}  (detected {(leg2Detected ? 1 : 0)}/1)");
+        _output.WriteLine($"RECALL Leg3 (entity<->table): {Fmt(recallLeg3)}  (detected {(leg3Detected ? 1 : 0)}/1)");
+        _output.WriteLine("Dapper-FROM leg: EXCLUDED from denominators (not buildable on the lean contract).");
+        _output.WriteLine("--- per-edge verdicts ---");
+        foreach (var v in verdicts)
+            _output.WriteLine(v);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Disciplined fixture writer.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private static void WriteDisciplinedFixture(string repo)
+    {
+        string cs = Path.Combine(repo, "server");
+        string ts = Path.Combine(repo, "web");
+        Directory.CreateDirectory(cs);
+        Directory.CreateDirectory(ts);
+
+        File.WriteAllText(Path.Combine(cs, "AppSetting.cs"), """
+            namespace Demo.Domain;
+
+            public sealed class AppSetting
+            {
+                public int Id { get; set; }
+                public string Key { get; set; } = string.Empty;
+                public string Value { get; set; } = string.Empty;
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "AppSettingDto.cs"), """
+            namespace Demo.Contracts;
+
+            public sealed class AppSettingDto
+            {
+                public int Id { get; set; }
+                public string Key { get; set; } = string.Empty;
+                public string Value { get; set; } = string.Empty;
+            }
+            """);
+
+        // EF DbContext with a DbSet<AppSetting> property named AppSettings (Leg 3 anchor).
+        File.WriteAllText(Path.Combine(cs, "AppDbContext.cs"), """
+            using Microsoft.EntityFrameworkCore;
+            using Demo.Domain;
+
+            namespace Demo.Data;
+
+            public sealed class AppDbContext : DbContext
+            {
+                public DbSet<AppSetting> AppSettings { get; set; } = null!;
+            }
+            """);
+
+        // AutoMapper profile: CreateMap<AppSetting, AppSettingDto>().ReverseMap() (Leg 2 anchor).
+        File.WriteAllText(Path.Combine(cs, "MappingProfile.cs"), """
+            using AutoMapper;
+            using Demo.Domain;
+            using Demo.Contracts;
+
+            namespace Demo.Mapping;
+
+            public sealed class MappingProfile : Profile
+            {
+                public MappingProfile()
+                {
+                    CreateMap<AppSetting, AppSettingDto>().ReverseMap();
+                }
+            }
+            """);
+
+        // Controller: [Route("api/[controller]")] + [HttpGet("{id}")] handler GetById (Leg 1 endpoint).
+        File.WriteAllText(Path.Combine(cs, "AppSettingsController.cs"), """
+            using Microsoft.AspNetCore.Mvc;
+            using Demo.Contracts;
+
+            namespace Demo.Api;
+
+            [ApiController]
+            [Route("api/[controller]")]
+            public sealed class AppSettingsController : ControllerBase
+            {
+                [HttpGet("{id}")]
+                public ActionResult<AppSettingDto> GetById(int id) => new AppSettingDto();
+
+                [HttpPost]
+                public ActionResult<AppSettingDto> Create([FromBody] AppSettingDto body) => body;
+            }
+            """);
+
+        // TS client: axios.get / axios.post to the same routes (Leg 1 frontend side; verb-known carriers).
+        File.WriteAllText(Path.Combine(ts, "appSettings.api.ts"), """
+            import axios from "axios";
+
+            export interface AppSettingDto {
+              id: number;
+              key: string;
+              value: string;
+            }
+
+            export async function fetchAppSetting(id: number): Promise<AppSettingDto> {
+              const res = await axios.get(`/api/appsettings/${id}`);
+              return res.data;
+            }
+
+            export async function createAppSetting(body: AppSettingDto): Promise<AppSettingDto> {
+              const res = await axios.post("/api/appsettings", body);
+              return res.data;
+            }
+            """);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Undisciplined fixture writer (the honesty-probe traps).
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private static void WriteUndisciplinedFixture(string repo)
+    {
+        string cs = Path.Combine(repo, "server");
+        string ts = Path.Combine(repo, "web");
+        string tests = Path.Combine(repo, "server.tests");
+        Directory.CreateDirectory(cs);
+        Directory.CreateDirectory(ts);
+        Directory.CreateDirectory(tests);
+
+        // CLEAN ground-truth shapes (these SHOULD bridge).
+        File.WriteAllText(Path.Combine(cs, "Customer.cs"), """
+            namespace Shop.Domain;
+
+            public sealed class Customer
+            {
+                public int Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public string Email { get; set; } = string.Empty;
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "CustomerDto.cs"), """
+            namespace Shop.Contracts;
+
+            public sealed class CustomerDto
+            {
+                public int Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public string Email { get; set; } = string.Empty;
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "UpdateCustomerRequest.cs"), """
+            namespace Shop.Contracts;
+
+            public sealed class UpdateCustomerRequest
+            {
+                public string Name { get; set; } = string.Empty;
+                public string Email { get; set; } = string.Empty;
+            }
+            """);
+
+        // EF DbContext: DbSet<Customer> Customers (Leg 3 ground truth).
+        File.WriteAllText(Path.Combine(cs, "ShopDbContext.cs"), """
+            using Microsoft.EntityFrameworkCore;
+            using Shop.Domain;
+
+            namespace Shop.Data;
+
+            public sealed class ShopDbContext : DbContext
+            {
+                public DbSet<Customer> Customers { get; set; } = null!;
+            }
+            """);
+
+        // AutoMapper: the clean map + an INBOUND map (Request->entity) + the AMBIGUOUS Account map.
+        File.WriteAllText(Path.Combine(cs, "ShopProfile.cs"), """
+            using AutoMapper;
+            using Shop.Domain;
+            using Shop.Contracts;
+
+            namespace Shop.Mapping;
+
+            public sealed class ShopProfile : Profile
+            {
+                public ShopProfile()
+                {
+                    CreateMap<Customer, CustomerDto>();
+                    CreateMap<UpdateCustomerRequest, Customer>();
+                    CreateMap<Billing.Account, AccountDto>();
+                }
+            }
+            """);
+
+        // AMBIGUOUS duplicate type name "Account" in two namespaces (trap (a)).
+        File.WriteAllText(Path.Combine(cs, "BillingAccount.cs"), """
+            namespace Billing;
+
+            public sealed class Account
+            {
+                public int Id { get; set; }
+                public decimal Balance { get; set; }
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "CrmAccount.cs"), """
+            namespace Crm;
+
+            public sealed class Account
+            {
+                public int Id { get; set; }
+                public string Owner { get; set; } = string.Empty;
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "AccountDto.cs"), """
+            namespace Shop.Contracts;
+
+            public sealed class AccountDto
+            {
+                public int Id { get; set; }
+                public decimal Balance { get; set; }
+            }
+            """);
+
+        // 1-FIELD WRAPPER pair sharing only "Id" (trap (b)) — no CreateMap, must NEVER anchor a field-set edge.
+        File.WriteAllText(Path.Combine(cs, "IdHolder.cs"), """
+            namespace Shop.Util;
+
+            public sealed class IdHolder
+            {
+                public int Id { get; set; }
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "IdHolderDto.cs"), """
+            namespace Shop.Contracts;
+
+            public sealed class IdHolderDto
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        // Controller with a POST endpoint CreateOrder (Leg 1 ground truth) + a GET reports endpoint.
+        File.WriteAllText(Path.Combine(cs, "OrdersController.cs"), """
+            using Microsoft.AspNetCore.Mvc;
+            using Shop.Contracts;
+
+            namespace Shop.Api;
+
+            [ApiController]
+            [Route("api/[controller]")]
+            public sealed class OrdersController : ControllerBase
+            {
+                [HttpPost]
+                public ActionResult CreateOrder([FromBody] CustomerDto body) => Ok();
+            }
+            """);
+        File.WriteAllText(Path.Combine(cs, "ReportsController.cs"), """
+            using Microsoft.AspNetCore.Mvc;
+
+            namespace Shop.Api;
+
+            [ApiController]
+            [Route("api/[controller]")]
+            public sealed class ReportsController : ControllerBase
+            {
+                [HttpGet]
+                public ActionResult GetReports() => Ok();
+            }
+            """);
+
+        // TS client: a STRONG axios.post (ground truth) + a verb-less fetch (trap (c)).
+        File.WriteAllText(Path.Combine(ts, "orders.api.ts"), """
+            import axios from "axios";
+
+            export interface CustomerDto {
+              id: number;
+              name: string;
+              email: string;
+            }
+
+            export async function createOrder(body: CustomerDto): Promise<void> {
+              await axios.post("/api/orders", body);
+            }
+
+            export async function loadReports(): Promise<unknown> {
+              const res = await fetch("/api/reports");
+              return res.json();
+            }
+            """);
+
+        // C# TEST file with an HttpClient url literal "/api/secret" (trap (d)) — must be excluded by language+test_role.
+        File.WriteAllText(Path.Combine(tests, "SecretEndpointTests.cs"), """
+            using System.Net.Http;
+            using System.Threading.Tasks;
+            using Xunit;
+
+            namespace Shop.Tests;
+
+            public sealed class SecretEndpointTests
+            {
+                [Fact]
+                public async Task Secret_IsReachable()
+                {
+                    using var client = new HttpClient();
+                    var res = await client.GetAsync("/api/secret");
+                    Assert.NotNull(res);
+                }
+            }
+            """);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Honesty classification of one emitted edge: is it a correct bridge or a false positive?
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private static (bool ok, string why) ClassifyHonesty(BridgeGraph graph, ScoredEdge edge)
+    {
+        string src = EndpointDisplayOf(graph, edge, EndpointSide.Source);
+        string tgt = EndpointDisplayOf(graph, edge, EndpointSide.Target);
+        var names = new HashSet<string>(new[] { src, tgt }, StringComparer.Ordinal);
+
+        // Correct ground-truth bridges.
+        if (edge.Edge.Kind == BridgeKind.StoredIn && names.Contains("Customer") && names.Contains("Customers"))
+            return (true, "Leg3 Customer->Customers");
+        if (edge.Edge.Kind == BridgeKind.MapsTo && names.Contains("Customer") && names.Contains("CustomerDto"))
+            return (true, "Leg2 Customer<->CustomerDto");
+        if (edge.Edge.Kind == BridgeKind.Hits && names.Contains("CreateOrder"))
+            return (true, "Leg1 POST /api/orders -> CreateOrder");
+
+        // The inbound CreateMap<UpdateCustomerRequest, Customer> is a REAL, correct structural edge (CreateMap is a
+        // valid breadcrumb). It is correct as long as the Request stays a DTO-side endpoint and it is not High-via-name.
+        if (edge.Edge.Kind == BridgeKind.MapsTo && names.Contains("UpdateCustomerRequest") && names.Contains("Customer"))
+            return (true, "Leg2 inbound CreateMap (structural; Request not mislabeled as entity)");
+
+        // The Account CreateMap is a real structural breadcrumb. It is acceptable as long as it never becomes a
+        // name-anchored High (the ambiguous-name guard owns that, asserted separately). Count as a structural TP.
+        if (edge.Edge.Kind == BridgeKind.MapsTo && (names.Contains("AccountDto") || names.Contains("Account")))
+            return (true, "Leg2 Account CreateMap (structural breadcrumb; ambiguity capped, not High)");
+
+        // CustomerDto is the request-body type of POST /api/orders, so a Consumes endpoint->DTO edge
+        // (CreateOrder -> CustomerDto) is a legitimate structural Leg-1 edge.
+        if (edge.Edge.Kind == BridgeKind.Consumes && names.Contains("CreateOrder") && names.Contains("CustomerDto"))
+            return (true, "Leg1 consumes CreateOrder -> CustomerDto ([FromBody])");
+
+        // GetReports is the GET /api/reports endpoint. The TS carrier is verb-less fetch, so any Hits edge it forms is
+        // route-only (verb-unknown). That is a HONEST, correct route bridge (Medium, never assumed-GET): the route DOES
+        // line up; only the verb is unknown, which the IsVerbUnknown flag faithfully reports (Guard 4 asserts that). It
+        // is therefore a true positive, NOT a phantom — a verb-unknown route match is the designed Medium outcome.
+        if (edge.Edge.Kind == BridgeKind.Hits && names.Contains("GetReports"))
+            return (true, "Leg1 route-only /api/reports -> GetReports (verb-unknown, honest Medium)");
+
+        // Anything else is a false positive (notably: an /api/secret edge, an IdHolder field-set edge, an
+        // assumed-GET /api/reports edge — each of which a hard guard above also asserts must not exist).
+        return (false, $"unexpected {edge.Edge.Kind} {src}->{tgt}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Extraction + graph helpers.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private static MillerRepositoryIndex ExtractAndLoad(string binary, TempWorkspace work)
+    {
+        var runner = new JulieExtractRunner(binary);
+        ExtractReport report = runner.Scan(work.Repo, work.Db, force: true);
+        Assert.Equal("scan", report.Operation);
+        Assert.NotEqual("failed", report.Status);
+        Assert.Equal((int)MillerExtractContract.ExpectedSchemaVersion, report.SchemaVersion);
+        Assert.Equal((int)MillerExtractContract.ExpectedExtractContractVersion, report.ExtractContractVersion);
+        Assert.True(report.SymbolsExtracted > 0, "scan should extract at least one symbol");
+
+        return RepositoryIndexLoader.Load(work.Db);
+    }
+
+    // Every distinct bridge edge in the graph, deduped by the graph's own signature (Kind|sortedIds). BridgeGraph
+    // has no node-set accessor, so we sweep node ids breadth-first from a complete seed set: every symbol id the
+    // index knows (covers symbol-backed endpoints, e.g. both sides of a MapsTo) plus the synthesized table/route ids
+    // the fixtures could create (covers non-symbol endpoints). Incident edges of any vertex name both endpoint ids,
+    // so the BFS reaches every connected vertex from those seeds.
+    private static IReadOnlyList<ScoredEdge> EnumerateDistinctEdges(MillerRepositoryIndex index, BridgeGraph graph)
+    {
+        var discovered = new HashSet<string>(StringComparer.Ordinal);
+        var frontier = new Queue<string>();
+        foreach (var seed in SeedNodeIds(index, graph))
+        {
+            if (discovered.Add(seed))
+                frontier.Enqueue(seed);
+        }
+
+        var seenEdges = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<ScoredEdge>();
+        while (frontier.Count > 0)
+        {
+            var id = frontier.Dequeue();
+            foreach (var edge in graph.Incident(id))
+            {
+                string? a = BridgeGraph.NodeIdOf(edge.Edge.SourceRef, edge.Edge.Kind, EndpointSide.Source);
+                string? b = BridgeGraph.NodeIdOf(edge.Edge.TargetRef, edge.Edge.Kind, EndpointSide.Target);
+                if (a is null || b is null)
+                    continue;
+
+                var (x, y) = string.CompareOrdinal(a, b) <= 0 ? (a, b) : (b, a);
+                if (seenEdges.Add($"{edge.Edge.Kind}|{x}|{y}"))
+                    result.Add(edge);
+
+                if (discovered.Add(a)) frontier.Enqueue(a);
+                if (discovered.Add(b)) frontier.Enqueue(b);
+            }
+        }
+        return result;
+    }
+
+    // The complete seed set: every indexed symbol id (so symbol-backed components are entered) + the synthesized
+    // table/route ids any fixture could produce. Filtered to actual vertices via Contains. Deterministic, needs no
+    // node-enumeration accessor on BridgeGraph.
+    private static IReadOnlyCollection<string> SeedNodeIds(MillerRepositoryIndex index, BridgeGraph graph)
+    {
+        var seeds = new List<string>();
+        foreach (var symbolId in AllSymbolIds(index))
+            if (graph.Contains(symbolId))
+                seeds.Add(symbolId);
+
+        foreach (var table in TableDisplays)
+            seeds.Add(BridgeGraph.SynthesizeId(BridgeNodeKind.DbTable, table));
+        foreach (var route in RouteDisplays)
+            seeds.Add(BridgeGraph.SynthesizeId(BridgeNodeKind.TsType, route));
+
+        return seeds.Where(graph.Contains).Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    private static readonly string[] TableDisplays = { "AppSettings", "Customers", "Reports", "Orders" };
+
+    private static readonly string[] RouteDisplays =
+    {
+        "/api/appsettings/{}", "api/appsettings/{}", "/api/orders", "api/orders",
+        "/api/reports", "api/reports", "/api/secret", "api/secret",
+        "/api/appsettings", "api/appsettings",
+    };
+
+    // Every symbol id the index holds (DocIds are contiguous 0..DocumentCount-1).
+    private static IReadOnlyCollection<string> AllSymbolIds(MillerRepositoryIndex index)
+    {
+        var ids = new List<string>(index.DocumentCount);
+        for (int docId = 0; docId < index.DocumentCount; docId++)
+            ids.Add(index.Resolve(docId).SymbolId);
+        return ids;
+    }
+
+    private static ScoredEdge SingleEdgeOfKind(BridgeGraph graph, string startId, BridgeKind kind)
+    {
+        var edges = graph.Walk(startId, 3).Where(e => e.Edge.Kind == kind).ToList();
+        Assert.True(edges.Count >= 1, $"expected at least one {kind} edge from {startId}, found none");
+        return edges[0];
+    }
+
+    private static bool EdgeTouchesDisplay(BridgeGraph graph, ScoredEdge edge, string display) =>
+        string.Equals(EndpointDisplayOf(graph, edge, EndpointSide.Source), display, StringComparison.Ordinal)
+        || string.Equals(EndpointDisplayOf(graph, edge, EndpointSide.Target), display, StringComparison.Ordinal);
+
+    private static string EndpointDisplayOf(BridgeGraph graph, ScoredEdge edge, EndpointSide side)
+    {
+        var edgeRef = side == EndpointSide.Source ? edge.Edge.SourceRef : edge.Edge.TargetRef;
+        var id = BridgeGraph.NodeIdOf(edgeRef, edge.Edge.Kind, side);
+        if (id is not null)
+        {
+            var node = graph.Node(id);
+            if (node is not null)
+                return node.Display;
+        }
+        // Fall back to the ref's own display (set by the leg) when the node is not in the lookup.
+        return edgeRef.Display ?? string.Empty;
+    }
+
+    private static string DescribeEdge(BridgeGraph graph, ScoredEdge edge) =>
+        $"{EndpointDisplayOf(graph, edge, EndpointSide.Source)} --{edge.Edge.Kind}--> {EndpointDisplayOf(graph, edge, EndpointSide.Target)}";
+
+    private static string FindSymbolId(MillerRepositoryIndex index, string name, string kind)
+    {
+        string? id = FindSymbolIdOrNull(index, name, kind);
+        Assert.True(id is not null, $"fixture symbol '{name}' (kind {kind}) was not extracted/indexed");
+        return id!;
+    }
+
+    private static string? FindSymbolIdOrNull(MillerRepositoryIndex index, string name, string kind)
+    {
+        var matches = index.FindByName(name)
+            .Where(s => string.Equals(s.Kind, kind, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (matches.Count == 0)
+            matches = index.FindByName(name).ToList();
+        return matches.Count > 0 ? matches[0].SymbolId : null;
+    }
+
+    private static string Fmt(double value) =>
+        value.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+    // Throwaway workspace: a repo dir to extract + the DB the extract writes to. MILLER_KEEP_FIXTURE=1 keeps it.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private readonly struct TempWorkspace : IDisposable
+    {
+        public string Root { get; }
+        public string Repo => Path.Combine(Root, "repo");
+        public string Db => Path.Combine(Root, "symbols.db");
+
+        public TempWorkspace()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "miller-lbt-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Repo);
+        }
+
+        public void Dispose()
+        {
+            if (Environment.GetEnvironmentVariable("MILLER_KEEP_FIXTURE") == "1")
+                return;
+            try { Directory.Delete(Root, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/tests/Miller.Tests/Indexing/LiveExtractIndexTests.cs
+++ b/tests/Miller.Tests/Indexing/LiveExtractIndexTests.cs
@@ -43,8 +43,8 @@ public sealed class LiveExtractIndexTests
 
             Assert.Equal("scan", report.Operation);
             Assert.NotEqual("failed", report.Status);
-            Assert.Equal(26, report.SchemaVersion);                 // pinned schema
-            Assert.Equal(1, report.ExtractContractVersion);         // pinned contract
+            Assert.Equal((int)MillerExtractContract.ExpectedSchemaVersion, report.SchemaVersion);                 // pinned schema
+            Assert.Equal((int)MillerExtractContract.ExpectedExtractContractVersion, report.ExtractContractVersion);         // pinned contract
             Assert.True(report.SymbolsExtracted > 0, "scan should extract at least one symbol");
 
             // --- read -> build -> query ---

--- a/tests/Miller.Tests/Indexing/RepositoryIndexLoaderBridgeTests.cs
+++ b/tests/Miller.Tests/Indexing/RepositoryIndexLoaderBridgeTests.cs
@@ -1,0 +1,206 @@
+using Microsoft.Data.Sqlite;
+using Miller.Core.Graph;
+using Miller.Core.Resolver; // BridgeKind, ConfidenceBand, ScoredEdge (the Walk result element type)
+using Miller.Indexing;
+using Xunit;
+
+namespace Miller.Tests.Indexing;
+
+/// <summary>
+/// Pins the M4 bridge wiring through the SINGLE production build path (plan Task 9): after
+/// <see cref="RepositoryIndexLoader.Load"/> runs <see cref="SqliteBridgeReader"/> + <see cref="BridgeGraphBuilder"/>,
+/// the resulting <see cref="MillerRepositoryIndex.BridgeGraph"/> is populated and the existing index features still
+/// work. Builds a temp 28/2 DB carrying the <c>UserDto → ApplicationUser → ApplicationUsers</c> chain (a CreateMap
+/// type-argument pair + a DbSet&lt;T&gt; property) plus the entity/DTO symbols the resolver needs. Fast suite.
+/// </summary>
+public sealed class RepositoryIndexLoaderBridgeTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _dbPath;
+
+    public RepositoryIndexLoaderBridgeTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "miller-loaderbridge-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(_dir);
+        _dbPath = Path.Combine(_dir, "symbols.db");
+        BuildChainDb();
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // Build a DB whose bridge breadcrumbs resolve into a real cross-language chain:
+    //   CreateMap<ApplicationUser, UserDto>  (DTO↔entity, MapsTo)   +   DbSet<ApplicationUser> ApplicationUsers (entity↔table, StoredIn)
+    // The entity (ApplicationUser) and DTO (UserDto) are real class symbols so the SymbolResolver resolves both
+    // sides and the scorer can band the StoredIn/MapsTo edges High.
+    private void BuildChainDb()
+    {
+        using var connection = new SqliteConnection(
+            new SqliteConnectionStringBuilder { DataSource = _dbPath, Mode = SqliteOpenMode.ReadWriteCreate }.ToString());
+        connection.Open();
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                CREATE TABLE symbols (
+                    id TEXT PRIMARY KEY, name TEXT, signature TEXT, kind TEXT, language TEXT,
+                    file_path TEXT, start_line INTEGER, end_line INTEGER, parent_id TEXT, metadata TEXT
+                );
+                CREATE TABLE identifiers (
+                    id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT, start_line INTEGER, containing_symbol_id TEXT
+                );
+                CREATE TABLE relationships (id TEXT PRIMARY KEY, from_symbol_id TEXT, to_symbol_id TEXT, kind TEXT);
+                CREATE TABLE type_arguments (
+                    id TEXT PRIMARY KEY, identifier_id TEXT, parent_arg_id TEXT, ordinal INTEGER,
+                    type_name TEXT, target_symbol_id TEXT, file_path TEXT, language TEXT, last_indexed TEXT
+                );
+                CREATE TABLE literals (
+                    id TEXT PRIMARY KEY, literal_text TEXT, kind TEXT, carrier TEXT, arg_position INTEGER,
+                    language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, start_byte INTEGER,
+                    end_byte INTEGER, containing_symbol_id TEXT, confidence REAL
+                );
+                CREATE TABLE symbol_annotations (
+                    id TEXT PRIMARY KEY, symbol_id TEXT, ordinal INTEGER, annotation TEXT, annotation_key TEXT, raw_text TEXT, carrier TEXT
+                );
+                CREATE TABLE schema_version (version INTEGER);
+                CREATE TABLE external_extract_metadata (key TEXT, value TEXT);
+
+                INSERT INTO schema_version(version) VALUES (28);
+                INSERT INTO external_extract_metadata(key, value) VALUES ('extract_contract_version', '2');
+
+                -- The entity, the DTO, and a DbContext exposing DbSet<ApplicationUser> ApplicationUsers.
+                INSERT INTO symbols(id, name, signature, kind, language, file_path, start_line, end_line, parent_id, metadata)
+                VALUES
+                  ('s-entity', 'ApplicationUser', 'public class ApplicationUser', 'class', 'csharp', 'model/ApplicationUser.cs', 1, 20, NULL, NULL),
+                  ('s-dto',    'UserDto',         'public class UserDto',         'class', 'csharp', 'dto/UserDto.cs',           1, 10, NULL, NULL),
+                  ('s-ctx',    'AppDbContext',    'public class AppDbContext',    'class', 'csharp', 'data/AppDbContext.cs',     1, 30, NULL, NULL),
+                  ('s-prop',   'ApplicationUsers','public DbSet<ApplicationUser> ApplicationUsers { get; set; }', 'property', 'csharp', 'data/AppDbContext.cs', 5, 5, 's-ctx', NULL),
+                  ('s-profile','MapProfile',      'public class MapProfile',      'class', 'csharp', 'map/MapProfile.cs',        1, 8, NULL, NULL);
+
+                -- CreateMap<ApplicationUser, UserDto> use-site: two top-level type args sharing identifier_id 'id-map'.
+                INSERT INTO type_arguments(id, identifier_id, parent_arg_id, ordinal, type_name, target_symbol_id, file_path, language, last_indexed)
+                VALUES
+                  ('ta-0', 'id-map', NULL, 0, 'ApplicationUser', NULL, 'map/MapProfile.cs', 'csharp', NULL),
+                  ('ta-1', 'id-map', NULL, 1, 'UserDto',         NULL, 'map/MapProfile.cs', 'csharp', NULL);
+                """;
+            command.ExecuteNonQuery();
+        }
+    }
+
+    [Fact]
+    public void Load_PopulatesBridgeGraph_WithTheEntityTableChain()
+    {
+        var index = RepositoryIndexLoader.Load(_dbPath);
+
+        // The entity↔table StoredIn edge: the entity node is ApplicationUser's symbol id, and it bridges to the
+        // synthesized table node (CsEntity → DbTable). The table node id is namespaced by kind + lowercased display.
+        Assert.True(index.BridgeGraph.Contains("s-entity"));
+
+        string tableNodeId = BridgeGraph.SynthesizeId(BridgeNodeKind.DbTable, "ApplicationUsers");
+        Assert.True(index.BridgeGraph.Contains(tableNodeId));
+
+        // Walking from the entity reaches the StoredIn edge to the table at depth 1, banded High (a DbSet anchor with
+        // a resolved entity is an explicit breadcrumb).
+        var fromEntity = index.BridgeGraph.Walk("s-entity", maxDepth: 3);
+        var storedIn = Assert.Single(fromEntity, e => e.Edge.Kind == BridgeKind.StoredIn);
+        Assert.Equal(ConfidenceBand.High, storedIn.Band);
+        Assert.Equal("ApplicationUser", storedIn.Edge.SourceRef.Display);
+        Assert.Equal("ApplicationUsers", storedIn.Edge.TargetRef.Display);
+    }
+
+    [Fact]
+    public void Load_PopulatesBridgeGraph_WithTheCreateMapDtoEntityEdge()
+    {
+        var index = RepositoryIndexLoader.Load(_dbPath);
+
+        // The DTO↔entity MapsTo edge from CreateMap<ApplicationUser, UserDto>: both sides resolve to real class
+        // symbols, so the node ids are the symbol ids and the edge connects them.
+        Assert.True(index.BridgeGraph.Contains("s-dto"));
+
+        var fromDto = index.BridgeGraph.Walk("s-dto", maxDepth: 3);
+        Assert.Contains(fromDto, e => e.Edge.Kind == BridgeKind.MapsTo);
+
+        // From the entity, the walk reaches BOTH the table (StoredIn) and the DTO (MapsTo) — the chain
+        // UserDto ↔ ApplicationUser ↔ ApplicationUsers is connected through the single entity node.
+        var fromEntity = index.BridgeGraph.Walk("s-entity", maxDepth: 3);
+        Assert.Contains(fromEntity, e => e.Edge.Kind == BridgeKind.StoredIn);
+        Assert.Contains(fromEntity, e => e.Edge.Kind == BridgeKind.MapsTo);
+    }
+
+    [Fact]
+    public void Load_StillBuildsTheSymbolIndexAndGraph_BridgeIsAdditive()
+    {
+        var index = RepositoryIndexLoader.Load(_dbPath);
+
+        // The existing index features are intact: every symbol is indexed, search resolves, and the dependency
+        // graph still carries every symbol as a node (the bridge graph is additive, not a replacement).
+        Assert.Equal(5, index.DocumentCount);
+        Assert.Equal("s-entity", index.FindByName("ApplicationUser").Single().SymbolId);
+        Assert.True(index.Graph.Contains("s-entity"));
+    }
+
+    [Fact]
+    public void Load_InvokesBridgeBuildMeasurementCallback()
+    {
+        // Plan Task 9: the loader MEASURES the bridge-graph build cost and hands the elapsed time to the caller
+        // (the services log it). The callback must fire exactly once with a non-negative duration.
+        int calls = 0;
+        TimeSpan observed = TimeSpan.FromSeconds(-1);
+        var index = RepositoryIndexLoader.Load(_dbPath, onBridgeGraphBuilt: elapsed =>
+        {
+            calls++;
+            observed = elapsed;
+        });
+
+        Assert.Equal(1, calls);
+        Assert.True(observed >= TimeSpan.Zero);
+        Assert.True(index.BridgeGraph.Contains("s-entity")); // and the graph is still populated
+    }
+
+    [Fact]
+    public void Load_EmptyBridgeBreadcrumbs_YieldEmptyBridgeGraph_IndexStillBuilds()
+    {
+        // A DB with symbols but NO bridge breadcrumbs (no type_arguments / DbSet props) builds an index whose
+        // bridge graph has no edges — but the index itself is fully functional.
+        string dir = Path.Combine(Path.GetTempPath(), "miller-nobridge-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        string dbPath = Path.Combine(dir, "symbols.db");
+        try
+        {
+            using (var connection = new SqliteConnection(
+                new SqliteConnectionStringBuilder { DataSource = dbPath, Mode = SqliteOpenMode.ReadWriteCreate }.ToString()))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE symbols (id TEXT PRIMARY KEY, name TEXT, signature TEXT, kind TEXT, language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, parent_id TEXT, metadata TEXT);
+                    CREATE TABLE identifiers (id TEXT PRIMARY KEY, name TEXT, kind TEXT, file_path TEXT, start_line INTEGER, containing_symbol_id TEXT);
+                    CREATE TABLE relationships (id TEXT PRIMARY KEY, from_symbol_id TEXT, to_symbol_id TEXT, kind TEXT);
+                    CREATE TABLE type_arguments (id TEXT PRIMARY KEY, identifier_id TEXT, parent_arg_id TEXT, ordinal INTEGER, type_name TEXT, target_symbol_id TEXT, file_path TEXT, language TEXT, last_indexed TEXT);
+                    CREATE TABLE literals (id TEXT PRIMARY KEY, literal_text TEXT, kind TEXT, carrier TEXT, arg_position INTEGER, language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER, containing_symbol_id TEXT, confidence REAL);
+                    CREATE TABLE symbol_annotations (id TEXT PRIMARY KEY, symbol_id TEXT, ordinal INTEGER, annotation TEXT, annotation_key TEXT, raw_text TEXT, carrier TEXT);
+                    CREATE TABLE schema_version (version INTEGER);
+                    CREATE TABLE external_extract_metadata (key TEXT, value TEXT);
+                    INSERT INTO schema_version(version) VALUES (28);
+                    INSERT INTO external_extract_metadata(key, value) VALUES ('extract_contract_version', '2');
+                    INSERT INTO symbols(id, name, signature, kind, language, file_path, start_line, end_line, parent_id, metadata)
+                    VALUES ('s1', 'Foo', 'public class Foo', 'class', 'csharp', 'Foo.cs', 1, 3, NULL, NULL);
+                    """;
+                command.ExecuteNonQuery();
+            }
+
+            var index = RepositoryIndexLoader.Load(dbPath);
+
+            Assert.Equal(1, index.DocumentCount);
+            // No breadcrumbs → the symbol is not a bridge node, and walking it yields nothing.
+            Assert.False(index.BridgeGraph.Contains("s1"));
+            Assert.Empty(index.BridgeGraph.Walk("s1", maxDepth: 3));
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs
+++ b/tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs
@@ -33,7 +33,7 @@ public sealed class RepositoryIndexLoaderTests
         {
             new JulieDbFixture.IdentifierRow("i1", "Validate", "call", "csharp", "src/A.cs", 2, ProcessId),
         };
-        return JulieDbFixture.Create(26, "1", rows, identifiers: identifiers, relationships: relationships);
+        return JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, rows, identifiers: identifiers, relationships: relationships);
     }
 
     [Fact]

--- a/tests/Miller.Tests/Indexing/SqliteBridgeReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/SqliteBridgeReaderTests.cs
@@ -1,0 +1,291 @@
+using Microsoft.Data.Sqlite;
+using Miller.Core.Graph;
+using Miller.Indexing;
+using Xunit;
+
+namespace Miller.Tests.Indexing;
+
+/// <summary>
+/// Pins <see cref="SqliteBridgeReader"/> (plan Task 9) against a hand-written 28/2 bridge DB. These are
+/// read-CONTRACT tests: they assert the exact <see cref="Miller.Core.Contracts.TypeArgument"/> /
+/// <see cref="Miller.Core.Contracts.LiteralRecord"/> / <see cref="Miller.Core.Contracts.SymbolAnnotation"/> /
+/// <see cref="Miller.Core.Contracts.DbSetProperty"/> mapping (ordering, NULL discipline, the DbSet&lt;T&gt;
+/// signature parse, and the literal→file:line seam the <see cref="BridgeGraphBuilder"/> requires). The reader
+/// performs NO leg transformation — that is Task 8's job — so these assert raw rows only. Fast suite: a temp
+/// SQLite DB, no julie-server.
+/// </summary>
+public sealed class SqliteBridgeReaderTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _dbPath;
+
+    public SqliteBridgeReaderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "miller-bridge-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(_dir);
+        _dbPath = Path.Combine(_dir, "symbols.db");
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ---- DB builder ------------------------------------------------------------------------------------------
+
+    private SqliteConnection OpenWrite()
+    {
+        var connection = new SqliteConnection(
+            new SqliteConnectionStringBuilder { DataSource = _dbPath, Mode = SqliteOpenMode.ReadWriteCreate }.ToString());
+        connection.Open();
+        return connection;
+    }
+
+    // Create the 28/2 bridge-relevant schema (the four tables the reader reads + the gate tables) and seed the gate.
+    private void CreateSchemaAndGate(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE symbols (
+                id TEXT PRIMARY KEY, name TEXT, signature TEXT, kind TEXT, language TEXT,
+                file_path TEXT, start_line INTEGER, end_line INTEGER, parent_id TEXT, metadata TEXT
+            );
+            CREATE TABLE type_arguments (
+                id TEXT PRIMARY KEY, identifier_id TEXT, parent_arg_id TEXT, ordinal INTEGER,
+                type_name TEXT, target_symbol_id TEXT, file_path TEXT, language TEXT, last_indexed TEXT
+            );
+            CREATE TABLE literals (
+                id TEXT PRIMARY KEY, literal_text TEXT, kind TEXT, carrier TEXT, arg_position INTEGER,
+                language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, start_byte INTEGER,
+                end_byte INTEGER, containing_symbol_id TEXT, confidence REAL
+            );
+            CREATE TABLE symbol_annotations (
+                id TEXT PRIMARY KEY, symbol_id TEXT, ordinal INTEGER, annotation TEXT, annotation_key TEXT,
+                raw_text TEXT, carrier TEXT
+            );
+            CREATE TABLE schema_version (version INTEGER);
+            CREATE TABLE external_extract_metadata (key TEXT, value TEXT);
+            """;
+        command.ExecuteNonQuery();
+
+        using var seed = connection.CreateCommand();
+        seed.CommandText = """
+            INSERT INTO schema_version(version) VALUES (28);
+            INSERT INTO external_extract_metadata(key, value) VALUES ('extract_contract_version', '2');
+            """;
+        seed.ExecuteNonQuery();
+    }
+
+    private static void Exec(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    // ---- type_arguments --------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_TypeArguments_OrderedByIdentifierThenOrdinal_WithNullDiscipline()
+    {
+        using (var c = OpenWrite())
+        {
+            CreateSchemaAndGate(c);
+            // Two use-sites. Insert OUT of order to prove the reader sorts by (identifier_id, ordinal).
+            Exec(c, """
+                INSERT INTO type_arguments(id, identifier_id, parent_arg_id, ordinal, type_name, target_symbol_id, file_path, language, last_indexed)
+                VALUES
+                  ('t4', 'idB', NULL, 1, 'ApplicationUser', NULL, 'src/Profile.cs', 'csharp', NULL),
+                  ('t2', 'idA', NULL, 1, 'UserDto',         NULL, 'src/Map.cs',     'csharp', NULL),
+                  ('t1', 'idA', NULL, 0, 'ApplicationUser', NULL, 'src/Map.cs',     'csharp', NULL),
+                  ('t3', 'idB', NULL, 0, 'List',            NULL, 'src/Profile.cs', 'csharp', NULL),
+                  ('t5', 'idB', 't3', 0, 'Inner',           NULL, 'src/Profile.cs', 'csharp', NULL);
+                """);
+        }
+
+        var data = SqliteBridgeReader.Read(_dbPath);
+
+        // Ordered by identifier_id then ordinal: idA(0,1) then idB(0,1) then nested idB(t5, ordinal 0).
+        Assert.Equal(
+            new[] { ("idA", 0, "ApplicationUser"), ("idA", 1, "UserDto"),
+                    ("idB", 0, "List"), ("idB", 0, "Inner"), ("idB", 1, "ApplicationUser") },
+            data.TypeArguments.Select(t => (t.IdentifierId, t.Ordinal, t.TypeName)).ToArray());
+
+        // parent_arg_id NULL → null; populated → verbatim. The nested arg is the one with ParentArgId="t3".
+        var nested = data.TypeArguments.Single(t => t.TypeName == "Inner");
+        Assert.Equal("t3", nested.ParentArgId);
+        Assert.Null(data.TypeArguments.Single(t => t.TypeName == "UserDto").ParentArgId);
+        Assert.Equal("src/Map.cs", data.TypeArguments.Single(t => t.TypeName == "UserDto").FilePath);
+    }
+
+    // ---- literals + the literal→file:line seam ---------------------------------------------------------------
+
+    [Fact]
+    public void Read_Literals_MapsUrlAndSql_AndExposesPerLiteralFileLineSites()
+    {
+        using (var c = OpenWrite())
+        {
+            CreateSchemaAndGate(c);
+            // A url literal (TS client call) and a sql literal — both must come through; ordered by file,start_byte.
+            Exec(c, """
+                INSERT INTO literals(id, literal_text, kind, carrier, arg_position, language, file_path, start_line, end_line, start_byte, end_byte, containing_symbol_id, confidence)
+                VALUES
+                  ('l2', '/api/users/{}', 'url', 'axios.get',  0, 'typescript', 'web/api.ts', 42, 42, 120, 135, 'sym-ts',  0.9),
+                  ('l1', 'SELECT 1 FROM dbo.AppSettings', 'sql', 'QueryAsync', 1, 'csharp', 'data/Repo.cs', 7, 7, 30, 60, 'sym-cs', 0.8);
+                """);
+        }
+
+        var data = SqliteBridgeReader.Read(_dbPath);
+
+        // Ordered by file_path then start_byte: data/Repo.cs(sql) before web/api.ts(url).
+        Assert.Equal(new[] { "sql", "url" }, data.Literals.Select(l => l.Kind).ToArray());
+
+        var url = data.Literals.Single(l => l.Kind == "url");
+        Assert.Equal("/api/users/{}", url.LiteralText);
+        Assert.Equal("axios.get", url.Carrier);
+        Assert.Equal(0, url.ArgPosition);
+        Assert.Equal("typescript", url.Language);
+        Assert.Equal("sym-ts", url.ContainingSymbolId);
+        Assert.Equal(120, url.Span.StartByte);
+        Assert.Equal(135, url.Span.EndByte);
+
+        // The literal→(file,line) seam: the lookup carries the literals row's OWN file_path/start_line, which the
+        // lean LiteralRecord does not re-expose. This is what BridgeGraphBuilder consumes for literal evidence.
+        Assert.True(data.LiteralSites.TryGetValue(url, out var urlSite));
+        Assert.Equal("web/api.ts", urlSite.FilePath);
+        Assert.Equal(42, urlSite.Line);
+
+        var sql = data.Literals.Single(l => l.Kind == "sql");
+        Assert.True(data.LiteralSites.TryGetValue(sql, out var sqlSite));
+        Assert.Equal("data/Repo.cs", sqlSite.FilePath);
+        Assert.Equal(7, sqlSite.Line);
+    }
+
+    // ---- symbol_annotations ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_Annotations_OrderedBySymbolThenOrdinal_ArgsLiveInRawText()
+    {
+        using (var c = OpenWrite())
+        {
+            CreateSchemaAndGate(c);
+            // A class [Route] and a method [HttpGet] — inserted out of order to prove (symbol_id, ordinal) sort.
+            Exec(c, """
+                INSERT INTO symbol_annotations(id, symbol_id, ordinal, annotation, annotation_key, raw_text, carrier)
+                VALUES
+                  ('a2', 'sym-method', 0, 'HttpGet', 'httpget', 'HttpGet("{id}")', 'attribute'),
+                  ('a1', 'sym-class',  0, 'Route',   'route',   'Route("api/[controller]")', 'attribute');
+                """);
+        }
+
+        var data = SqliteBridgeReader.Read(_dbPath);
+
+        // Ordered by symbol_id then ordinal: sym-class before sym-method (ordinal both 0).
+        Assert.Equal(new[] { "sym-class", "sym-method" }, data.Annotations.Select(a => a.SymbolId).ToArray());
+
+        var route = data.Annotations.Single(a => a.AnnotationKey == "route");
+        Assert.Equal("Route", route.Annotation);
+        Assert.Equal("Route(\"api/[controller]\")", route.RawText); // args live ONLY in raw_text (findings 28-2)
+        Assert.Equal("attribute", route.Carrier);
+
+        var verb = data.Annotations.Single(a => a.AnnotationKey == "httpget");
+        Assert.Equal("HttpGet(\"{id}\")", verb.RawText);
+    }
+
+    // ---- DbSet<T> properties ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_DbSetProperties_TableIsPropertyName_EntityIsGenericArg_LeafResolved()
+    {
+        using (var c = OpenWrite())
+        {
+            CreateSchemaAndGate(c);
+            // Three DbContext properties + one non-DbSet property (must be excluded) + a namespaced generic arg.
+            Exec(c, """
+                INSERT INTO symbols(id, name, signature, kind, language, file_path, start_line, end_line, parent_id, metadata)
+                VALUES
+                  ('p1', 'ApplicationUsers', 'public DbSet<ApplicationUser> ApplicationUsers { get; set; }', 'property', 'csharp', 'data/Ctx.cs', 10, 10, 'ctx', NULL),
+                  ('p2', 'AppSettings',      'public DbSet<Core.Data.AppSetting> AppSettings { get; set; }',  'property', 'csharp', 'data/Ctx.cs', 11, 11, 'ctx', NULL),
+                  ('p3', 'Preferences',      'public DbSet<Preferences> Preferences { get; set; }',          'property', 'csharp', 'data/Ctx.cs', 12, 12, 'ctx', NULL),
+                  ('p4', 'Name',             'public string Name { get; set; }',                              'property', 'csharp', 'model/User.cs', 5, 5, 'u', NULL),
+                  ('m1', 'SaveChanges',      'public int SaveChanges()',                                      'method',   'csharp', 'data/Ctx.cs', 20, 22, 'ctx', NULL);
+                """);
+        }
+
+        var data = SqliteBridgeReader.Read(_dbPath);
+
+        // Only the three DbSet<T> properties are anchors; the plain string property + the method are excluded.
+        Assert.Equal(
+            new[] { ("ApplicationUsers", "ApplicationUser"), ("AppSettings", "AppSetting"), ("Preferences", "Preferences") },
+            data.DbSetProperties
+                .OrderBy(d => d.StartLine)
+                .Select(d => (d.TableName, d.EntityTypeName))
+                .ToArray());
+
+        // Table = property NAME (EF convention), NOT a pluralized entity name; entity = the DbSet<T> generic LEAF.
+        var appUsers = data.DbSetProperties.Single(d => d.TableName == "ApplicationUsers");
+        Assert.Equal("ApplicationUser", appUsers.EntityTypeName); // not "ApplicationUsers"
+        Assert.Equal("data/Ctx.cs", appUsers.FilePath);
+        Assert.Equal(10, appUsers.StartLine);
+        // A namespaced generic arg resolves to its leaf type.
+        Assert.Equal("AppSetting", data.DbSetProperties.Single(d => d.TableName == "AppSettings").EntityTypeName);
+    }
+
+    [Fact]
+    public void Read_EmptyBridgeTables_YieldEmptyCollections_NotNull()
+    {
+        using (var c = OpenWrite())
+            CreateSchemaAndGate(c); // schema + gate, no bridge rows
+
+        var data = SqliteBridgeReader.Read(_dbPath);
+
+        Assert.Empty(data.TypeArguments);
+        Assert.Empty(data.Literals);
+        Assert.Empty(data.Annotations);
+        Assert.Empty(data.DbSetProperties);
+        Assert.Empty(data.LiteralSites);
+    }
+
+    // ---- gate + error paths ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_IncompatibleSchema_Throws()
+    {
+        using (var c = OpenWrite())
+        {
+            // Build the schema but seed a WRONG schema_version so the gate rejects it before any bridge read.
+            using var command = c.CreateCommand();
+            command.CommandText = """
+                CREATE TABLE type_arguments (id TEXT PRIMARY KEY, identifier_id TEXT, parent_arg_id TEXT, ordinal INTEGER, type_name TEXT, target_symbol_id TEXT, file_path TEXT, language TEXT, last_indexed TEXT);
+                CREATE TABLE literals (id TEXT PRIMARY KEY, literal_text TEXT, kind TEXT, carrier TEXT, arg_position INTEGER, language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, start_byte INTEGER, end_byte INTEGER, containing_symbol_id TEXT, confidence REAL);
+                CREATE TABLE symbol_annotations (id TEXT PRIMARY KEY, symbol_id TEXT, ordinal INTEGER, annotation TEXT, annotation_key TEXT, raw_text TEXT, carrier TEXT);
+                CREATE TABLE symbols (id TEXT PRIMARY KEY, name TEXT, signature TEXT, kind TEXT, language TEXT, file_path TEXT, start_line INTEGER, end_line INTEGER, parent_id TEXT, metadata TEXT);
+                CREATE TABLE schema_version (version INTEGER);
+                CREATE TABLE external_extract_metadata (key TEXT, value TEXT);
+                INSERT INTO schema_version(version) VALUES (27);
+                INSERT INTO external_extract_metadata(key, value) VALUES ('extract_contract_version', '2');
+                """;
+            command.ExecuteNonQuery();
+        }
+
+        Assert.Throws<IncompatibleExtractException>(() => SqliteBridgeReader.Read(_dbPath));
+    }
+
+    [Fact]
+    public void Read_MissingDbFile_ThrowsFileNotFound()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), "miller-nope-" + Guid.NewGuid().ToString("N"), "symbols.db");
+
+        var ex = Assert.Throws<FileNotFoundException>(() => SqliteBridgeReader.Read(missing));
+        Assert.Contains(missing, ex.Message);
+    }
+
+    [Fact]
+    public void Read_NullPath_Throws()
+    {
+        // ArgumentException.ThrowIfNullOrWhiteSpace throws ArgumentNullException (a subclass) for null — matching
+        // RepositoryIndexLoader/SqliteSymbolReader. Assert the exact derived type, and that whitespace still throws.
+        Assert.Throws<ArgumentNullException>(() => SqliteBridgeReader.Read(null!));
+        Assert.Throws<ArgumentException>(() => SqliteBridgeReader.Read("   "));
+    }
+}

--- a/tests/Miller.Tests/Indexing/SqliteSymbolReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/SqliteSymbolReaderTests.cs
@@ -81,7 +81,7 @@ public sealed class SqliteSymbolReaderTests
         // D7: the reader projects symbols.end_line (the whole-symbol span end) so the diff→symbol line-precise
         // mapping (D5) can intersect [StartLine, EndLine] against a changed range — without a per-call DB hop.
         // NULL end_line (the same nullable-INTEGER trap as start_line) must read as 0, not throw.
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("c0000000000000000000000000000001", "Spanned", "method", "csharp",
                 "src/Spanned.cs", "public void Spanned()", 10, null) { EndLine = 42 },
@@ -133,7 +133,7 @@ public sealed class SqliteSymbolReaderTests
         // when true (compact serde JSON). Miller surfaces that as IndexedSymbol.IsTest. Verified here across
         // go/python/csharp positives + the negative / false / NULL / substring-trap / malformed cases.
         // (M2 decision-4 — the cross-language primary test signal.)
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("a0000000000000000000000000000001", "TestAdd", "function", "go",
                 "math/add_test.go", "func TestAdd(t *testing.T)", 3, null) { Metadata = "{\"is_test\":true}" },
@@ -195,10 +195,10 @@ public sealed class SqliteSymbolReaderTests
     {
         // The gate must run before the SELECT: a schema-27 DB (with rows) throws the typed gate error,
         // it does not return rows.
-        using var fx = JulieDbFixture.Create(27, "1", JulieDbFixture.DefaultRows);
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema + 1, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows);
 
         var ex = Assert.Throws<IncompatibleExtractException>(() => SqliteSymbolReader.Read(fx.DbPath));
-        Assert.Contains("27", ex.Message);
+        Assert.Contains(JulieDbFixture.SchemaText(1), ex.Message);
     }
 
     [Fact]

--- a/tests/Miller.Tests/Indexing/SqliteSymbolReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/SqliteSymbolReaderTests.cs
@@ -173,6 +173,58 @@ public sealed class SqliteSymbolReaderTests
     }
 
     [Fact]
+    public void Read_TestRole_FromMetadata_PopulatesRoleAndIsTest_CrossLanguage()
+    {
+        // M4 Task 9: julie's test_detection writes a "test_role" string (cross-language) into symbols.metadata for
+        // test symbols. Miller surfaces it as IndexedSymbol.TestRole (the raw role value) ALONGSIDE the existing
+        // is_test boolean. A fixture_setup carries a role WITHOUT is_test:true — TestRole.IsTest must still be true
+        // for it (presence of a non-blank role is the test signal), so this is parsed independently of is_test.
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
+        {
+            // is_test true + an explicit test_role: both populated.
+            new JulieDbFixture.SymbolRow("d0000000000000000000000000000001", "TestAdd", "function", "go",
+                "math/add_test.go", "func TestAdd(t *testing.T)", 3, null)
+                { Metadata = "{\"is_test\":true,\"test_role\":\"test_case\"}" },
+            // A fixture: test_role present WITHOUT is_test:true (julie may emit role-only). Role IS the test signal.
+            new JulieDbFixture.SymbolRow("d0000000000000000000000000000002", "SetUp", "method", "csharp",
+                "Tests/Fixtures.cs", "public void SetUp()", 5, null)
+                { Metadata = "{\"test_role\":\"fixture_setup\"}" },
+            // Production code: neither key → TestRole null, IsTest false.
+            new JulieDbFixture.SymbolRow("e0000000000000000000000000000001", "Add", "function", "go",
+                "math/add.go", "func Add(a, b int) int", 5, null) { Metadata = "{}" },
+            // is_test true but NO test_role key → IsTest true, TestRole null (the two signals are independent).
+            new JulieDbFixture.SymbolRow("e0000000000000000000000000000002", "Adds", "method", "csharp",
+                "Tests/CalcTests.cs", "public void Adds()", 9, null) { Metadata = "{\"is_test\":true}" },
+        });
+
+        var symbols = SqliteSymbolReader.Read(fx.DbPath);
+        IndexedSymbol Of(string name) => symbols.Single(s => s.Name == name);
+
+        var testAdd = Of("TestAdd");
+        Assert.True(testAdd.IsTest);
+        Assert.NotNull(testAdd.TestRole);
+        Assert.Equal("test_case", testAdd.TestRole!.Value);
+        Assert.True(testAdd.TestRole.IsTest);
+
+        // Role-only (no is_test:true): the role is still parsed and IsTest on the role is true.
+        var setUp = Of("SetUp");
+        Assert.False(setUp.IsTest); // is_test boolean absent
+        Assert.NotNull(setUp.TestRole);
+        Assert.Equal("fixture_setup", setUp.TestRole!.Value);
+        Assert.True(setUp.TestRole.IsTest); // presence of a non-blank role IS the test signal
+
+        // Production code: both null/false.
+        var add = Of("Add");
+        Assert.False(add.IsTest);
+        Assert.Null(add.TestRole);
+
+        // is_test true, no role key: is_test honored, role null.
+        var adds = Of("Adds");
+        Assert.True(adds.IsTest);
+        Assert.Null(adds.TestRole);
+    }
+
+    [Fact]
     public void ToSearchableDocument_ProjectsTheScoringFields_DroppingJoinKeys()
     {
         using var fx = JulieDbFixture.CreateDefault();

--- a/tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs
@@ -62,7 +62,7 @@ public sealed class SymbolGraphReaderTests
             new JulieDbFixture.SymbolRow(LogBId, "Log", "method", "csharp", "src/D.cs",
                 "public void Log()", 1, null),
         };
-        return JulieDbFixture.Create(26, "1", rows, identifiers: identifiers, relationships: relationships);
+        return JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, rows, identifiers: identifiers, relationships: relationships);
     }
 
     [Fact]

--- a/tests/Miller.Tests/Resolver/BridgeScorerTests.cs
+++ b/tests/Miller.Tests/Resolver/BridgeScorerTests.cs
@@ -1,0 +1,390 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="BridgeScorer"/> — the trust contract (design §5). Every assertion is proven from the candidate
+/// PAYLOAD before any leg exists: the scorer reads typed <see cref="Signal"/> records (fieldCount/Jaccard, name tier,
+/// per-side <see cref="NameResolutionSignal"/>) and never re-queries the resolver. Covers the four required cases —
+/// <c>fieldset{count=1}</c> ⇒ no edge; <c>fieldset{count=8,jaccard=0.6}</c> + a structural signal ⇒ scores;
+/// ambiguous-name ⇒ never High; multi-signal outscores single — plus the §5 band boundaries and the unresolved-no-edge
+/// rule. Asserts on the concrete band and numeric score, not just "did not throw".
+/// </summary>
+public sealed class BridgeScorerTests
+{
+    // ---- payload builders (keep each test about the SIGNALS, not ref plumbing) ---------------------------------
+
+    private static NameResolution Resolved(string id = "1") => new(ResolutionStatus.Resolved, id, 1);
+    private static NameResolution Ambiguous(int matchCount = 2) => new(ResolutionStatus.Ambiguous, null, matchCount);
+    private static NameResolution Unresolved() => new(ResolutionStatus.Unresolved, null, 0);
+
+    private static EdgeRef Ref(string display, NameResolution resolution)
+        => new(display, resolution.SymbolId, "x.cs", resolution);
+
+    private static CandidateEdge Edge(
+        IReadOnlyList<Signal> signals,
+        NameResolution? source = null,
+        NameResolution? target = null,
+        BridgeKind kind = BridgeKind.MapsTo,
+        FieldSet? sourceFields = null,
+        FieldSet? targetFields = null)
+    {
+        var src = source ?? Resolved("S");
+        var tgt = target ?? Resolved("T");
+        return new CandidateEdge(
+            kind,
+            Ref("Source", src),
+            Ref("Target", tgt),
+            Evidence: [],
+            Signals: signals,
+            SourceFieldSet: sourceFields,
+            TargetFieldSet: targetFields);
+    }
+
+    private static FieldSet Fields(int count)
+    {
+        var members = new List<FieldMember>(count);
+        for (int i = 0; i < count; i++)
+            members.Add(new FieldMember("F" + i, "string"));
+        return new FieldSet("owner", members);
+    }
+
+    private static readonly Evidence Site = new("Profile.cs", 24);
+
+    // ---- the four required payload-proven cases ----------------------------------------------------------------
+
+    [Fact]
+    public void FieldSetOnly_OneField_ProducesNoEdge()
+    {
+        // A 1-field/generic shape can NOT anchor, and field-set Jaccard is NEVER a sole signal — so a candidate whose
+        // ONLY signal is a 1-field overlap must yield no edge at all.
+        var edge = Edge([new FieldSetSignal(FieldCount: 1, Jaccard: 1.0, Site)]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void FieldSetOnly_ManyFields_StillProducesNoEdge()
+    {
+        // Even a rich, high-Jaccard field-set is never a SOLE anchor — it only raises an edge that already has a signal.
+        var edge = Edge([new FieldSetSignal(FieldCount: 8, Jaccard: 0.9, Site)]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void Structural_PlusRichFieldSet_ScoresHigh()
+    {
+        // fieldset{count=8, jaccard=0.6} + a structural breadcrumb (CreateMap) => a real, High edge.
+        var edge = Edge(
+        [
+            new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+            new FieldSetSignal(FieldCount: 8, Jaccard: 0.6, Site),
+        ]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score >= 0.9, $"expected High (>=0.9), got {scored.Score}");
+    }
+
+    [Fact]
+    public void AmbiguousName_WithStructuralBreadcrumb_IsNeverHigh()
+    {
+        // The structural breadcrumb alone would be High, but a side whose name resolves AMBIGUOUSLY can NEVER be High —
+        // the scorer reads NameResolution.status off the payload, it does NOT re-query the resolver.
+        var edge = Edge(
+            signals:
+            [
+                new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+                new NameResolutionSignal(EndpointSide.Target, ResolutionStatus.Ambiguous, MatchCount: 2),
+            ],
+            target: Ambiguous());
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.NotEqual(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score < 0.9, $"ambiguous-name edge must be < High, got {scored.Score}");
+    }
+
+    [Fact]
+    public void MultiSignal_OutscoresOtherwiseIdenticalSingleSignal()
+    {
+        // N independent signals score higher than one (the multi-signal boost). Same structural anchor, but the
+        // multi-signal candidate adds a name corroborator + a rich field-set.
+        var single = Edge([new StructuralSignal(SignalRule.RouteVerbMatch, Present: true, Site)]);
+        var multi = Edge(
+        [
+            new StructuralSignal(SignalRule.RouteVerbMatch, Present: true, Site),
+            new NameSignal(NameTier.Exact, Site),
+            new FieldSetSignal(FieldCount: 8, Jaccard: 0.8, Site),
+        ]);
+
+        var scoredSingle = BridgeScorer.Score(single);
+        var scoredMulti = BridgeScorer.Score(multi);
+
+        Assert.NotNull(scoredSingle);
+        Assert.NotNull(scoredMulti);
+        Assert.True(
+            scoredMulti!.Score > scoredSingle!.Score,
+            $"multi ({scoredMulti.Score}) should outscore single ({scoredSingle.Score})");
+        Assert.True(scoredMulti.IsMultiSignal);
+        Assert.False(scoredSingle.IsMultiSignal);
+    }
+
+    [Fact]
+    public void DuplicateRuleSignals_DoNotInflateScoreOrBoost()
+    {
+        // Two field-set comparisons of the SAME rule must count once: the dup candidate scores identically to the
+        // single-field-set one and is not "more multi-signal". The boost rewards independent KINDS of evidence.
+        var single = Edge(
+        [
+            new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+            new FieldSetSignal(FieldCount: 8, Jaccard: 0.6, Site),
+        ]);
+        var withDuplicate = Edge(
+        [
+            new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+            new FieldSetSignal(FieldCount: 8, Jaccard: 0.6, Site),
+            new FieldSetSignal(FieldCount: 6, Jaccard: 0.9, Site), // same rule (FieldSetJaccard) — must not double-count
+        ]);
+
+        var scoredSingle = BridgeScorer.Score(single);
+        var scoredDup = BridgeScorer.Score(withDuplicate);
+
+        Assert.NotNull(scoredSingle);
+        Assert.NotNull(scoredDup);
+        Assert.Equal(scoredSingle!.Score, scoredDup!.Score);
+        Assert.Equal(scoredSingle.IsMultiSignal, scoredDup.IsMultiSignal);
+    }
+
+    [Fact]
+    public void DuplicateStructuralRule_IsNotMultiSignal()
+    {
+        // The same structural breadcrumb emitted twice is ONE kind of evidence: High band, but NOT multi-signal and no
+        // within-band boost (the score sits at the High base, not base + step).
+        var edge = Edge(
+        [
+            new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+            new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+        ]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.False(scored.IsMultiSignal);
+        Assert.Equal(0.90, scored.Score, precision: 5);
+    }
+
+    [Fact]
+    public void TwoDistinctStructuralRules_AreMultiSignal()
+    {
+        // Different structural rules ARE independent kinds of evidence — they stack into the multi-signal boost (only
+        // same-rule repeats are deduped).
+        var edge = Edge(
+        [
+            new StructuralSignal(SignalRule.RouteVerbMatch, Present: true, Site),
+            new StructuralSignal(SignalRule.ReturnTypeDto, Present: true, Site),
+        ], kind: BridgeKind.Hits);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.IsMultiSignal);
+        Assert.True(scored.Score > 0.90, $"two distinct structural rules should boost above the High base, got {scored.Score}");
+    }
+
+    // ---- §5 band boundaries ------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(SignalRule.CreateMap)]
+    [InlineData(SignalRule.DbSetProperty)]
+    [InlineData(SignalRule.RouteVerbMatch)]
+    public void StructuralBreadcrumb_Resolved_ScoresHigh(SignalRule rule)
+    {
+        var edge = Edge([new StructuralSignal(rule, Present: true, Site)]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score >= 0.9);
+    }
+
+    [Fact]
+    public void DapperFrom_WithRealFrom_ScoresHigh()
+    {
+        // DapperFrom is High ONLY when a real FROM is present — a leg signals that by emitting it present=true.
+        var edge = Edge([new StructuralSignal(SignalRule.DapperFrom, Present: true, Site)], kind: BridgeKind.StoredIn);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void StructuralSignal_PresentFalse_DoesNotAnchor()
+    {
+        // A considered-but-absent structural signal is no anchor — alone it yields no edge.
+        var edge = Edge([new StructuralSignal(SignalRule.CreateMap, Present: false, Site)]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void RouteOnlyMatch_IsMedium_NotHigh()
+    {
+        // A verb-unknown carrier matched on route alone => Medium, never High (never assume GET).
+        var edge = Edge([new StructuralSignal(SignalRule.RouteOnlyMatch, Present: true, Site)], kind: BridgeKind.Hits);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+        Assert.InRange(scored.Score, 0.7, 0.85);
+    }
+
+    [Fact]
+    public void ExactName_PlusCorroborator_IsMedium()
+    {
+        // Exact/affix name + >=1 corroborator (a rich field-set) => Medium. Name alone would be no edge.
+        var edge = Edge(
+        [
+            new NameSignal(NameTier.Exact, Site),
+            new FieldSetSignal(FieldCount: 6, Jaccard: 0.7, Site),
+        ]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+    }
+
+    [Fact]
+    public void NameMatchAlone_ProducesNoEdge()
+    {
+        // The name finisher is NEVER the sole signal — a name match with no corroborator yields no edge.
+        var edge = Edge([new NameSignal(NameTier.Exact, Site)]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void NameMatch_CorroboratedByOneFieldShape_ProducesNoEdge()
+    {
+        // A 1-field shape can NOT corroborate a name match into an edge (kills RevisionEntry↔DocumentRevisionDto FPs).
+        var edge = Edge(
+        [
+            new NameSignal(NameTier.Affix, Site),
+            new FieldSetSignal(FieldCount: 1, Jaccard: 1.0, Site),
+        ]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    // ---- resolution gates --------------------------------------------------------------------------------------
+
+    [Fact]
+    public void UnresolvedSide_ProducesNoEdge()
+    {
+        // unresolved => no edge, even with a structural breadcrumb (there is no symbol to point at).
+        var edge = Edge(
+            signals:
+            [
+                new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+                new NameResolutionSignal(EndpointSide.Source, ResolutionStatus.Unresolved, MatchCount: 0),
+            ],
+            source: Unresolved());
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void AmbiguousName_WithCorroborator_DegradesToMedium_NotDropped()
+    {
+        // An ambiguous side is never High, but a corroborated structural edge still surfaces at a reduced band so the
+        // user sees the candidate (flagged), rather than silently vanishing.
+        var edge = Edge(
+            signals:
+            [
+                new StructuralSignal(SignalRule.CreateMap, Present: true, Site),
+                new NameSignal(NameTier.Exact, Site),
+                new NameResolutionSignal(EndpointSide.Target, ResolutionStatus.Ambiguous, MatchCount: 3),
+            ],
+            target: Ambiguous(3));
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+        Assert.True(scored.HasAmbiguousName);
+    }
+
+    [Fact]
+    public void EmptySignals_ProducesNoEdge()
+    {
+        var edge = Edge([]);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void Score_NullEdge_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BridgeScorer.Score(null!));
+    }
+
+    [Fact]
+    public void ScoredEdge_CarriesTheOriginalCandidate()
+    {
+        // The scorer wraps, never mutates — the candidate (with its evidence + signals) is preserved for rendering.
+        var edge = Edge([new StructuralSignal(SignalRule.DbSetProperty, Present: true, Site)], kind: BridgeKind.StoredIn);
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.Same(edge, scored!.Edge);
+    }
+
+    [Fact]
+    public void RouteVerbMatch_AmbiguousName_FlagDoesNotPromoteAboveMedium()
+    {
+        // A High-eligible route match still can't be High with an ambiguous side; the verb-unknown/ambiguous flags ride
+        // along so the trace tool renders the reduced certainty.
+        var edge = Edge(
+            signals:
+            [
+                new StructuralSignal(SignalRule.RouteVerbMatch, Present: true, Site),
+                new NameResolutionSignal(EndpointSide.Target, ResolutionStatus.Ambiguous, MatchCount: 2),
+            ],
+            kind: BridgeKind.Hits,
+            target: Ambiguous());
+
+        var scored = BridgeScorer.Score(edge);
+
+        Assert.NotNull(scored);
+        Assert.NotEqual(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.HasAmbiguousName);
+    }
+}

--- a/tests/Miller.Tests/Resolver/DtoEntityBridgeTests.cs
+++ b/tests/Miller.Tests/Resolver/DtoEntityBridgeTests.cs
@@ -1,0 +1,457 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins design §4 Leg 2 (<see cref="DtoEntityBridge"/>): C# DTO ⇄ entity edges (<see cref="BridgeKind.MapsTo"/>).
+/// Every fixture is hand-built in-memory (NO julie, NO I/O), so these are fast-suite tests. The leg only builds
+/// candidates and delegates ALL confidence to <see cref="BridgeScorer"/>; the tests assert the resulting band/score and
+/// the load-bearing traps:
+/// <list type="bullet">
+/// <item>a <c>CreateMap&lt;A,B&gt;</c> use-site yields a High <see cref="SignalRule.CreateMap"/> edge directed
+///   copy-source(ord 0)→copy-dest(ord 1) — NOT entity→DTO, so an inbound <c>CreateMap&lt;XRequest, Entity&gt;</c> is not
+///   mislabeled (findings 28-2 + design §4);</item>
+/// <item>a <c>ReverseMap</c> emits the inverse edge too;</item>
+/// <item>a manual/projection mapping (name + a rich field-set) is corroborated to Medium — never High — and a
+///   1-field shape can NOT anchor it (the <c>RevisionEntry↔DocumentRevisionDto</c> false-positive class);</item>
+/// <item>a record-DTO's positional params produce the field-set the Jaccard reads;</item>
+/// <item>an ambiguous side is never High; an unresolved side yields no edge.</item>
+/// </list>
+/// </summary>
+public sealed class DtoEntityBridgeTests
+{
+    // ---- in-memory fixture builders ----------------------------------------------------------------------------
+    // A type owner plus its property children: the test seeds these into BOTH the SymbolResolver (so the name resolves)
+    // and the FieldSources map (so the leg can build the field-set via FieldSetExtractor), exactly as a Task-8 builder
+    // would. SymbolDetail ctor order: (Id, Name, Kind, FilePath, Signature, Namespace, TestRole, ParentClassName).
+
+    private sealed record OwnerSpec(
+        string Id, string Name, string? Namespace, string Kind, string? Signature, string File,
+        IReadOnlyList<(string Name, string Type)> Props);
+
+    private static OwnerSpec Owner(
+        string id, string name, string? ns, string kind = "class", string? signature = null,
+        string file = "Domain/Types.cs", params (string Name, string Type)[] props) =>
+        new(id, name, ns, kind, signature, file, props);
+
+    private static SymbolDetail OwnerSymbol(OwnerSpec o) =>
+        new(o.Id, o.Name, o.Kind, o.File, o.Signature ?? $"public {o.Kind} {o.Name}", o.Namespace, null, null);
+
+    private static SymbolDetail PropSymbol(OwnerSpec o, (string Name, string Type) p) =>
+        new($"{o.Id}.{p.Name}", p.Name, "property", o.File, $"{p.Type} {p.Name}", o.Namespace, null, null);
+
+    // Build the (resolver, input) pair from owner specs + the CreateMap/projection candidates. Every owner and its
+    // properties go into the resolver's symbol set; each owner with properties gets a TypeFieldSource entry.
+    private static (SymbolResolver Resolver, DtoEntityInput Input) Build(
+        IReadOnlyList<OwnerSpec> owners,
+        IReadOnlyList<CreateMapCandidate>? maps = null,
+        IReadOnlyList<ProjectionCandidate>? projections = null)
+    {
+        var symbols = new List<SymbolDetail>();
+        var fieldSources = new Dictionary<string, TypeFieldSource>(StringComparer.Ordinal);
+
+        foreach (var o in owners)
+        {
+            var ownerSymbol = OwnerSymbol(o);
+            symbols.Add(ownerSymbol);
+
+            var children = new List<SymbolDetail>();
+            foreach (var p in o.Props)
+            {
+                var child = PropSymbol(o, p);
+                children.Add(child);
+                symbols.Add(child);
+            }
+
+            // A record carries its fields in the signature (no property children); a class/interface carries them as
+            // children. Either way the owner gets a field source so the leg can build its field-set.
+            fieldSources[o.Id] = new TypeFieldSource(ownerSymbol, children, []);
+        }
+
+        var resolver = new SymbolResolver(symbols);
+        var input = new DtoEntityInput(maps ?? [], projections ?? [], fieldSources);
+        return (resolver, input);
+    }
+
+    // CreateMapCandidate ctor order: (SourceTypeName, DestTypeName, FilePath, Line, HasReverseMap).
+    private static CreateMapCandidate Map(
+        string source, string dest, bool reverse = false, string file = "Mapping/Profile.cs", int line = 24) =>
+        new(source, dest, file, line, reverse);
+
+    // ProjectionCandidate ctor order: (SourceTypeName, DestTypeName, FilePath, Line).
+    private static ProjectionCandidate Projection(
+        string source, string dest, string file = "Services/Mapper.cs", int line = 50) =>
+        new(source, dest, file, line);
+
+    // ---- PRIMARY: CreateMap<A,B> -------------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_CreateMap_EmitsHighMapsToEdge_SourceToDest()
+    {
+        // CreateMap<Account, AccountDto>: ordinal 0 = copy-source (entity), ordinal 1 = copy-dest (DTO). The edge is
+        // directed source->dest, anchored by the CreateMap structural breadcrumb => High.
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Domain"), Owner("d1", "AccountDto", "Dtos")],
+            maps: [Map("Account", "AccountDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.Equal(BridgeKind.MapsTo, edge.Kind);
+        Assert.Equal("Account", edge.SourceRef.Display);
+        Assert.Equal("AccountDto", edge.TargetRef.Display);
+        Assert.Equal("e1", edge.SourceRef.SymbolId);
+        Assert.Equal("d1", edge.TargetRef.SymbolId);
+        Assert.Contains(edge.Signals, s => s is StructuralSignal { Rule: SignalRule.CreateMap, Present: true });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score >= 0.90);
+        Assert.False(scored.HasAmbiguousName);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_QualifiedTypeNames_ResolveByLeafName()
+    {
+        // Real MyraNext rows are namespace-qualified (Core.Reporting.Data.Account / ResponseObjects.Account). The leaf
+        // name resolves via the embedded qualifier tie-break; the Display is the leaf name, not the qualified string.
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Core.Reporting.Data"), Owner("d1", "Account", "ResponseObjects")],
+            maps: [Map("Core.Reporting.Data.Account", "ResponseObjects.Account")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.Equal("Account", edge.SourceRef.Display);
+        Assert.Equal("Account", edge.TargetRef.Display);
+        Assert.Equal("e1", edge.SourceRef.SymbolId);
+        Assert.Equal("d1", edge.TargetRef.SymbolId);
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_InboundRequestToEntity_DirectionIsCopyFlow_NotEntityVsDto()
+    {
+        // An INBOUND map CreateMap<CreateOrderRequest, Order>: the DTO is at ordinal 0, the entity at ordinal 1. The
+        // edge must follow the COPY direction (source=request, dest=entity) and must NOT be flipped to entity->DTO.
+        // (Hardcoding entity=ordinal-0 would emit a confident reversed edge — the design §8 trap.)
+        var (resolver, input) = Build(
+            [Owner("req", "CreateOrderRequest", "Requests"), Owner("ord", "Order", "Domain")],
+            maps: [Map("CreateOrderRequest", "Order")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.Equal("CreateOrderRequest", edge.SourceRef.Display);
+        Assert.Equal("Order", edge.TargetRef.Display);
+        Assert.Equal("req", edge.SourceRef.SymbolId);
+        Assert.Equal("ord", edge.TargetRef.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_ZeroSharedFields_StillHigh()
+    {
+        // CreateMap is a structural breadcrumb: even when the two shapes share NO fields, the breadcrumb alone is High.
+        // (The field-set is a corroborator, never a requirement.) Source and dest are seeded with disjoint properties.
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Account", "Domain", props: [("AccountNumber", "string"), ("Balance", "decimal")]),
+                Owner("d1", "AccountDto", "Dtos", props: [("DisplayName", "string"), ("Tier", "int")]),
+            ],
+            maps: [Map("Account", "AccountDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_ReverseMap_EmitsBothDirections()
+    {
+        // CreateMap<Account, AccountDto>().ReverseMap() => the forward edge Account->AccountDto AND the inverse
+        // AccountDto->Account, both High, both CreateMap breadcrumbs.
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Domain"), Owner("d1", "AccountDto", "Dtos")],
+            maps: [Map("Account", "AccountDto", reverse: true)]);
+
+        var edges = DtoEntityBridge.Resolve(input, resolver);
+
+        Assert.Equal(2, edges.Count);
+        Assert.Contains(edges, e => e.SourceRef.Display == "Account" && e.TargetRef.Display == "AccountDto");
+        Assert.Contains(edges, e => e.SourceRef.Display == "AccountDto" && e.TargetRef.Display == "Account");
+        Assert.All(edges, e =>
+        {
+            Assert.Contains(e.Signals, s => s is StructuralSignal { Rule: SignalRule.CreateMap, Present: true });
+            var scored = BridgeScorer.Score(e);
+            Assert.NotNull(scored);
+            Assert.Equal(ConfidenceBand.High, scored!.Band);
+        });
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_StemMatch_AddsNameCorroborator_MultiSignalHigh()
+    {
+        // Account entity vs AccountDto DTO: the canonical stems fold together (Dto suffix stripped), so a NameSignal
+        // corroborator fires alongside the CreateMap breadcrumb — a multi-signal High edge.
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Domain"), Owner("d1", "AccountDto", "Dtos")],
+            maps: [Map("Account", "AccountDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.Contains(edge.Signals, s => s is NameSignal);
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.IsMultiSignal);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_UnrelatedNames_NoNameSignal()
+    {
+        // CreateMap<Permission, SecurityPermission>: the stems do NOT fold (the leg never fabricates a name match), so
+        // no NameSignal — still a valid High edge on the CreateMap breadcrumb alone, but single-signal.
+        var (resolver, input) = Build(
+            [Owner("e1", "Permission", "Domain"), Owner("d1", "SecurityPermission", "Dtos")],
+            maps: [Map("Permission", "SecurityPermission")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.DoesNotContain(edge.Signals, s => s is NameSignal);
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.False(scored.IsMultiSignal);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_AmbiguousSide_NeverHigh()
+    {
+        // Two same-named entities in different namespaces/projects, an unqualified source name + no usable hint =>
+        // ambiguous => the edge is capped at Medium and flagged, even though the CreateMap breadcrumb is present.
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Account", "Core.Reporting.Data", file: "ServiceA/Account.cs"),
+                Owner("e2", "Account", "Billing.Data", file: "ServiceB/Account.cs"),
+                Owner("d1", "AccountDto", "Dtos"),
+            ],
+            // Map use-site is in a third project so the file tie-break cannot pick one of the two Accounts.
+            maps: [Map("Account", "AccountDto", file: "Mapping/Profile.cs")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Ambiguous, edge.SourceRef.Resolution.Status);
+        Assert.Contains(edge.Signals,
+            s => s is NameResolutionSignal { Endpoint: EndpointSide.Source, Status: ResolutionStatus.Ambiguous });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+        Assert.True(scored.HasAmbiguousName);
+    }
+
+    [Fact]
+    public void Resolve_CreateMap_UnresolvedSide_NoEdge()
+    {
+        // The dest type names a DTO that does not exist as a symbol => unresolved => the leg emits a candidate carrying
+        // the Unresolved status, and the scorer drops it (no symbol to point at).
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Domain")],
+            maps: [Map("Account", "GhostDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Unresolved, edge.TargetRef.Resolution.Status);
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    [Fact]
+    public void Resolve_MultipleCreateMaps_OneEdgePerMap()
+    {
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Account", "Domain"), Owner("d1", "AccountDto", "Dtos"),
+                Owner("e2", "Permission", "Domain"), Owner("d2", "PermissionDto", "Dtos"),
+            ],
+            maps: [Map("Account", "AccountDto"), Map("Permission", "PermissionDto")]);
+
+        var edges = DtoEntityBridge.Resolve(input, resolver);
+
+        Assert.Equal(2, edges.Count);
+        Assert.All(edges, e => Assert.Equal(BridgeKind.MapsTo, e.Kind));
+        Assert.Contains(edges, e => e.SourceRef.Display == "Account");
+        Assert.Contains(edges, e => e.SourceRef.Display == "Permission");
+    }
+
+    // ---- SECONDARY: manual / projection mapping (name + field-set) ---------------------------------------------
+
+    [Fact]
+    public void Resolve_Projection_NameAndRichFieldSet_IsMedium_NeverHigh()
+    {
+        // A manual mapping with no structural breadcrumb: name stems fold (Order/OrderDto) AND the field-sets overlap
+        // richly (>=2 shared fields). The scorer lands this at Medium — a projection is NEVER High (no breadcrumb).
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Order", "Domain", props: [("Id", "int"), ("CustomerName", "string"), ("Total", "decimal")]),
+                Owner("d1", "OrderDto", "Dtos", props: [("Id", "int"), ("CustomerName", "string"), ("Total", "decimal")]),
+            ],
+            projections: [Projection("Order", "OrderDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        Assert.Equal(BridgeKind.MapsTo, edge.Kind);
+        Assert.Contains(edge.Signals, s => s is NameSignal);
+        Assert.Contains(edge.Signals, s => s is FieldSetSignal { FieldCount: >= 2, Jaccard: > 0.0 });
+        // A projection carries NO structural breadcrumb.
+        Assert.DoesNotContain(edge.Signals, s => s is StructuralSignal { Present: true });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_Projection_CarriesBothFieldSets_WithRealJaccard()
+    {
+        // The candidate carries SourceFieldSet/TargetFieldSet (the §5 Jaccard inputs) AND the FieldSetSignal computed
+        // from them. With 2 of 3 fields shared the Jaccard is 0.5 (|{Id,Name}| / |{Id,Name,Extra,Other}|).
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Widget", "Domain", props: [("Id", "int"), ("Name", "string"), ("Extra", "string")]),
+                Owner("d1", "WidgetDto", "Dtos", props: [("Id", "int"), ("Name", "string"), ("Other", "string")]),
+            ],
+            projections: [Projection("Widget", "WidgetDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.NotNull(edge.SourceFieldSet);
+        Assert.NotNull(edge.TargetFieldSet);
+        Assert.Equal(3, edge.SourceFieldSet!.Count);
+        Assert.Equal(3, edge.TargetFieldSet!.Count);
+
+        var fs = Assert.IsType<FieldSetSignal>(Assert.Single(edge.Signals, s => s is FieldSetSignal));
+        Assert.Equal(3, fs.FieldCount);
+        // {Id,Name} shared; union {Id,Name,Extra,Other} => 2/4 = 0.5.
+        Assert.Equal(0.5, fs.Jaccard, precision: 5);
+    }
+
+    [Fact]
+    public void Resolve_Projection_RecordDto_PositionalParams_ProduceTheFieldSet()
+    {
+        // A record DTO has NO property children — its field-set comes from the positional params in the signature. The
+        // entity is a class with matching properties; the Jaccard must read the record params correctly.
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "DocumentRevision", "Domain",
+                    props: [("Id", "int"), ("Title", "string"), ("CreatedAt", "DateTime")]),
+                Owner("d1", "DocumentRevisionDto", "Dtos", kind: "record",
+                    signature: "public record DocumentRevisionDto(int Id, string Title, DateTime CreatedAt)"),
+            ],
+            projections: [Projection("DocumentRevision", "DocumentRevisionDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        // The record DTO's field-set is the 3 positional params (not an empty set from a naive child query).
+        Assert.NotNull(edge.TargetFieldSet);
+        Assert.Equal(3, edge.TargetFieldSet!.Count);
+        Assert.Contains(edge.TargetFieldSet.Fields, f => f.Name == "Title");
+
+        // All 3 fields shared => Jaccard 1.0, count 3: a valid corroborator. With the name match => Medium.
+        var fs = Assert.IsType<FieldSetSignal>(Assert.Single(edge.Signals, s => s is FieldSetSignal));
+        Assert.Equal(3, fs.FieldCount);
+        Assert.Equal(1.0, fs.Jaccard, precision: 5);
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_Projection_OneFieldShape_DoesNotAnchor_NoEdge()
+    {
+        // The RevisionEntry↔DocumentRevisionDto false-positive class: a 1-field shape can NOT corroborate a name match
+        // into an edge. A projection whose only overlap is a single shared field yields NO edge from the scorer.
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "RevisionEntry", "Domain", props: [("Id", "int")]),
+                Owner("d1", "RevisionEntryDto", "Dtos", props: [("Id", "int")]),
+            ],
+            projections: [Projection("RevisionEntry", "RevisionEntryDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        // The leg still emits the FieldSetSignal carrying fieldCount=1 — the scorer is the one that refuses it.
+        Assert.Contains(edge.Signals, s => s is FieldSetSignal { FieldCount: 1 });
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    [Fact]
+    public void Resolve_Projection_NameMatchButNoFieldOverlap_NoEdge()
+    {
+        // A projection whose names fold but whose shapes share NO fields: the name finisher is never sole, and a
+        // 0-overlap field-set is no corroborator => the scorer drops it (no confident garbage on name alone).
+        var (resolver, input) = Build(
+            [
+                Owner("e1", "Account", "Domain", props: [("AccountNumber", "string"), ("Balance", "decimal")]),
+                Owner("d1", "AccountDto", "Dtos", props: [("DisplayName", "string"), ("Tier", "int")]),
+            ],
+            projections: [Projection("Account", "AccountDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    [Fact]
+    public void Resolve_Projection_NoFieldSources_NoCorroborator_NoEdge()
+    {
+        // When neither side has a field source (e.g. the builder could not scope children), a projection has only a
+        // name match — never sole — so the scorer drops it. The leg emits the name signal but no field-set signal.
+        var resolver = new SymbolResolver(
+        [
+            new SymbolDetail("e1", "Account", "class", "Domain/Account.cs", "public class Account", "Domain", null, null),
+            new SymbolDetail("d1", "AccountDto", "class", "Dtos/AccountDto.cs", "public class AccountDto", "Dtos", null, null),
+        ]);
+        var input = new DtoEntityInput([], [Projection("Account", "AccountDto")], FieldSources: null);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        Assert.Contains(edge.Signals, s => s is NameSignal);
+        Assert.DoesNotContain(edge.Signals, s => s is FieldSetSignal);
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    [Fact]
+    public void Resolve_Projection_UnresolvedSide_NoEdge()
+    {
+        var (resolver, input) = Build(
+            [Owner("e1", "Account", "Domain", props: [("Id", "int"), ("Name", "string")])],
+            projections: [Projection("Account", "GhostDto")]);
+
+        var edge = Assert.Single(DtoEntityBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Unresolved, edge.TargetRef.Resolution.Status);
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    // ---- guards ------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_NullInput_Throws()
+    {
+        var resolver = new SymbolResolver([]);
+        Assert.Throws<ArgumentNullException>(() => DtoEntityBridge.Resolve(null!, resolver));
+    }
+
+    [Fact]
+    public void Resolve_NullResolver_Throws()
+    {
+        var input = new DtoEntityInput([], []);
+        Assert.Throws<ArgumentNullException>(() => DtoEntityBridge.Resolve(input, null!));
+    }
+}

--- a/tests/Miller.Tests/Resolver/EntityTableBridgeTests.cs
+++ b/tests/Miller.Tests/Resolver/EntityTableBridgeTests.cs
@@ -1,0 +1,307 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins design §4 Leg 3 (<see cref="EntityTableBridge"/>): C# entity ⇄ DB table edges (<see cref="BridgeKind.StoredIn"/>).
+/// Every fixture is hand-built in-memory (NO julie, NO I/O), so these are fast-suite tests. The leg only builds
+/// candidates and delegates ALL confidence to <see cref="BridgeScorer"/>; the tests assert the resulting band/score and
+/// the load-bearing traps:
+/// <list type="bullet">
+/// <item>the entity comes from the <c>DbSet&lt;T&gt;</c> generic arg, NEVER the DbContext class container (findings 28-2);</item>
+/// <item>the table name is the DbSet property name (EF convention), not a pluralized entity;</item>
+/// <item>a Dapper FROM literal anchors only when a real <c>FROM</c> clause is present;</item>
+/// <item>an ambiguous entity name is never High; an unresolved entity yields no edge.</item>
+/// </list>
+/// </summary>
+public sealed class EntityTableBridgeTests
+{
+    // SymbolDetail ctor order: (Id, Name, Kind, FilePath, Signature, Namespace, TestRole, ParentClassName).
+    private static SymbolDetail Entity(string id, string name, string? ns, string file = "Domain/Entities.cs") =>
+        new(id, name, "class", file, $"public class {name}", ns, null, null);
+
+    // DbSetProperty ctor order: (PropertySymbolId, TableName, EntityTypeName, FilePath, StartLine).
+    private static DbSetProperty DbSet(string entity, string table,
+        string file = "Data/MyraNextContext.cs", int line = 18) =>
+        new("prop:" + table, table, entity, file, line);
+
+    // LiteralRecord ctor order: (LiteralText, Kind, Carrier, ArgPosition, Language, ContainingSymbolId, Span).
+    private static DapperFromCandidate Dapper(string sql, string entity,
+        string file = "Data/Repo.cs", int line = 42) =>
+        new(
+            new LiteralRecord(sql, "sql", "QueryAsync", 0, "csharp", "m1", new SourceSpan(0, sql.Length)),
+            entity,
+            file,
+            line);
+
+    // ---- PRIMARY: DbSet<T> property ----------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_DbSetProperty_EmitsEntityToTableStoredInEdge_High()
+    {
+        // ApplicationUser entity is uniquely resolvable; the DbSet property "ApplicationUsers" names the table.
+        var resolver = new SymbolResolver([Entity("e1", "ApplicationUser", "Domain")]);
+        var input = new EntityTableInput([DbSet("ApplicationUser", "ApplicationUsers")], []);
+
+        var edges = EntityTableBridge.Resolve(input, resolver);
+
+        var edge = Assert.Single(edges);
+        Assert.Equal(BridgeKind.StoredIn, edge.Kind);
+        Assert.Equal("ApplicationUser", edge.SourceRef.Display);
+        Assert.Equal("ApplicationUsers", edge.TargetRef.Display);
+
+        Assert.Contains(edge.Signals, s => s is StructuralSignal { Rule: SignalRule.DbSetProperty, Present: true });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score >= 0.90);
+        Assert.False(scored.HasAmbiguousName);
+        // ApplicationUser/ApplicationUsers stems fold, so this High edge is multi-signal (DbSet breadcrumb + Affix
+        // NameSignal). The single-breadcrumb High path is pinned by Resolve_DbSetProperty_UnrelatedTableName_NoNameSignal.
+        Assert.True(scored.IsMultiSignal);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_EntityIsGenericArg_NotDbContextContainer()
+    {
+        // The TRAP (findings 28-2): the DbSet use-site container is the DbContext class (MyraNextContext). The edge
+        // must point at the entity (ApplicationUser), and the resolved source symbol must be the entity symbol — never
+        // the context. We seed both names so a leg that picked the container would resolve to "ctx".
+        var resolver = new SymbolResolver(
+        [
+            Entity("e1", "ApplicationUser", "Domain"),
+            new SymbolDetail("ctx", "MyraNextContext", "class", "Data/MyraNextContext.cs",
+                "public class MyraNextContext : DbContext", "Data", null, null),
+        ]);
+        var input = new EntityTableInput([DbSet("ApplicationUser", "ApplicationUsers")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+
+        // The source is the ENTITY, resolved to the entity symbol — not the DbContext class.
+        Assert.Equal("ApplicationUser", edge.SourceRef.Display);
+        Assert.Equal("e1", edge.SourceRef.SymbolId);
+        Assert.NotEqual("MyraNextContext", edge.SourceRef.Display);
+        Assert.NotEqual("ctx", edge.SourceRef.SymbolId);
+
+        // The table side is a non-symbol node (named by EF convention), trivially resolved with no symbol id.
+        Assert.Null(edge.TargetRef.SymbolId);
+        Assert.Equal(ResolutionStatus.Resolved, edge.TargetRef.Resolution.Status);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_TableIsPropertyName_NotPluralizedEntity()
+    {
+        // Plan Task 5: Preferences->Preferences (entity "Preferences" already plural; table = property name verbatim).
+        // A pluralizer-on-the-entity would mis-map; the leg must take the property name as the table.
+        var resolver = new SymbolResolver([Entity("e1", "Preferences", "Domain")]);
+        var input = new EntityTableInput([DbSet("Preferences", "Preferences")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+
+        Assert.Equal("Preferences", edge.TargetRef.Display);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_EntityTableNameStem_CorroboratesWithNameSignal()
+    {
+        // AppSetting entity vs AppSettings table: the stems fold to the same canonical stem, so a NameSignal
+        // corroborator fires alongside the DbSet breadcrumb — a multi-signal High edge.
+        var resolver = new SymbolResolver([Entity("e1", "AppSetting", "Domain")]);
+        var input = new EntityTableInput([DbSet("AppSetting", "AppSettings")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+
+        Assert.Contains(edge.Signals, s => s is StructuralSignal { Rule: SignalRule.DbSetProperty, Present: true });
+        Assert.Contains(edge.Signals, s => s is NameSignal { Tier: NameTier.Affix });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.IsMultiSignal);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_EntityNameEqualsTable_NameSignalIsExactTier()
+    {
+        // When the entity leaf name and the table name are identical (case-folded), the corroborating NameSignal is the
+        // Exact tier — distinct from the singular/plural Affix tier above.
+        var resolver = new SymbolResolver([Entity("e1", "AuditLog", "Domain")]);
+        var input = new EntityTableInput([DbSet("AuditLog", "AuditLog")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+
+        Assert.Contains(edge.Signals, s => s is NameSignal { Tier: NameTier.Exact });
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_UnrelatedTableName_NoNameSignal()
+    {
+        // A DbSet whose property name does not fold to the entity stem (a deliberate mapping override) gets the DbSet
+        // breadcrumb but NO name corroborator — the leg never fabricates a name match.
+        var resolver = new SymbolResolver([Entity("e1", "Preference", "Domain")]);
+        var input = new EntityTableInput([DbSet("Preference", "AppSettings")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+
+        Assert.DoesNotContain(edge.Signals, s => s is NameSignal);
+        // Still a valid High edge on the structural breadcrumb alone.
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.False(scored.IsMultiSignal);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_AmbiguousEntity_NeverHigh()
+    {
+        // Two same-named entities, no tie-break hint => ambiguous => the edge is capped at Medium and flagged, even
+        // though the DbSet structural breadcrumb is present.
+        var resolver = new SymbolResolver(
+        [
+            Entity("e1", "Account", "Core.Reporting.Data", "ServiceA/Account.cs"),
+            Entity("e2", "Account", "ResponseObjects", "ServiceB/Account.cs"),
+        ]);
+        var input = new EntityTableInput([DbSet("Account", "Accounts")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Ambiguous, edge.SourceRef.Resolution.Status);
+        Assert.Contains(edge.Signals,
+            s => s is NameResolutionSignal { Endpoint: EndpointSide.Source, Status: ResolutionStatus.Ambiguous });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+        Assert.True(scored.HasAmbiguousName);
+    }
+
+    [Fact]
+    public void Resolve_DbSetProperty_UnresolvedEntity_NoEdge()
+    {
+        // The DbSet<T> arg names an entity that does not exist as a symbol => unresolved => the leg still emits a
+        // candidate carrying the Unresolved status, and the scorer drops it (no symbol to point at).
+        var resolver = new SymbolResolver([Entity("e1", "SomeOtherType", "Domain")]);
+        var input = new EntityTableInput([DbSet("GhostEntity", "GhostEntities")], []);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Unresolved, edge.SourceRef.Resolution.Status);
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.Null(scored);
+    }
+
+    [Fact]
+    public void Resolve_MultipleDbSets_OneEdgePerProperty()
+    {
+        // The 11/11 MyraNext shape in miniature: each DbSet property yields its own entity↔table edge.
+        var resolver = new SymbolResolver(
+        [
+            Entity("e1", "ApplicationUser", "Domain"),
+            Entity("e2", "Preferences", "Domain"),
+            Entity("e3", "AppSetting", "Domain"),
+        ]);
+        var input = new EntityTableInput(
+        [
+            DbSet("ApplicationUser", "ApplicationUsers"),
+            DbSet("Preferences", "Preferences"),
+            DbSet("AppSetting", "AppSettings"),
+        ], []);
+
+        var edges = EntityTableBridge.Resolve(input, resolver);
+
+        Assert.Equal(3, edges.Count);
+        Assert.All(edges, e => Assert.Equal(BridgeKind.StoredIn, e.Kind));
+        Assert.Contains(edges, e => e.TargetRef.Display == "ApplicationUsers");
+        Assert.Contains(edges, e => e.TargetRef.Display == "Preferences");
+        Assert.Contains(edges, e => e.TargetRef.Display == "AppSettings");
+    }
+
+    // ---- SECONDARY: Dapper FROM literal ------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_DapperLiteral_WithFrom_EmitsDapperFromEdge_High()
+    {
+        // A real inline SQL literal "SELECT TOP 1 Id FROM dbo.AppSettings" -> table token after FROM (schema-stripped).
+        var resolver = new SymbolResolver([Entity("e1", "AppSetting", "Domain")]);
+        var input = new EntityTableInput([], [Dapper("SELECT TOP 1 Id FROM dbo.AppSettings", "AppSetting")]);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+        Assert.Equal(BridgeKind.StoredIn, edge.Kind);
+        Assert.Equal("AppSetting", edge.SourceRef.Display);
+        // The table token comes from the FROM clause, with the schema qualifier stripped.
+        Assert.Equal("AppSettings", edge.TargetRef.Display);
+        Assert.Contains(edge.Signals, s => s is StructuralSignal { Rule: SignalRule.DapperFrom, Present: true });
+
+        var scored = BridgeScorer.Score(edge);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_DapperLiteral_NoFrom_NoDapperFromEdge()
+    {
+        // A stored-proc artifact literal (a splitOn column list, no FROM) must NOT emit a DapperFrom edge — never guess
+        // a table when there is no FROM clause (design §8 trap; MyraNext's 13/15 sql literals are exactly this shape).
+        var resolver = new SymbolResolver([Entity("e1", "ProjectRole", "Domain")]);
+        var input = new EntityTableInput([], [Dapper("AccountNumber,ProjectRole", "ProjectRole")]);
+
+        var edges = EntityTableBridge.Resolve(input, resolver);
+
+        Assert.Empty(edges);
+    }
+
+    [Fact]
+    public void Resolve_DapperLiteral_FromWithoutSchema_StillParsesTable()
+    {
+        // FROM with no schema qualifier: "SELECT * FROM Orders WHERE Id = {}" -> table "Orders".
+        var resolver = new SymbolResolver([Entity("e1", "Order", "Domain")]);
+        var input = new EntityTableInput([], [Dapper("SELECT * FROM Orders WHERE Id = {}", "Order")]);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+        Assert.Equal("Orders", edge.TargetRef.Display);
+        Assert.Contains(edge.Signals, s => s is StructuralSignal { Rule: SignalRule.DapperFrom, Present: true });
+    }
+
+    [Fact]
+    public void Resolve_DapperLiteral_SubstringFromInColumn_DoesNotFalseTrigger()
+    {
+        // "FROM" must match only as a whole token. A column named "FromDate" (no real FROM clause) must NOT anchor.
+        var resolver = new SymbolResolver([Entity("e1", "Audit", "Domain")]);
+        var input = new EntityTableInput([], [Dapper("SELECT FromDate, ToDate", "Audit")]);
+
+        var edges = EntityTableBridge.Resolve(input, resolver);
+
+        Assert.Empty(edges);
+    }
+
+    [Fact]
+    public void Resolve_DapperLiteral_UnresolvedEntity_NoEdge()
+    {
+        // A real FROM but the entity does not resolve => the scorer drops it (no symbol to point at).
+        var resolver = new SymbolResolver([Entity("e1", "SomethingElse", "Domain")]);
+        var input = new EntityTableInput([], [Dapper("SELECT * FROM Orders", "GhostEntity")]);
+
+        var edge = Assert.Single(EntityTableBridge.Resolve(input, resolver));
+        Assert.Equal(ResolutionStatus.Unresolved, edge.SourceRef.Resolution.Status);
+
+        Assert.Null(BridgeScorer.Score(edge));
+    }
+
+    // ---- guards ------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_NullInput_Throws()
+    {
+        var resolver = new SymbolResolver([]);
+        Assert.Throws<ArgumentNullException>(() => EntityTableBridge.Resolve(null!, resolver));
+    }
+
+    [Fact]
+    public void Resolve_NullResolver_Throws()
+    {
+        var input = new EntityTableInput([], []);
+        Assert.Throws<ArgumentNullException>(() => EntityTableBridge.Resolve(input, null!));
+    }
+}

--- a/tests/Miller.Tests/Resolver/FieldSetExtractorTests.cs
+++ b/tests/Miller.Tests/Resolver/FieldSetExtractorTests.cs
@@ -1,0 +1,176 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="FieldSetExtractor"/> — the field-set source the scorer's Jaccard corroborator reads (design §5).
+/// Four cases the design calls out: (1) class/interface properties via <c>parent_id</c> children; (2) C# <c>record</c>
+/// positional params parsed from the <c>signature</c> (records have NO property children — a naive child query returns
+/// empty and misfires the corroborator); (3) <c>[JsonProperty("x")]</c> rename from <c>raw_text</c>; (4) the
+/// balanced-bracket return-type unwrap for transitive returns. Asserts exact ordered fields / unwrapped type names.
+/// </summary>
+public sealed class FieldSetExtractorTests
+{
+    private static SymbolDetail Sym(string id, string name, string kind, string signature = "")
+        => new(
+            Id: id, Name: name, Kind: kind, FilePath: "x.cs", Signature: signature,
+            Namespace: null, TestRole: null, ParentClassName: null);
+
+    [Fact]
+    public void ExtractFields_ClassProperties_FromChildren_InDeclarationOrder()
+    {
+        var owner = Sym("U", "UserDto", "class");
+        var children = new[]
+        {
+            Sym("U.Id", "Id", "property", "int Id"),
+            Sym("U.Name", "Name", "property", "string Name"),
+            Sym("U.Email", "Email", "property", "string Email"),
+        };
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children, annotations: []);
+
+        Assert.Equal("U", fieldSet.OwnerId);
+        Assert.Equal(
+            [new FieldMember("Id", "int"), new FieldMember("Name", "string"), new FieldMember("Email", "string")],
+            fieldSet.Fields);
+        Assert.Equal(3, fieldSet.Count);
+    }
+
+    [Fact]
+    public void ExtractFields_NonPropertyChildren_AreExcluded()
+    {
+        // A nested method/class child is not a field; only properties and fields contribute to the shape.
+        var owner = Sym("U", "UserDto", "class");
+        var children = new[]
+        {
+            Sym("U.Id", "Id", "property", "int Id"),
+            Sym("U.ToString", "ToString", "method", "string ToString()"),
+            Sym("U.Nested", "Nested", "class", "class Nested"),
+            Sym("U.Tag", "Tag", "field", "string Tag"),
+        };
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children, annotations: []);
+
+        Assert.Equal(
+            [new FieldMember("Id", "int"), new FieldMember("Tag", "string")],
+            fieldSet.Fields);
+    }
+
+    [Fact]
+    public void ExtractFields_CSharpRecord_ParsesPositionalParams_FromSignature()
+    {
+        // Records have NO property children. The fields come from the positional params in the signature.
+        var owner = Sym("D", "DocumentRevisionDto", "record",
+            "public record DocumentRevisionDto(int Id, string Title, DateTime CreatedAt)");
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children: [], annotations: []);
+
+        Assert.Equal(
+            [
+                new FieldMember("Id", "int"),
+                new FieldMember("Title", "string"),
+                new FieldMember("CreatedAt", "DateTime"),
+            ],
+            fieldSet.Fields);
+    }
+
+    [Fact]
+    public void ExtractFields_Record_WithGenericParam_KeepsGenericTypeIntact()
+    {
+        // A positional param whose type is generic (commas inside <>) must not be split on the inner comma.
+        var owner = Sym("P", "PagedResult", "record",
+            "public record PagedResult(List<int> Items, IDictionary<string, int> Counts, int Total)");
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children: [], annotations: []);
+
+        Assert.Equal(
+            [
+                new FieldMember("Items", "List<int>"),
+                new FieldMember("Counts", "IDictionary<string, int>"),
+                new FieldMember("Total", "int"),
+            ],
+            fieldSet.Fields);
+    }
+
+    [Fact]
+    public void ExtractFields_JsonPropertyRename_UsesWireName()
+    {
+        // [JsonProperty("user_id")] on the Id property => the field-set wire name is "user_id", not "Id".
+        var owner = Sym("U", "UserDto", "class");
+        var children = new[]
+        {
+            Sym("U.Id", "Id", "property", "int Id"),
+            Sym("U.Name", "Name", "property", "string Name"),
+        };
+        var annotations = new[]
+        {
+            new SymbolAnnotation("U.Id", 0, "JsonProperty", "jsonproperty", "JsonProperty(\"user_id\")", "JsonProperty"),
+        };
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children, annotations);
+
+        Assert.Equal(
+            [new FieldMember("user_id", "int"), new FieldMember("Name", "string")],
+            fieldSet.Fields);
+    }
+
+    [Fact]
+    public void ExtractFields_PropertyTypes_HandleAccessorsModifiersAndNameSubstrings()
+    {
+        // Member type extraction must tokenize from the END, not locate the name by substring: "Order" is a substring
+        // of its own type "OrderRef", and modifiers/accessors/initializers must be dropped so the declared type is clean.
+        var owner = Sym("U", "OrderDto", "class");
+        var children = new[]
+        {
+            Sym("U.Order", "Order", "property", "OrderRef Order { get; set; }"),
+            Sym("U.Name", "Name", "property", "public required string Name"),
+            Sym("U.Id", "Id", "property", "int Id { get; init; } = 0"),
+            Sym("U.Tag", "Tag", "field", "string Tag = \"x\""),
+        };
+
+        var fieldSet = FieldSetExtractor.ExtractFields(owner, children, annotations: []);
+
+        Assert.Equal(
+            [
+                new FieldMember("Order", "OrderRef"),
+                new FieldMember("Name", "string"),
+                new FieldMember("Id", "int"),
+                new FieldMember("Tag", "string"),
+            ],
+            fieldSet.Fields);
+    }
+
+    // ---- balanced-bracket return-type unwrap -------------------------------------------------------------------
+
+    public static TheoryData<string, string?> UnwrapTable() => new()
+    {
+        // signature/return, expected unwrapped named type (null = no named user type / bare)
+        { "AppSetting", "AppSetting" },
+        { "Task<AppSetting>", "AppSetting" },
+        { "ActionResult<AppSetting>", "AppSetting" },
+        { "Task<ActionResult<AppSetting>>", "AppSetting" },
+        { "Task<IEnumerable<IProject>>", "IProject" },
+        { "ActionResult<List<UserDto>>", "UserDto" },
+        // Bare ActionResult / IActionResult unwrap to nothing (no named user type) => null, NO edge.
+        { "ActionResult", null },
+        { "IActionResult", null },
+        { "Task<ActionResult>", null },
+        { "Task<IActionResult>", null },
+        // A primitive inner type is not a named user type for the responds-> edge => null (the Task<bool> case).
+        { "Task<bool>", null },
+        { "Task<int>", null },
+        { "Task<string>", null },
+        // void / Task with no generic => null.
+        { "Task", null },
+        { "void", null },
+    };
+
+    [Theory]
+    [MemberData(nameof(UnwrapTable))]
+    public void UnwrapReturnType_PeelsWrappers_ToNamedUserType(string returnType, string? expected)
+    {
+        Assert.Equal(expected, FieldSetExtractor.UnwrapReturnType(returnType));
+    }
+}

--- a/tests/Miller.Tests/Resolver/FieldSetSimilarityTests.cs
+++ b/tests/Miller.Tests/Resolver/FieldSetSimilarityTests.cs
@@ -1,0 +1,92 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="FieldSetSimilarity"/> — the source of the scorer's <see cref="FieldSetSignal"/> corroborator. The
+/// Jaccard is the field-NAME overlap (|A∩B| / |A∪B|, case-insensitive); the carried <see cref="FieldSetSignal.FieldCount"/>
+/// is the MIN of the two shapes' distinct-name counts, so the §5 "1-field can't anchor" rule reads the smaller side.
+/// Asserts the exact ratio and count.
+/// </summary>
+public sealed class FieldSetSimilarityTests
+{
+    private static FieldSet Set(string owner, params string[] names)
+        => new(owner, [.. names.Select(n => new FieldMember(n, "string"))]);
+
+    [Fact]
+    public void Compare_IdenticalShapes_Jaccard1_FieldCountIsTheSharedCount()
+    {
+        var a = Set("A", "Id", "Name", "Email");
+        var b = Set("B", "Id", "Name", "Email");
+
+        var signal = FieldSetSimilarity.Compare(a, b);
+
+        Assert.Equal(1.0, signal.Jaccard);
+        Assert.Equal(3, signal.FieldCount);
+    }
+
+    [Fact]
+    public void Compare_PartialOverlap_ComputesJaccard()
+    {
+        // A = {Id, Name, Email, Age}; B = {Id, Name, Phone} => intersection 2, union 5 => 0.4.
+        var a = Set("A", "Id", "Name", "Email", "Age");
+        var b = Set("B", "Id", "Name", "Phone");
+
+        var signal = FieldSetSimilarity.Compare(a, b);
+
+        Assert.Equal(0.4, signal.Jaccard, precision: 10);
+        Assert.Equal(3, signal.FieldCount); // min(4, 3)
+    }
+
+    [Fact]
+    public void Compare_FieldNamesAreCaseInsensitive()
+    {
+        var a = Set("A", "UserId", "Name");
+        var b = Set("B", "userid", "NAME");
+
+        var signal = FieldSetSimilarity.Compare(a, b);
+
+        Assert.Equal(1.0, signal.Jaccard);
+        Assert.Equal(2, signal.FieldCount);
+    }
+
+    [Fact]
+    public void Compare_OneFieldSide_FieldCountIsOne_SoItCannotAnchor()
+    {
+        // The MIN rule is what makes "1-field can't anchor" decidable: a wide DTO vs a 1-field wrapper => FieldCount 1.
+        var wide = Set("W", "Id", "Name", "Email", "Age", "Phone");
+        var oneField = Set("O", "Id");
+
+        var signal = FieldSetSimilarity.Compare(wide, oneField);
+
+        Assert.Equal(1, signal.FieldCount);
+    }
+
+    [Fact]
+    public void Compare_DisjointShapes_JaccardZero()
+    {
+        var a = Set("A", "Id", "Name");
+        var b = Set("B", "Foo", "Bar");
+
+        var signal = FieldSetSimilarity.Compare(a, b);
+
+        Assert.Equal(0.0, signal.Jaccard);
+    }
+
+    [Fact]
+    public void Compare_BothEmpty_JaccardZero_FieldCountZero()
+    {
+        var signal = FieldSetSimilarity.Compare(Set("A"), Set("B"));
+
+        Assert.Equal(0.0, signal.Jaccard);
+        Assert.Equal(0, signal.FieldCount);
+    }
+
+    [Fact]
+    public void Jaccard_NullArgument_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => FieldSetSimilarity.Jaccard(null!, Set("B", "x")));
+    }
+}

--- a/tests/Miller.Tests/Resolver/NameNormalizerTests.cs
+++ b/tests/Miller.Tests/Resolver/NameNormalizerTests.cs
@@ -1,0 +1,81 @@
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="NameNormalizer.Stem"/> — the "safe finisher" that folds a type name to a canonical stem so an
+/// entity and its DTO collapse to the same key. Asserts the exact stem, never just "non-empty". Covers: <c>I</c>/<c>_</c>
+/// prefix strip, the DTO/Model/Request/Response/View/VM/Entity suffix strip, singular↔plural folding, and the
+/// combined case. A row that proves <c>Equal(a) == Equal(b)</c> for an entity/DTO pair is the load-bearing assertion.
+/// </summary>
+public sealed class NameNormalizerTests
+{
+    public static TheoryData<string, string> StemTable() => new()
+    {
+        // Interface "I" prefix stripped (but not a real leading-I word like "Identity" — only when CamelCase follows).
+        { "IUser", "user" },
+        { "IUserService", "userservice" },
+        // Underscore prefix stripped.
+        { "_internalThing", "internalthing" },
+        // DTO / Model / Request / Response / View / VM / Entity suffixes stripped.
+        { "UserDto", "user" },
+        { "UserModel", "user" },
+        { "CreateOrderRequest", "createorder" },
+        { "OrderResponse", "order" },
+        { "UserView", "user" },
+        { "UserVM", "user" },
+        { "ApplicationUserEntity", "applicationuser" },
+        // Plural → singular (the canonical stem is singular).
+        { "Users", "user" },
+        { "Categories", "category" },
+        { "Boxes", "box" },
+        // Combined: interface + plural + nothing else.
+        { "IUsers", "user" },
+        // Combined: prefix + suffix.
+        { "IUserDto", "user" },
+        // A bare already-canonical name is unchanged (lowercased).
+        { "Order", "order" },
+        // Suffix is only stripped as a whole trailing token, not mid-word: "Modeller" must NOT lose "Model".
+        { "Modeller", "modeller" },
+        // DELIBERATE aggressive fold (design §4 — the name leg is corroborator-only, NEVER a sole High signal): a
+        // control/domain type whose name ends in a role word collapses just like a ViewModel/Model would. There is no
+        // syntactic way to tell "UserView" (a DTO) from "WebView" (a control) apart, and the limited blast radius
+        // (spurious Medium pairings only) is the accepted tradeoff. Pinned so the behavior is explicit, not incidental.
+        { "WebView", "web" },
+        { "TreeView", "tree" },
+        { "DataModel", "data" },
+    };
+
+    [Theory]
+    [MemberData(nameof(StemTable))]
+    public void Stem_FoldsToCanonical(string input, string expected)
+    {
+        Assert.Equal(expected, NameNormalizer.Stem(input));
+    }
+
+    [Fact]
+    public void Stem_EntityAndDto_CollapseToSameStem()
+    {
+        // The whole point: an entity and its DTO must produce the same stem so the name leg can pair them.
+        Assert.Equal(NameNormalizer.Stem("ApplicationUser"), NameNormalizer.Stem("ApplicationUserDto"));
+        Assert.Equal(NameNormalizer.Stem("User"), NameNormalizer.Stem("IUser"));
+        Assert.Equal(NameNormalizer.Stem("Account"), NameNormalizer.Stem("Accounts"));
+    }
+
+    [Fact]
+    public void Stem_DistinctTypes_DoNotCollide()
+    {
+        // Two genuinely different types must NOT collapse — guards against an over-eager strip.
+        Assert.NotEqual(NameNormalizer.Stem("UserDto"), NameNormalizer.Stem("OrderDto"));
+        Assert.NotEqual(NameNormalizer.Stem("Preference"), NameNormalizer.Stem("AppSetting"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Stem_BlankInput_ReturnsEmpty(string input)
+    {
+        Assert.Equal(string.Empty, NameNormalizer.Stem(input));
+    }
+}

--- a/tests/Miller.Tests/Resolver/RouteBridgeTests.cs
+++ b/tests/Miller.Tests/Resolver/RouteBridgeTests.cs
@@ -1,0 +1,464 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins design §4 Leg 1 (<see cref="RouteBridge"/>): TS client HTTP call ⇄ C# controller endpoint
+/// (<see cref="BridgeKind.Hits"/>), plus the endpoint's response DTO (<see cref="BridgeKind.Responds"/>) and
+/// request DTO (<see cref="BridgeKind.Consumes"/>). Every fixture is hand-built in-memory (NO julie, NO I/O), so
+/// these are fast-suite tests. The leg only builds candidates and delegates ALL confidence to
+/// <see cref="BridgeScorer"/>; the tests assert the resulting band/score and the load-bearing traps:
+/// <list type="bullet">
+/// <item>an <c>axios.&lt;verb&gt;</c> client + a matching endpoint => a <see cref="SignalRule.RouteVerbMatch"/> Hits
+///   edge at High (after <c>[controller]</c>/<c>[action]</c> token expansion, design §8 risk 3);</item>
+/// <item>a verb-less carrier (<c>fetch</c>) that matches on route alone => a <see cref="SignalRule.RouteOnlyMatch"/>
+///   Hits edge at Medium, flagged verb-unknown, with the verb NEVER assumed GET;</item>
+/// <item>two controllers' <c>{id}</c> templates normalize to distinct routes — no false merge into one Hits edge;</item>
+/// <item>an endpoint return type unwrapping to a named DTO => a <see cref="SignalRule.ReturnTypeDto"/> Responds edge;
+///   a bare <c>ActionResult</c> => NO Responds edge;</item>
+/// <item>a <c>[FromBody]</c> request DTO => a <see cref="SignalRule.FromBodyDto"/> Consumes edge;</item>
+/// <item>a C# test HttpClient url literal is excluded from the TS side.</item>
+/// </list>
+/// </summary>
+public sealed class RouteBridgeTests
+{
+    // SymbolDetail ctor order: (Id, Name, Kind, FilePath, Signature, Namespace, TestRole, ParentClassName).
+    private static SymbolDetail Dto(string id, string name, string? ns = "Dtos", string file = "Api/Dtos/Dtos.cs") =>
+        new(id, name, "class", file, $"public class {name}", ns, null, null);
+
+    // A TS client call. Defaults to the real-data shape: a typescript url literal at arg 0, axios.<verb> carrier.
+    private static TsClientCall Call(
+        string carrier,
+        string route,
+        string language = "typescript",
+        TestRole? testRole = null,
+        string file = "web/src/api/client.ts",
+        int line = 12,
+        string containingSymbolId = "ts.fn") =>
+        new(
+            new LiteralRecord(route, "url", carrier, 0, language, containingSymbolId, new SourceSpan(0, route.Length)),
+            testRole,
+            file,
+            line);
+
+    // A C# controller endpoint. Defaults to the real-data shape: Route("api/[controller]") on the class + an HttpVerb
+    // annotation on the method, a concrete return type, no request body.
+    private static ControllerEndpoint Endpoint(
+        string verbKey,
+        string parentClassName,
+        string methodName,
+        string? classRoute = "api/[controller]",
+        string? methodRoute = null,
+        string returnType = "Task<ActionResult>",
+        string? requestBodyType = null,
+        string file = "Api/Controllers/Controller.cs",
+        int line = 30,
+        string symbolId = "cs.endpoint") =>
+        new(symbolId, verbKey, classRoute, methodRoute, parentClassName, methodName, returnType, requestBodyType, file, line);
+
+    // ---- Hits: verb-known (axios.<verb>) -----------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_AxiosGet_MatchingEndpoint_EmitsRouteVerbMatchHits_High()
+    {
+        // axios.get /api/appsettings/${id}  ⇄  HttpGet("{id}") on AppSettingsController under Route("api/[controller]")
+        // Both normalize to (GET, api/appsettings/{}) => a RouteVerbMatch Hits edge at High.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.get", "/api/appsettings/${id}")],
+            [Endpoint("httpget", "AppSettingsController", "GetById", methodRoute: "{id}")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        var hits = Assert.Single(edges, e => e.Kind == BridgeKind.Hits);
+        Assert.Contains(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteVerbMatch, Present: true });
+        Assert.DoesNotContain(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteOnlyMatch, Present: true });
+        Assert.Equal("api/appsettings/{}", hits.TargetRef.Display);
+
+        var scored = BridgeScorer.Score(hits);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+        Assert.True(scored.Score >= 0.90);
+        Assert.False(scored.IsVerbUnknown);
+        Assert.False(scored.HasAmbiguousName);
+    }
+
+    [Fact]
+    public void Resolve_VerbMismatch_NoHitsEdge()
+    {
+        // Same route, but the client POSTs and the endpoint is GET => the (verb, route) pair does not match, so no
+        // Hits edge (a verb-known mismatch is a real distinction, not a route-only fallback).
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.post", "/api/appsettings/${id}")],
+            [Endpoint("httpget", "AppSettingsController", "GetById", methodRoute: "{id}")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        Assert.DoesNotContain(edges, e => e.Kind == BridgeKind.Hits);
+    }
+
+    [Fact]
+    public void Resolve_RouteMismatch_NoHitsEdge()
+    {
+        // A near-miss route ("/api/appsettings" vs the endpoint's "{id}" tail) must NOT match.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.get", "/api/appsettings")],
+            [Endpoint("httpget", "AppSettingsController", "GetById", methodRoute: "{id}")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        Assert.DoesNotContain(edges, e => e.Kind == BridgeKind.Hits);
+    }
+
+    // ---- Hits: verb-unknown (fetch / verb-less carriers) -------------------------------------------------------
+
+    [Fact]
+    public void Resolve_FetchVerbUnknown_RouteMatches_EmitsRouteOnlyMatch_Medium_NeverAssumesGet()
+    {
+        // A verb-less carrier (fetch): the route lines up but the verb is unknown. The edge matches on route ALONE =>
+        // a RouteOnlyMatch Hits edge at Medium, flagged IsVerbUnknown, and the verb is NEVER assumed to be GET — even
+        // though the endpoint it matched IS a GET.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("fetch", "/api/appsettings")],
+            [Endpoint("httpget", "AppSettingsController", "List")]);
+
+        var hits = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+
+        Assert.Contains(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteOnlyMatch, Present: true });
+        Assert.DoesNotContain(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteVerbMatch, Present: true });
+        // The TS side display is the canonical route; it carries no fabricated verb.
+        Assert.Equal("api/appsettings", hits.SourceRef.Display);
+
+        var scored = BridgeScorer.Score(hits);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.Medium, scored!.Band);
+        Assert.True(scored.IsVerbUnknown);
+        Assert.InRange(scored.Score, 0.70, 0.85);
+    }
+
+    [Theory]
+    [InlineData("fetch")]
+    [InlineData("$fetch")]
+    [InlineData("ofetch")]
+    [InlineData("axios")]
+    [InlineData("ky")]
+    [InlineData("got")]
+    public void Resolve_VerbLessCarriers_AllRouteOnly(string carrier)
+    {
+        // Every julie verb-less carrier yields a route-only (verb-unknown) match, never a RouteVerbMatch.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call(carrier, "/api/appsettings")],
+            [Endpoint("httpget", "AppSettingsController", "List")]);
+
+        var hits = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+        Assert.Contains(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteOnlyMatch, Present: true });
+        Assert.DoesNotContain(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteVerbMatch, Present: true });
+    }
+
+    // ---- collision guard ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_TwoControllersSameMethodTemplate_NoFalseMerge_EachMatchesOnlyItsClient()
+    {
+        // THE collision guard (design §8 risk 3). Two controllers each expose HttpGet("{id}") under
+        // Route("api/[controller]"); two clients hit each one. The {id} templates must normalize to DISTINCT routes,
+        // so each client matches ONLY its own controller — never a cross-merge.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [
+                Call("axios.get", "/api/appsettings/${id}"),
+                Call("axios.get", "/api/objectcodemappings/${id}"),
+            ],
+            [
+                Endpoint("httpget", "AppSettingsController", "GetById", methodRoute: "{id}", symbolId: "ep.appsettings"),
+                Endpoint("httpget", "ObjectCodeMappingsController", "GetById", methodRoute: "{id}", symbolId: "ep.ocm"),
+            ]);
+
+        var hits = RouteBridge.Resolve(input, resolver).Where(e => e.Kind == BridgeKind.Hits).ToList();
+
+        // Exactly two Hits edges (one per client→endpoint pair), each on a distinct route.
+        Assert.Equal(2, hits.Count);
+        Assert.Contains(hits, e => e.TargetRef.Display == "api/appsettings/{}" && e.TargetRef.SymbolId == "ep.appsettings");
+        Assert.Contains(hits, e => e.TargetRef.Display == "api/objectcodemappings/{}" && e.TargetRef.SymbolId == "ep.ocm");
+        // No edge crosses the two routes (the merge that token-dropping would cause).
+        Assert.DoesNotContain(hits, e => e.SourceRef.Display == "api/appsettings/{}" && e.TargetRef.SymbolId == "ep.ocm");
+        Assert.DoesNotContain(hits, e => e.SourceRef.Display == "api/objectcodemappings/{}" && e.TargetRef.SymbolId == "ep.appsettings");
+    }
+
+    // ---- TS side filtering: language + test_role ---------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_CsharpTestHttpClientLiteral_Excluded_FromTsSide()
+    {
+        // A C# test HttpClient url literal (language=csharp, a test_role) must NOT be treated as a TS client call.
+        // On real data the 57 csharp literals are all test HttpClient; only the 39 typescript ones are real calls.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("client.GetAsync", "/api/appsettings", language: "csharp", testRole: new TestRole("test_case"))],
+            [Endpoint("httpget", "AppSettingsController", "List")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        Assert.DoesNotContain(edges, e => e.Kind == BridgeKind.Hits);
+    }
+
+    [Fact]
+    public void Resolve_NonUrlLiteral_Excluded()
+    {
+        // A non-url literal (e.g. a sql literal) is not a client call and must be ignored by the route bridge.
+        var resolver = new SymbolResolver([]);
+        var sql = new LiteralRecord("SELECT * FROM X", "sql", "QueryAsync", 0, "csharp", "m", new SourceSpan(0, 1));
+        var input = new RouteBridgeInput(
+            [new TsClientCall(sql, null, "Data/Repo.cs", 5)],
+            [Endpoint("httpget", "AppSettingsController", "List")]);
+
+        Assert.DoesNotContain(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+    }
+
+    [Fact]
+    public void Resolve_TypescriptNonTestLiteral_Included()
+    {
+        // The positive of the filter: a typescript url literal with no test_role IS a real client call.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.get", "/api/appsettings", language: "typescript", testRole: null)],
+            [Endpoint("httpget", "AppSettingsController", "List")]);
+
+        Assert.Contains(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+    }
+
+    // ---- Responds: return-type unwrap to a named DTO ----------------------------------------------------------
+
+    [Fact]
+    public void Resolve_ReturnTypeUnwrapsToNamedDto_EmitsRespondsEdge()
+    {
+        // Task<ActionResult<AppSetting>> unwraps (balanced bracket depth) to the named DTO AppSetting => a Responds
+        // edge endpoint—responds→ AppSetting, anchored by ReturnTypeDto and resolved by name.
+        var resolver = new SymbolResolver([Dto("d1", "AppSetting")]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpget", "AppSettingsController", "GetById", methodRoute: "{id}",
+                returnType: "Task<ActionResult<AppSetting>>")]);
+
+        var responds = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Responds);
+
+        Assert.Equal("AppSetting", responds.TargetRef.Display);
+        Assert.Equal("d1", responds.TargetRef.SymbolId);
+        Assert.Contains(responds.Signals, s => s is StructuralSignal { Rule: SignalRule.ReturnTypeDto, Present: true });
+
+        var scored = BridgeScorer.Score(responds);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_ReturnTypeUnwrapsToCollectionElement_EmitsRespondsEdge()
+    {
+        // Task<IEnumerable<IProject>> unwraps to the collection element type IProject (an interface is a valid named
+        // user type per design §4) => a Responds edge.
+        var resolver = new SymbolResolver(
+            [new SymbolDetail("i1", "IProject", "interface", "Api/Models/IProject.cs", "public interface IProject", "Models", null, null)]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpget", "ProjectsController", "List", returnType: "Task<IEnumerable<IProject>>")]);
+
+        var responds = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Responds);
+
+        Assert.Equal("IProject", responds.TargetRef.Display);
+        Assert.Equal("i1", responds.TargetRef.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_BareActionResult_NoRespondsEdge()
+    {
+        // A bare Task<ActionResult> (mostly mutations) unwraps to null => NO Responds edge, no penalty to any Hits.
+        var resolver = new SymbolResolver([Dto("d1", "AppSetting")]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httppost", "AppSettingsController", "Create", returnType: "Task<ActionResult>")]);
+
+        Assert.DoesNotContain(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Responds);
+    }
+
+    [Fact]
+    public void Resolve_PrimitiveReturnType_NoRespondsEdge()
+    {
+        // Task<bool> unwraps to a primitive, which is NOT a named user DTO => NO Responds edge (the lone Task<bool>
+        // case in the 28-2 findings is dropped, not double-counted).
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpget", "AwardsController", "HasSubawardExpenses", returnType: "Task<bool>")]);
+
+        Assert.DoesNotContain(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Responds);
+    }
+
+    [Fact]
+    public void Resolve_RespondsUnresolvedDto_NoEdgeFromScorer()
+    {
+        // The return type unwraps to a named type, but that type is not a symbol => unresolved => the leg emits the
+        // candidate carrying Unresolved, and the scorer drops it (no symbol to point at).
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpget", "AppSettingsController", "GetById", returnType: "Task<ActionResult<GhostDto>>")]);
+
+        var responds = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Responds);
+        Assert.Equal(ResolutionStatus.Unresolved, responds.TargetRef.Resolution.Status);
+        Assert.Null(BridgeScorer.Score(responds));
+    }
+
+    // ---- Consumes: [FromBody] / request parameter DTO ---------------------------------------------------------
+
+    [Fact]
+    public void Resolve_FromBodyDto_EmitsConsumesEdge()
+    {
+        // A request body type (recovered from the method's [FromBody]/parameter type) => a Consumes edge
+        // endpoint—consumes→ CreateAppSettingRequest, anchored by FromBodyDto and resolved by name.
+        var resolver = new SymbolResolver([Dto("r1", "CreateAppSettingRequest", "Requests")]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httppost", "AppSettingsController", "Create", returnType: "Task<ActionResult>",
+                requestBodyType: "CreateAppSettingRequest")]);
+
+        var consumes = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Consumes);
+
+        Assert.Equal("CreateAppSettingRequest", consumes.TargetRef.Display);
+        Assert.Equal("r1", consumes.TargetRef.SymbolId);
+        Assert.Contains(consumes.Signals, s => s is StructuralSignal { Rule: SignalRule.FromBodyDto, Present: true });
+
+        var scored = BridgeScorer.Score(consumes);
+        Assert.NotNull(scored);
+        Assert.Equal(ConfidenceBand.High, scored!.Band);
+    }
+
+    [Fact]
+    public void Resolve_NoRequestBody_NoConsumesEdge()
+    {
+        // No [FromBody]/request type => NO Consumes edge.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpget", "AppSettingsController", "List", requestBodyType: null)]);
+
+        Assert.DoesNotContain(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Consumes);
+    }
+
+    [Fact]
+    public void Resolve_ConsumesUnresolvedDto_NoEdgeFromScorer()
+    {
+        // A [FromBody] type that is not a symbol => unresolved => the scorer drops the Consumes candidate.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httppost", "AppSettingsController", "Create", requestBodyType: "GhostRequest")]);
+
+        var consumes = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Consumes);
+        Assert.Equal(ResolutionStatus.Unresolved, consumes.TargetRef.Resolution.Status);
+        Assert.Null(BridgeScorer.Score(consumes));
+    }
+
+    // ---- combined endpoint: hits + responds + consumes --------------------------------------------------------
+
+    [Fact]
+    public void Resolve_OneEndpoint_EmitsHitsRespondsAndConsumes()
+    {
+        // A single POST endpoint with a concrete return DTO and a request body, hit by a matching axios.post client:
+        // one Hits edge (verb-known), one Responds edge, one Consumes edge — three distinct edge kinds.
+        var resolver = new SymbolResolver(
+            [Dto("res", "AppSetting"), Dto("req", "CreateAppSettingRequest", "Requests")]);
+        var input = new RouteBridgeInput(
+            [Call("axios.post", "/api/appsettings")],
+            [Endpoint("httppost", "AppSettingsController", "Create",
+                returnType: "Task<ActionResult<AppSetting>>", requestBodyType: "CreateAppSettingRequest")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        var hits = Assert.Single(edges, e => e.Kind == BridgeKind.Hits);
+        var responds = Assert.Single(edges, e => e.Kind == BridgeKind.Responds);
+        var consumes = Assert.Single(edges, e => e.Kind == BridgeKind.Consumes);
+
+        Assert.Contains(hits.Signals, s => s is StructuralSignal { Rule: SignalRule.RouteVerbMatch, Present: true });
+        Assert.Equal("AppSetting", responds.TargetRef.Display);
+        Assert.Equal("CreateAppSettingRequest", consumes.TargetRef.Display);
+
+        Assert.Equal(ConfidenceBand.High, BridgeScorer.Score(hits)!.Band);
+        Assert.Equal(ConfidenceBand.High, BridgeScorer.Score(responds)!.Band);
+        Assert.Equal(ConfidenceBand.High, BridgeScorer.Score(consumes)!.Band);
+    }
+
+    [Fact]
+    public void Resolve_RespondsAndConsumes_FireEvenWithNoClientCall()
+    {
+        // The responds/consumes edges describe the endpoint's shape and do NOT depend on any client matching it — an
+        // endpoint with no caller still yields its Responds + Consumes edges.
+        var resolver = new SymbolResolver(
+            [Dto("res", "AppSetting"), Dto("req", "UpdateAppSettingRequest", "Requests")]);
+        var input = new RouteBridgeInput(
+            [],
+            [Endpoint("httpput", "AppSettingsController", "Update",
+                returnType: "Task<ActionResult<AppSetting>>", requestBodyType: "UpdateAppSettingRequest")]);
+
+        var edges = RouteBridge.Resolve(input, resolver);
+
+        Assert.DoesNotContain(edges, e => e.Kind == BridgeKind.Hits);
+        Assert.Single(edges, e => e.Kind == BridgeKind.Responds);
+        Assert.Single(edges, e => e.Kind == BridgeKind.Consumes);
+    }
+
+    // ---- route normalization details still hold through the leg ------------------------------------------------
+
+    [Fact]
+    public void Resolve_AbsoluteMethodRoute_OverridesClassPrefix_StillMatchesClient()
+    {
+        // A method route starting with "/" overrides the class [Route]; a client hitting that absolute route matches.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.get", "/health/ready")],
+            [Endpoint("httpget", "DiagnosticsController", "Ready", classRoute: "api/[controller]", methodRoute: "/health/ready")]);
+
+        var hits = Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+        Assert.Equal("health/ready", hits.TargetRef.Display);
+    }
+
+    [Fact]
+    public void Resolve_ActionTokenExpansion_MatchesClient()
+    {
+        // [action] expands to the method name; a client on api/orders/submit matches the endpoint.
+        var resolver = new SymbolResolver([]);
+        var input = new RouteBridgeInput(
+            [Call("axios.post", "/api/orders/submit")],
+            [Endpoint("httppost", "OrdersController", "Submit", classRoute: "api/[controller]/[action]")]);
+
+        Assert.Single(RouteBridge.Resolve(input, resolver), e => e.Kind == BridgeKind.Hits);
+    }
+
+    // ---- guards ------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_NullInput_Throws()
+    {
+        var resolver = new SymbolResolver([]);
+        Assert.Throws<ArgumentNullException>(() => RouteBridge.Resolve(null!, resolver));
+    }
+
+    [Fact]
+    public void Resolve_NullResolver_Throws()
+    {
+        var input = new RouteBridgeInput([], []);
+        Assert.Throws<ArgumentNullException>(() => RouteBridge.Resolve(input, null!));
+    }
+
+    [Fact]
+    public void Resolve_NoEndpointsNoCalls_EmptyResult()
+    {
+        var resolver = new SymbolResolver([]);
+        Assert.Empty(RouteBridge.Resolve(new RouteBridgeInput([], []), resolver));
+    }
+}

--- a/tests/Miller.Tests/Resolver/RouteNormalizerTests.cs
+++ b/tests/Miller.Tests/Resolver/RouteNormalizerTests.cs
@@ -1,0 +1,230 @@
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="RouteNormalizer"/> — where the route-bridge precision lives (design §4 Leg 1, §8 risk 3). Two
+/// surfaces: the TS client side (<see cref="RouteNormalizer.FromClientCall"/>: verb from carrier or verb-unknown,
+/// param folding) and the C# endpoint side (<see cref="RouteNormalizer.FromEndpoint"/>: <c>[controller]</c>/
+/// <c>[action]</c>/<c>[area]</c> token expansion BEFORE prefix concat, absolute override, param folding). Every row
+/// asserts the exact <c>(verb, route)</c>. The load-bearing negatives: two controllers' <c>{id}</c> templates must
+/// normalize to DISTINCT routes (collision guard), and a verb-less carrier must be verb-unknown, NOT assumed GET.
+/// </summary>
+public sealed class RouteNormalizerTests
+{
+    // ---- TS client side: verb derivation + route folding -------------------------------------------------------
+
+    public static TheoryData<string, string, string?, string> ClientCallTable() => new()
+    {
+        // carrier, literalText, expectedVerb (null = verb-unknown), expectedRoute
+        // axios.<verb> carriers: verb known from the carrier tail.
+        { "axios.post", "/api/appsettings", "POST", "api/appsettings" },
+        { "axios.get", "/api/appsettings", "GET", "api/appsettings" },
+        { "axios.delete", "/api/objectcodemappings/{}", "DELETE", "api/objectcodemappings/{}" },
+        { "axios.patch", "/api/messages/{}/dismiss", "PATCH", "api/messages/{}/dismiss" },
+        // <Verb>Async carriers: verb known.
+        { "PostAsync", "/api/orders", "POST", "api/orders" },
+        { "GetAsync", "/api/orders", "GET", "api/orders" },
+        // Param shapes all fold to {}: ${id}, :id, {id}.
+        { "axios.get", "/api/users/${userId}", "GET", "api/users/{}" },
+        { "axios.get", "/api/users/:userId", "GET", "api/users/{}" },
+        { "axios.get", "/api/users/{userId}", "GET", "api/users/{}" },
+        // A param followed by a literal extension keeps the extension (the :param fold is identifier-bounded, not
+        // "everything to /"), so all three param syntaxes match the C# "{id}.json" endpoint side.
+        { "axios.get", "/api/files/:id.json", "GET", "api/files/{}.json" },
+        { "axios.get", "/api/files/${id}.json", "GET", "api/files/{}.json" },
+        { "axios.get", "/api/files/{id}.json", "GET", "api/files/{}.json" },
+        // Trailing slash dropped, case folded, query string stripped.
+        { "axios.get", "/API/Users/", "GET", "api/users" },
+        { "axios.get", "/api/users?active=true", "GET", "api/users" },
+        // Leading slash normalized away (routes compared without it).
+        { "axios.get", "api/users", "GET", "api/users" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ClientCallTable))]
+    public void FromClientCall_DerivesVerbAndNormalizesRoute(
+        string carrier, string literalText, string? expectedVerb, string expectedRoute)
+    {
+        var result = RouteNormalizer.FromClientCall(carrier, literalText);
+
+        Assert.Equal(expectedVerb, result.Verb);
+        Assert.Equal(expectedRoute, result.Route);
+        Assert.Equal(expectedVerb is not null, result.VerbKnown);
+    }
+
+    [Theory]
+    // Verb-less carriers: NEVER assume GET. Verb-unknown, route still normalized.
+    [InlineData("fetch")]
+    [InlineData("$fetch")]
+    [InlineData("ofetch")]
+    [InlineData("axios")]
+    [InlineData("request")]
+    [InlineData("ky")]
+    [InlineData("got")]
+    [InlineData("sendasync")]
+    public void FromClientCall_VerbLessCarrier_IsVerbUnknown_NeverAssumesGet(string carrier)
+    {
+        var result = RouteNormalizer.FromClientCall(carrier, "/api/users");
+
+        Assert.Null(result.Verb);
+        Assert.False(result.VerbKnown);
+        Assert.NotEqual("GET", result.Verb); // explicit: the never-assume-GET invariant
+        Assert.Equal("api/users", result.Route); // route still recovered
+    }
+
+    // ---- C# endpoint side: token expansion + prefix concat -----------------------------------------------------
+
+    [Fact]
+    public void FromEndpoint_ExpandsControllerToken_BeforePrefixConcat()
+    {
+        // Route("api/[controller]") on AppSettingsController + HttpGet("{id}") => api/appsettings/{}
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget",
+            classRoute: "api/[controller]",
+            methodRoute: "{id}",
+            parentClassName: "AppSettingsController",
+            methodName: "GetById");
+
+        Assert.Equal("GET", result.Verb);
+        Assert.True(result.VerbKnown);
+        Assert.Equal("api/appsettings/{}", result.Route);
+    }
+
+    [Fact]
+    public void FromEndpoint_ExpandsActionToken_FromMethodName()
+    {
+        // [action] expands to the method name lowercased.
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httppost",
+            classRoute: "api/[controller]/[action]",
+            methodRoute: null,
+            parentClassName: "OrdersController",
+            methodName: "Submit");
+
+        Assert.Equal("POST", result.Verb);
+        Assert.Equal("api/orders/submit", result.Route);
+    }
+
+    [Fact]
+    public void FromEndpoint_ExpandsAreaToken()
+    {
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget",
+            classRoute: "[area]/[controller]",
+            methodRoute: "{id}",
+            parentClassName: "AdminController",
+            methodName: "Get",
+            area: "Admin");
+
+        Assert.Equal("admin/admin/{}", result.Route);
+    }
+
+    [Fact]
+    public void FromEndpoint_AbsoluteMethodRoute_OverridesClassPrefix()
+    {
+        // A method route starting with "/" is absolute: it ignores the class [Route] prefix.
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget",
+            classRoute: "api/[controller]",
+            methodRoute: "/health/ready",
+            parentClassName: "DiagnosticsController",
+            methodName: "Ready");
+
+        Assert.Equal("health/ready", result.Route);
+    }
+
+    [Fact]
+    public void FromEndpoint_NoMethodRoute_UsesClassRouteAlone()
+    {
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget",
+            classRoute: "api/[controller]",
+            methodRoute: null,
+            parentClassName: "AppSettingsController",
+            methodName: "List");
+
+        Assert.Equal("api/appsettings", result.Route);
+    }
+
+    [Fact]
+    public void FromEndpoint_ControllerSuffixStrippedCaseInsensitively()
+    {
+        // Only the trailing "Controller" is removed; the rest is lowercased verbatim.
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget",
+            classRoute: "api/[controller]",
+            methodRoute: null,
+            parentClassName: "ObjectCodeMappingsController",
+            methodName: "List");
+
+        Assert.Equal("api/objectcodemappings", result.Route);
+    }
+
+    /// <summary>
+    /// THE collision guard (design §8 risk 3). Two controllers each expose <c>HttpGet("{id}")</c> under
+    /// <c>Route("api/[controller]")</c>. If <c>[controller]</c> expansion dropped the controller name they would both
+    /// normalize to <c>api/{}</c> and merge into one High-confidence WRONG link. They MUST stay distinct.
+    /// </summary>
+    [Fact]
+    public void FromEndpoint_TwoControllersWithSameMethodTemplate_NormalizeToDistinctRoutes()
+    {
+        var a = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget", classRoute: "api/[controller]", methodRoute: "{id}",
+            parentClassName: "AppSettingsController", methodName: "GetById");
+        var b = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget", classRoute: "api/[controller]", methodRoute: "{id}",
+            parentClassName: "ObjectCodeMappingsController", methodName: "GetById");
+
+        Assert.Equal("api/appsettings/{}", a.Route);
+        Assert.Equal("api/objectcodemappings/{}", b.Route);
+        Assert.NotEqual(a.Route, b.Route); // the collision guard, stated as an assertion
+    }
+
+    [Fact]
+    public void FromEndpoint_ClientAndEndpoint_NormalizeToTheSameRoute_ForAMatch()
+    {
+        // The end-to-end point: a TS axios.get and the C# endpoint it hits produce an identical (verb, route).
+        var client = RouteNormalizer.FromClientCall("axios.get", "/api/appsettings/${id}");
+        var endpoint = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget", classRoute: "api/[controller]", methodRoute: "{id}",
+            parentClassName: "AppSettingsController", methodName: "GetById");
+
+        Assert.Equal(client.Verb, endpoint.Verb);
+        Assert.Equal(client.Route, endpoint.Route);
+    }
+
+    [Fact]
+    public void ParamWithExtension_ClientAndEndpoint_NormalizeToTheSameRoute()
+    {
+        // The :param fold must stop at the identifier so a "/files/:id.json" client call and the C# "{id}.json"
+        // endpoint produce the SAME route — the over-consuming ":[^/]+" form folded the extension away on one side only.
+        var client = RouteNormalizer.FromClientCall("axios.get", "/api/files/:id.json");
+        var endpoint = RouteNormalizer.FromEndpoint(
+            verbKey: "httpget", classRoute: "api/[controller]", methodRoute: "{id}.json",
+            parentClassName: "FilesController", methodName: "GetById");
+
+        Assert.Equal("api/files/{}.json", client.Route);
+        Assert.Equal(client.Route, endpoint.Route);
+    }
+
+    [Theory]
+    // Verb key mapping: the annotation_key (lowercased) maps to the canonical HTTP verb.
+    [InlineData("httpget", "GET")]
+    [InlineData("httppost", "POST")]
+    [InlineData("httpput", "PUT")]
+    [InlineData("httpdelete", "DELETE")]
+    [InlineData("httppatch", "PATCH")]
+    [InlineData("httphead", "HEAD")]
+    [InlineData("httpoptions", "OPTIONS")]
+    public void FromEndpoint_MapsVerbKeyToHttpVerb(string verbKey, string expectedVerb)
+    {
+        var result = RouteNormalizer.FromEndpoint(
+            verbKey: verbKey, classRoute: "api/[controller]", methodRoute: null,
+            parentClassName: "XController", methodName: "M");
+
+        Assert.Equal(expectedVerb, result.Verb);
+        Assert.True(result.VerbKnown);
+    }
+}

--- a/tests/Miller.Tests/Resolver/SymbolResolverTests.cs
+++ b/tests/Miller.Tests/Resolver/SymbolResolverTests.cs
@@ -1,0 +1,161 @@
+using Miller.Core.Contracts;
+using Miller.Core.Resolver;
+using Xunit;
+
+namespace Miller.Tests.Resolver;
+
+/// <summary>
+/// Pins <see cref="SymbolResolver"/> — the by-NAME cross-file resolver that every leg leans on because julie ships
+/// <c>target_symbol_id</c> NULL at extract (design §3 "[v3] Cross-file resolution is by NAME"). Asserts the four
+/// outcomes: a unique name resolves; a namespace/project hint breaks a tie; &gt;1 match with no usable hint is
+/// AMBIGUOUS (the caller must lower/drop — NEVER High); 0 match is UNRESOLVED. The ambiguity case is the load-bearing
+/// negative: two same-named types in different files must never auto-resolve to one symbol.
+/// </summary>
+public sealed class SymbolResolverTests
+{
+    private static SymbolDetail Sym(string id, string name, string file, string? ns = null, string kind = "class")
+        => new(
+            Id: id, Name: name, Kind: kind, FilePath: file, Signature: "",
+            Namespace: ns, TestRole: null, ParentClassName: null);
+
+    [Fact]
+    public void Resolve_UniqueName_ResolvesToThatSymbol()
+    {
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "ApplicationUser", "Domain/User.cs"),
+            Sym("2", "Order", "Domain/Order.cs"),
+        ]);
+
+        var result = resolver.Resolve("ApplicationUser");
+
+        Assert.Equal(ResolutionStatus.Resolved, result.Status);
+        Assert.Equal("1", result.SymbolId);
+        Assert.Equal(1, result.MatchCount);
+    }
+
+    [Fact]
+    public void Resolve_NamespaceQualifiedTypeName_MatchesByLeafName()
+    {
+        // CreateMap args are often namespace-qualified ("Core.Reporting.Data.Account"); resolve by the leaf name.
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "Account", "Domain/Account.cs", ns: "Core.Reporting.Data"),
+        ]);
+
+        var result = resolver.Resolve("Core.Reporting.Data.Account");
+
+        Assert.Equal(ResolutionStatus.Resolved, result.Status);
+        Assert.Equal("1", result.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_NoMatch_IsUnresolved()
+    {
+        var resolver = new SymbolResolver([Sym("1", "Order", "Domain/Order.cs")]);
+
+        var result = resolver.Resolve("Nonexistent");
+
+        Assert.Equal(ResolutionStatus.Unresolved, result.Status);
+        Assert.Null(result.SymbolId);
+        Assert.Equal(0, result.MatchCount);
+    }
+
+    /// <summary>
+    /// THE ambiguity guard. Two distinct types named <c>User</c> in different files, no hint to choose. The resolver
+    /// must report Ambiguous with matchCount=2 and NO chosen symbol — the caller lowers/drops the edge, never High.
+    /// </summary>
+    [Fact]
+    public void Resolve_TwoSameNamedTypes_NoHint_IsAmbiguous_NeverAutoResolves()
+    {
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "User", "ServiceA/User.cs", ns: "ServiceA.Models"),
+            Sym("2", "User", "ServiceB/User.cs", ns: "ServiceB.Models"),
+        ]);
+
+        var result = resolver.Resolve("User");
+
+        Assert.Equal(ResolutionStatus.Ambiguous, result.Status);
+        Assert.Null(result.SymbolId); // never silently picks one
+        Assert.Equal(2, result.MatchCount);
+    }
+
+    [Fact]
+    public void Resolve_AmbiguousByName_NamespaceHint_BreaksTheTie()
+    {
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "User", "ServiceA/User.cs", ns: "ServiceA.Models"),
+            Sym("2", "User", "ServiceB/User.cs", ns: "ServiceB.Models"),
+        ]);
+
+        // A fully-qualified type name supplies the namespace hint that disambiguates.
+        var result = resolver.Resolve("ServiceB.Models.User");
+
+        Assert.Equal(ResolutionStatus.Resolved, result.Status);
+        Assert.Equal("2", result.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_AmbiguousByName_FileHint_BreaksTheTie()
+    {
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "User", "ServiceA/User.cs", ns: "ServiceA.Models"),
+            Sym("2", "User", "ServiceB/User.cs", ns: "ServiceB.Models"),
+        ]);
+
+        // The use-site file hint prefers the candidate in the same file/project tree.
+        var result = resolver.Resolve("User", preferFile: "ServiceA/Mapping/Profile.cs", preferNamespace: null);
+
+        // "ServiceA/..." shares the leading path segment with candidate 1 only.
+        Assert.Equal(ResolutionStatus.Resolved, result.Status);
+        Assert.Equal("1", result.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_HintMatchesNoCandidate_StaysAmbiguous()
+    {
+        // A hint that matches neither candidate must NOT force a pick — still ambiguous.
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "User", "ServiceA/User.cs", ns: "ServiceA.Models"),
+            Sym("2", "User", "ServiceB/User.cs", ns: "ServiceB.Models"),
+        ]);
+
+        var result = resolver.Resolve("User", preferFile: "ServiceC/Other.cs", preferNamespace: "ServiceC.Models");
+
+        Assert.Equal(ResolutionStatus.Ambiguous, result.Status);
+        Assert.Null(result.SymbolId);
+    }
+
+    [Fact]
+    public void Resolve_HintMatchesMultipleCandidates_StaysAmbiguous()
+    {
+        // If the namespace hint still leaves >1 candidate, it remains ambiguous (no arbitrary pick by id).
+        var resolver = new SymbolResolver(
+        [
+            Sym("1", "User", "Shared/UserA.cs", ns: "Shared.Models"),
+            Sym("2", "User", "Shared/UserB.cs", ns: "Shared.Models"),
+        ]);
+
+        var result = resolver.Resolve("Shared.Models.User");
+
+        Assert.Equal(ResolutionStatus.Ambiguous, result.Status);
+        Assert.Equal(2, result.MatchCount);
+        Assert.Null(result.SymbolId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_BlankName_IsUnresolved(string name)
+    {
+        var resolver = new SymbolResolver([Sym("1", "Order", "Domain/Order.cs")]);
+
+        var result = resolver.Resolve(name);
+
+        Assert.Equal(ResolutionStatus.Unresolved, result.Status);
+    }
+}

--- a/tests/Miller.Tests/Server/FreshnessServicePollNowTests.cs
+++ b/tests/Miller.Tests/Server/FreshnessServicePollNowTests.cs
@@ -47,7 +47,7 @@ public sealed class FreshnessServicePollNowTests
     public void PollNow_NewerRevisionPersisted_SwapsAndReportsTheNewRevision()
     {
         using var fx = JulieDbFixture.Create(
-            26, "1", JulieDbFixture.DefaultRows, workspaceId: Ws,
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows, workspaceId: Ws,
             revisions: new[] { new JulieDbFixture.RevisionRow(5, Ws) });
         var holder = HolderAt(fx, builtRevision: 1); // the writer has moved to 5, the held index is at 1
         var service = NewServiceOverDb(fx.DbPath, Ws, holder);
@@ -63,7 +63,7 @@ public sealed class FreshnessServicePollNowTests
     public void PollNow_EqualRevision_IsANoOp()
     {
         using var fx = JulieDbFixture.Create(
-            26, "1", JulieDbFixture.DefaultRows, workspaceId: Ws,
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows, workspaceId: Ws,
             revisions: new[] { new JulieDbFixture.RevisionRow(4, Ws) });
         var holder = HolderAt(fx, builtRevision: 4); // already current
         var service = NewServiceOverDb(fx.DbPath, Ws, holder);
@@ -82,7 +82,7 @@ public sealed class FreshnessServicePollNowTests
         // The host loop's ExecuteAsync never ran (so _reader/_rebuilder are null). PollNow must build a transient
         // reader/rebuilder from the workspace and still converge — never throw into the tool.
         using var fx = JulieDbFixture.Create(
-            26, "1", JulieDbFixture.DefaultRows, workspaceId: Ws,
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows, workspaceId: Ws,
             revisions: new[] { new JulieDbFixture.RevisionRow(9, Ws) });
         var holder = HolderAt(fx, builtRevision: 2);
         var service = NewServiceOverDb(fx.DbPath, Ws, holder);
@@ -102,7 +102,7 @@ public sealed class FreshnessServicePollNowTests
         // the SqliteConnection out from under an in-flight query. We stand in for an in-flight poll by holding the
         // gate (RunUnderPollGateForTest) and assert a concurrent disposal cannot complete until the gate releases.
         using var fx = JulieDbFixture.Create(
-            26, "1", JulieDbFixture.DefaultRows, workspaceId: Ws,
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows, workspaceId: Ws,
             revisions: new[] { new JulieDbFixture.RevisionRow(1, Ws) });
         var holder = HolderAt(fx, builtRevision: 1);
         var service = NewServiceOverDb(fx.DbPath, Ws, holder);
@@ -151,7 +151,7 @@ public sealed class FreshnessServicePollNowTests
     {
         // No workspace_id => no canonical_revisions cursor to poll (a never-scanned/static extract). PollNow must
         // honestly report not-swapped at the held revision rather than fabricate a convergence.
-        using var fx = JulieDbFixture.Create(26, "1", JulieDbFixture.DefaultRows); // no workspaceId, no revisions
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows); // no workspaceId, no revisions
         var holder = HolderAt(fx, builtRevision: 3);
         var service = NewServiceOverDb(fx.DbPath, workspaceId: null, holder);
         var beforeIndex = holder.Current;

--- a/tests/Miller.Tests/Server/HolderRepointTests.cs
+++ b/tests/Miller.Tests/Server/HolderRepointTests.cs
@@ -20,13 +20,13 @@ public sealed class HolderRepointTests
         MillerRepositoryIndex.Build(SqliteSymbolReader.Read(fx.DbPath));
 
     // An index WITHOUT the marker symbol, and one WITH it — the swap moves between them.
-    private static JulieDbFixture WithoutMarker() => JulieDbFixture.Create(26, "1", new[]
+    private static JulieDbFixture WithoutMarker() => JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
     {
         new JulieDbFixture.SymbolRow("a0001122334455667788990a1b2c3d4e", "ExistingType", "class", "csharp",
             "src/Existing.cs", "public class ExistingType", 1, null),
     });
 
-    private static JulieDbFixture WithMarker() => JulieDbFixture.Create(26, "1", new[]
+    private static JulieDbFixture WithMarker() => JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
     {
         new JulieDbFixture.SymbolRow("a0001122334455667788990a1b2c3d4e", "ExistingType", "class", "csharp",
             "src/Existing.cs", "public class ExistingType", 1, null),

--- a/tests/Miller.Tests/Server/IndexBootstrapServiceTests.cs
+++ b/tests/Miller.Tests/Server/IndexBootstrapServiceTests.cs
@@ -39,7 +39,7 @@ public sealed class IndexBootstrapServiceTests
         // The happy path: a reused DB with persisted revisions seeds the holder from the MAX (so the freshness
         // poll does not rebuild on the first tick).
         using var fx = JulieDbFixture.Create(
-            schemaVersion: 26, contractValue: "1",
+            schemaVersion: JulieDbFixture.PinnedSchema, contractValue: JulieDbFixture.PinnedContract,
             rows: System.Array.Empty<JulieDbFixture.SymbolRow>(),
             workspaceId: "ws-seed",
             revisions: new[]
@@ -174,7 +174,7 @@ public sealed class IndexBootstrapServiceTests
             return;
 
         using var fx = JulieDbFixture.Create(
-            schemaVersion: 26, contractValue: "1",
+            schemaVersion: JulieDbFixture.PinnedSchema, contractValue: JulieDbFixture.PinnedContract,
             rows: System.Array.Empty<JulieDbFixture.SymbolRow>(),
             workspaceId: "ws-1",
             revisions: new[] { new JulieDbFixture.RevisionRow(2, "ws-1") });

--- a/tests/Miller.Tests/Server/IndexerCoreTests.cs
+++ b/tests/Miller.Tests/Server/IndexerCoreTests.cs
@@ -49,8 +49,8 @@ public sealed class IndexerCoreTests
         }
 
         private static ExtractReport Stub(string status) => new(
-            Status: status, Operation: "test", DbPath: "x", Root: null, SchemaVersion: 26,
-            SchemaState: "current", ExtractContractVersion: 1, AnalysisState: null,
+            Status: status, Operation: "test", DbPath: "x", Root: null, SchemaVersion: (int)MillerExtractContract.ExpectedSchemaVersion,
+            SchemaState: "current", ExtractContractVersion: (int)MillerExtractContract.ExpectedExtractContractVersion, AnalysisState: null,
             FilesScanned: 0, SymbolsExtracted: 0, FilesTotal: 0, SymbolsTotal: 0,
             RelationshipsTotal: 0, IdentifiersTotal: 0, TypesTotal: 0, Errors: System.Array.Empty<ExtractError>(),
             Revision: 2, FilesUpdated: 1, FilesDeleted: 0);

--- a/tests/Miller.Tests/Server/IndexerServiceScanTests.cs
+++ b/tests/Miller.Tests/Server/IndexerServiceScanTests.cs
@@ -38,8 +38,8 @@ public sealed class IndexerServiceScanTests
         }
 
         private static ExtractReport Stub() => new(
-            Status: "changed", Operation: "scan", DbPath: "x", Root: null, SchemaVersion: 26,
-            SchemaState: "current", ExtractContractVersion: 1, AnalysisState: null,
+            Status: "changed", Operation: "scan", DbPath: "x", Root: null, SchemaVersion: (int)MillerExtractContract.ExpectedSchemaVersion,
+            SchemaState: "current", ExtractContractVersion: (int)MillerExtractContract.ExpectedExtractContractVersion, AnalysisState: null,
             FilesScanned: 0, SymbolsExtracted: 0, FilesTotal: 0, SymbolsTotal: 0,
             RelationshipsTotal: 0, IdentifiersTotal: 0, TypesTotal: 0, Errors: System.Array.Empty<ExtractError>(),
             Revision: 7, FilesUpdated: 0, FilesDeleted: 0);

--- a/tests/Miller.Tests/Server/InspectToolTests.cs
+++ b/tests/Miller.Tests/Server/InspectToolTests.cs
@@ -148,7 +148,7 @@ public sealed class InspectToolTests
     [Fact]
     public void Run_AmbiguousName_ReturnsCandidates_NeverPicksFirst()
     {
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("aa11223344556677889900aabbccddee", "Handle", "method", "csharp",
                 "a/First.cs", "void Handle()", 3, null),

--- a/tests/Miller.Tests/Server/JulieExtractOpsTests.cs
+++ b/tests/Miller.Tests/Server/JulieExtractOpsTests.cs
@@ -19,8 +19,8 @@ public sealed class JulieExtractOpsTests
     {
         var calls = new List<Recorded>();
         ExtractReport Stub() => new(
-            Status: "changed", Operation: "test", DbPath: db, Root: canonicalRoot, SchemaVersion: 26,
-            SchemaState: "current", ExtractContractVersion: 1, AnalysisState: null,
+            Status: "changed", Operation: "test", DbPath: db, Root: canonicalRoot, SchemaVersion: (int)MillerExtractContract.ExpectedSchemaVersion,
+            SchemaState: "current", ExtractContractVersion: (int)MillerExtractContract.ExpectedExtractContractVersion, AnalysisState: null,
             FilesScanned: 0, SymbolsExtracted: 0, FilesTotal: 0, SymbolsTotal: 0,
             RelationshipsTotal: 0, IdentifiersTotal: 0, TypesTotal: 0,
             Errors: System.Array.Empty<ExtractError>(), Revision: 2, FilesUpdated: 1, FilesDeleted: 0);

--- a/tests/Miller.Tests/Server/LargeDbWriter.cs
+++ b/tests/Miller.Tests/Server/LargeDbWriter.cs
@@ -11,7 +11,7 @@ namespace Miller.Tests.Server;
 /// subset the production build path (<see cref="RepositoryIndexLoader.Load"/> → <see cref="SqliteSymbolReader.Read"/>
 /// + <see cref="SymbolGraphReader.Read"/>) + the schema gate require (files + symbols [incl. <c>end_line</c>, D7]
 /// + the <c>relationships</c>/<c>identifiers</c> edge tables [D2] + schema_version + external_extract_metadata),
-/// at the pinned schema 26 / contract 1. The edge tables are created empty here — the rebuild latency this
+/// at the pinned schema 28 / contract 2. The edge tables are created empty here — the rebuild latency this
 /// measures is the read+build path, and empty edge reads still exercise the loader's two extra SELECTs.
 /// </summary>
 internal static class LargeDbWriter
@@ -53,8 +53,8 @@ internal static class LargeDbWriter
             """);
         Exec(conn, "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL, description TEXT NOT NULL);");
         Exec(conn, "CREATE TABLE external_extract_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL);");
-        Exec(conn, "INSERT INTO schema_version (version, applied_at, description) VALUES (26, 0, 'test');");
-        Exec(conn, "INSERT INTO external_extract_metadata (key, value, updated_at) VALUES ('extract_contract_version', '1', 0);");
+        Exec(conn, $"INSERT INTO schema_version (version, applied_at, description) VALUES ({MillerExtractContract.ExpectedSchemaVersion}, 0, 'test');");
+        Exec(conn, $"INSERT INTO external_extract_metadata (key, value, updated_at) VALUES ('extract_contract_version', '{MillerExtractContract.ExpectedExtractContractVersion}', 0);");
 
         using var tx = conn.BeginTransaction();
 

--- a/tests/Miller.Tests/Server/SearchToolTests.cs
+++ b/tests/Miller.Tests/Server/SearchToolTests.cs
@@ -22,7 +22,7 @@ public sealed class SearchToolTests
     // path-flagged test row (tests/auth/AuthServiceTests.cs — no metadata) AND a julie-is_test row whose path
     // is NOT test-shaped (src/auth/AuthHelper.cs carrying {"is_test":true}, a [Fact] method julie flagged).
     // The third row is the one the path-only filter would miss; it pins the sym.IsTest branch of the predicate.
-    private static JulieDbFixture FixtureWithTestPaths() => JulieDbFixture.Create(26, "1", new[]
+    private static JulieDbFixture FixtureWithTestPaths() => JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
     {
         new JulieDbFixture.SymbolRow("a0001122334455667788990a1b2c3d4e", "AuthService", "class", "csharp",
             "src/auth/AuthService.cs", "public class AuthService", 1, null),
@@ -94,7 +94,7 @@ public sealed class SearchToolTests
         var rows = Enumerable.Range(0, 5).Select(i => new JulieDbFixture.SymbolRow(
             $"{i:x32}".PadLeft(32, '0')[..32], $"Widget{i}", "class", "csharp",
             $"src/Widget{i}.cs", $"public class Widget{i}", 1, null)).ToArray();
-        using var fx = JulieDbFixture.Create(26, "1", rows);
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, rows);
         var index = BuildIndex(fx);
 
         string output = SearchTool.Run(index, "widget", SearchToolMode.Auto, limit: 2,

--- a/tests/Miller.Tests/Server/SmartTargetResolverTests.cs
+++ b/tests/Miller.Tests/Server/SmartTargetResolverTests.cs
@@ -52,7 +52,7 @@ public sealed class SmartTargetResolverTests
         // decision-4: a target is a file because julie INDEXED that extension here — not because the extension
         // is on a hand-picked allowlist. Seed languages the old 22-entry whitelist omitted (.vue, .ex, .zig)
         // and assert they resolve as files purely from the indexed data.
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("a0112233445566778899aabbccddee01", "App", "class", "vue",
                 "ui/App.vue", "App", 1, null),
@@ -156,7 +156,7 @@ public sealed class SmartTargetResolverTests
     public void Resolve_AmbiguousName_ReturnsAllCandidates()
     {
         // Two distinct symbols share the name "Handle" across two files.
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("aa11223344556677889900aabbccddee", "Handle", "method", "csharp",
                 "a/First.cs", "void Handle()", 3, null),
@@ -179,7 +179,7 @@ public sealed class SmartTargetResolverTests
     [Fact]
     public void Resolve_Scope_DisambiguatesAmbiguousNameToOneFile()
     {
-        using var fx = JulieDbFixture.Create(26, "1", new[]
+        using var fx = JulieDbFixture.Create(JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, new[]
         {
             new JulieDbFixture.SymbolRow("aa11223344556677889900aabbccddee", "Handle", "method", "csharp",
                 "a/First.cs", "void Handle()", 3, null),

--- a/tests/Miller.Tests/Server/WorkspaceToolTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceToolTests.cs
@@ -97,7 +97,7 @@ public sealed class WorkspaceToolTests : IDisposable
 
     private static JulieDbFixture CreateSynth(long revision, string? workspaceId) =>
         JulieDbFixture.Create(
-            26, "1", JulieDbFixture.DefaultRows, workspaceId: workspaceId,
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract, JulieDbFixture.DefaultRows, workspaceId: workspaceId,
             revisions: workspaceId is null
                 ? null
                 : new[] { new JulieDbFixture.RevisionRow(revision, workspaceId) });
@@ -112,8 +112,8 @@ public sealed class WorkspaceToolTests : IDisposable
         {
             ScanForce.Add(force);
             return new ExtractReport(
-                Status: "changed", Operation: "scan", DbPath: "x", Root: null, SchemaVersion: 26,
-                SchemaState: "current", ExtractContractVersion: 1, AnalysisState: null,
+                Status: "changed", Operation: "scan", DbPath: "x", Root: null, SchemaVersion: (int)MillerExtractContract.ExpectedSchemaVersion,
+                SchemaState: "current", ExtractContractVersion: (int)MillerExtractContract.ExpectedExtractContractVersion, AnalysisState: null,
                 FilesScanned: 0, SymbolsExtracted: 0, FilesTotal: 0, SymbolsTotal: 0,
                 RelationshipsTotal: 0, IdentifiersTotal: 0, TypesTotal: 0, Errors: [],
                 Revision: 99, FilesUpdated: 0, FilesDeleted: 0);

--- a/tests/Miller.Tests/Tools/TraceToolTests.cs
+++ b/tests/Miller.Tests/Tools/TraceToolTests.cs
@@ -1,0 +1,463 @@
+using Miller.Core.Contracts;
+using Miller.Core.Graph;
+using Miller.Core.Resolver;
+using Miller.Indexing;
+using Miller.Server.Resolution;
+using Miller.Server.Tools;
+using Xunit;
+
+namespace Miller.Tests.Tools;
+
+/// <summary>
+/// Fast/pure unit tests for the <c>trace</c> tool's <see cref="TraceTool.Run"/> core (M4 Task 10). All three modes
+/// (auto / path / bridge) plus the no-path case, the load-bearing honesty flags ([verb-unknown] / [ambiguous]),
+/// depth/limit bounds, and compact-vs-full rendering are exercised directly against in-memory fixtures — no MCP, no DI,
+/// no DB, no julie. Category!=Scale (the default fast suite).
+/// </summary>
+public sealed class TraceToolTests
+{
+    // ---------- fixture builders ----------
+
+    // A symbol-graph index over the given symbols + dependency edges (no bridge). DocIds are the 0-based ordinals
+    // MillerRepositoryIndex.Build requires.
+    private static MillerRepositoryIndex BuildSymbolIndex(
+        IReadOnlyList<(string id, string name, string kind, string file, int line)> symbols,
+        IReadOnlyList<(string from, string to)> edges)
+    {
+        var indexed = new List<IndexedSymbol>(symbols.Count);
+        for (int i = 0; i < symbols.Count; i++)
+        {
+            var (id, name, kind, file, line) = symbols[i];
+            indexed.Add(new IndexedSymbol(
+                DocId: i, SymbolId: id, Name: name, Signature: $"{kind} {name}()",
+                Kind: kind, Language: "csharp", FilePath: file, StartLine: line, EndLine: line, ParentId: null));
+        }
+        var graphEdges = edges.Select(e => new GraphEdge(e.from, e.to, "calls")).ToList();
+        return MillerRepositoryIndex.Build(indexed, graphEdges);
+    }
+
+    // A trivially-resolved NameResolution for a symbol-backed endpoint.
+    private static NameResolution Resolved(string symbolId) =>
+        new(ResolutionStatus.Resolved, symbolId, MatchCount: 1);
+
+    // An EdgeRef for a symbol-backed endpoint (id == node id).
+    private static EdgeRef SymbolRef(string symbolId, string display, string file) =>
+        new(display, symbolId, file, Resolved(symbolId));
+
+    // An EdgeRef for a non-symbol endpoint (DB table / route): no symbol id, trivially resolved.
+    private static EdgeRef NonSymbolRef(string display) =>
+        new(display, SymbolId: null, FilePath: null, new NameResolution(ResolutionStatus.Resolved, null, 1));
+
+    private static ScoredEdge MakeScored(
+        BridgeKind kind, EdgeRef source, EdgeRef target, ConfidenceBand band, double score,
+        bool ambiguous = false, bool verbUnknown = false, IReadOnlyList<Signal>? signals = null)
+    {
+        var candidate = new CandidateEdge(
+            kind, source, target,
+            Evidence: Array.Empty<Evidence>(),
+            Signals: signals ?? Array.Empty<Signal>());
+        return new ScoredEdge(candidate, score, band,
+            IsMultiSignal: (signals?.Count ?? 0) > 1, HasAmbiguousName: ambiguous, IsVerbUnknown: verbUnknown);
+    }
+
+    // Build a node lookup covering every endpoint of the given scored edges, then the bridge graph + an index that
+    // carries it. Symbol-backed endpoints get a real IndexedSymbol so SmartTargetResolver can resolve them by name.
+    private static MillerRepositoryIndex BuildBridgeIndex(
+        IReadOnlyList<(string symbolId, string name, string file, int line)> symbols,
+        IReadOnlyList<ScoredEdge> edges,
+        IReadOnlyDictionary<string, BridgeNode> extraNodes)
+    {
+        var indexed = new List<IndexedSymbol>(symbols.Count);
+        var nodes = new Dictionary<string, BridgeNode>(StringComparer.Ordinal);
+        for (int i = 0; i < symbols.Count; i++)
+        {
+            var (symbolId, name, file, line) = symbols[i];
+            indexed.Add(new IndexedSymbol(
+                DocId: i, SymbolId: symbolId, Name: name, Signature: $"class {name}", Kind: "class",
+                Language: "csharp", FilePath: file, StartLine: line, EndLine: line, ParentId: null));
+            nodes[symbolId] = new BridgeNode(symbolId, BridgeNodeKind.CsDto, name, file, line);
+        }
+        foreach (var (id, node) in extraNodes)
+            nodes[id] = node;
+
+        var bridge = BridgeGraph.Build(edges, nodes);
+        return MillerRepositoryIndex.Build(indexed, Array.Empty<GraphEdge>(), bridge);
+    }
+
+    private static SmartTargetResolver ResolverFor(MillerRepositoryIndex index) => new(index);
+
+    // ---------- mode: auto ----------
+
+    [Fact]
+    public void Auto_ReturnsCallersAndCallees_WithHopAndProvenance()
+    {
+        // A depends on B; C depends on A. Direction.Both from A reaches both B (callee) and C (caller).
+        var index = BuildSymbolIndex(
+            new[]
+            {
+                ("a", "Alpha", "method", "src/A.cs", 10),
+                ("b", "Beta", "method", "src/B.cs", 20),
+                ("c", "Gamma", "method", "src/C.cs", 30),
+            },
+            new[] { ("a", "b"), ("c", "a") });
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "auto", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out int visited);
+
+        Assert.Equal(2, emitted);
+        Assert.Equal(2, visited);
+        Assert.Contains("# trace Alpha (auto, 2 neighbour(s))", outp);
+        Assert.Contains("Beta  method  src/B.cs:20  (hop 1)", outp);
+        Assert.Contains("Gamma  method  src/C.cs:30  (hop 1)", outp);
+    }
+
+    [Fact]
+    public void Auto_RespectsLimit()
+    {
+        var index = BuildSymbolIndex(
+            new[]
+            {
+                ("a", "Alpha", "method", "src/A.cs", 1),
+                ("b", "Beta", "method", "src/B.cs", 2),
+                ("c", "Gamma", "method", "src/C.cs", 3),
+                ("d", "Delta", "method", "src/D.cs", 4),
+            },
+            new[] { ("a", "b"), ("a", "c"), ("a", "d") });
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "auto", to: null, depth: 1, limit: 2, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(2, emitted);
+    }
+
+    [Fact]
+    public void Auto_NoNeighbours_CleanMessage()
+    {
+        var index = BuildSymbolIndex(
+            new[] { ("a", "Alpha", "method", "src/A.cs", 1) },
+            Array.Empty<(string, string)>());
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "auto", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("No neighbours", outp);
+    }
+
+    [Fact]
+    public void Auto_TargetNotFound_CleanMessage()
+    {
+        var index = BuildSymbolIndex(
+            new[] { ("a", "Alpha", "method", "src/A.cs", 1) },
+            Array.Empty<(string, string)>());
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "DoesNotExist", mode: "auto", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("not found", outp);
+    }
+
+    // ---------- mode: path ----------
+
+    [Fact]
+    public void Path_RendersOrderedShortestPath()
+    {
+        // a -> b -> c (forward dependency adjacency).
+        var index = BuildSymbolIndex(
+            new[]
+            {
+                ("a", "Alpha", "method", "src/A.cs", 1),
+                ("b", "Beta", "method", "src/B.cs", 2),
+                ("c", "Gamma", "method", "src/C.cs", 3),
+            },
+            new[] { ("a", "b"), ("b", "c") });
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "path", to: "Gamma", depth: 5, limit: 20, fullFormat: false,
+            out int emitted, out int visited);
+
+        Assert.Equal(3, emitted);   // Alpha, Beta, Gamma
+        Assert.Equal(3, visited);
+        Assert.Contains("# trace path Alpha -> Gamma (2 hop(s))", outp);
+        // Ordered: Alpha first (no arrow), then -> Beta, then -> Gamma. Search the BODY only — the header line also
+        // contains "Alpha" and "Gamma", which would otherwise confuse the ordering check.
+        int headerEnd = outp.IndexOf('\n');
+        Assert.True(headerEnd > 0, "compact path output must have a header line");
+        string body = outp[(headerEnd + 1)..];
+        int alpha = body.IndexOf("Alpha", StringComparison.Ordinal);
+        int beta = body.IndexOf("Beta", StringComparison.Ordinal);
+        int gamma = body.IndexOf("Gamma", StringComparison.Ordinal);
+        Assert.True(alpha >= 0 && alpha < beta && beta < gamma,
+            "path body must be rendered Alpha -> Beta -> Gamma in order");
+        Assert.Contains("-> Beta  method  src/B.cs:2", outp);
+    }
+
+    [Fact]
+    public void Path_NoConnection_CleanMessage()
+    {
+        // a and c are not connected.
+        var index = BuildSymbolIndex(
+            new[]
+            {
+                ("a", "Alpha", "method", "src/A.cs", 1),
+                ("c", "Gamma", "method", "src/C.cs", 3),
+            },
+            Array.Empty<(string, string)>());
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "path", to: "Gamma", depth: 5, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("No path from 'Alpha' to 'Gamma'", outp);
+    }
+
+    [Fact]
+    public void Path_BeyondDepth_NoPath()
+    {
+        var index = BuildSymbolIndex(
+            new[]
+            {
+                ("a", "Alpha", "method", "src/A.cs", 1),
+                ("b", "Beta", "method", "src/B.cs", 2),
+                ("c", "Gamma", "method", "src/C.cs", 3),
+            },
+            new[] { ("a", "b"), ("b", "c") });
+
+        // depth=1 cannot reach Gamma (2 hops away).
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "path", to: "Gamma", depth: 1, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("No path", outp);
+    }
+
+    [Fact]
+    public void Path_MissingTo_UsageMessage()
+    {
+        var index = BuildSymbolIndex(
+            new[] { ("a", "Alpha", "method", "src/A.cs", 1) },
+            Array.Empty<(string, string)>());
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "path", to: null, depth: 5, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("mode=path requires 'to'", outp);
+    }
+
+    // ---------- mode: bridge ----------
+
+    [Fact]
+    public void Bridge_RendersChainWithScoreAndBand()
+    {
+        // UserDto --CreateMap--> ApplicationUser --DbSet--> ApplicationUsers (a table, non-symbol node).
+        var dtoEntity = MakeScored(
+            BridgeKind.MapsTo,
+            SymbolRef("dto", "UserDto", "src/UserDto.cs"),
+            SymbolRef("ent", "ApplicationUser", "src/ApplicationUser.cs"),
+            ConfidenceBand.High, 0.95);
+
+        string tableNodeId = BridgeGraph.SynthesizeId(BridgeNodeKind.DbTable, "ApplicationUsers");
+        var entityTable = MakeScored(
+            BridgeKind.StoredIn,
+            SymbolRef("ent", "ApplicationUser", "src/ApplicationUser.cs"),
+            NonSymbolRef("ApplicationUsers"),
+            ConfidenceBand.High, 0.9);
+
+        var extra = new Dictionary<string, BridgeNode>(StringComparer.Ordinal)
+        {
+            [tableNodeId] = new BridgeNode(tableNodeId, BridgeNodeKind.DbTable, "ApplicationUsers", null, 0),
+        };
+        var index = BuildBridgeIndex(
+            new[] { ("dto", "UserDto", "src/UserDto.cs", 1), ("ent", "ApplicationUser", "src/ApplicationUser.cs", 1) },
+            new[] { dtoEntity, entityTable },
+            extra);
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "UserDto", mode: "bridge", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out int visited);
+
+        Assert.Equal(2, emitted);
+        Assert.Equal(2, visited);
+        Assert.Contains("UserDto  --CreateMap-->  ApplicationUser", outp);
+        Assert.Contains("0.95 (High)", outp);
+        Assert.Contains("ApplicationUser  --DbSet-->  ApplicationUsers", outp);
+        Assert.Contains("0.90 (High)", outp);
+    }
+
+    [Fact]
+    public void Bridge_RendersVerbUnknownFlag()
+    {
+        // A route-only (verb-unknown) Hits edge: TS call -> endpoint.
+        string callNodeId = BridgeGraph.SynthesizeId(BridgeNodeKind.TsType, "api/users");
+        var hits = MakeScored(
+            BridgeKind.Hits,
+            NonSymbolRef("api/users"),
+            SymbolRef("ep", "GetUsers", "src/UsersController.cs"),
+            ConfidenceBand.Medium, 0.75, verbUnknown: true);
+
+        var extra = new Dictionary<string, BridgeNode>(StringComparer.Ordinal)
+        {
+            [callNodeId] = new BridgeNode(callNodeId, BridgeNodeKind.TsType, "api/users", "web/api.ts", 5),
+        };
+        var index = BuildBridgeIndex(
+            new[] { ("ep", "GetUsers", "src/UsersController.cs", 12) },
+            new[] { hits },
+            extra);
+
+        // Start from the endpoint symbol (a symbol-backed node) so it resolves by name.
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "GetUsers", mode: "bridge", to: null, depth: 2, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(1, emitted);
+        Assert.Contains("[verb-unknown]", outp);
+        Assert.Contains("0.75 (Medium)", outp);
+    }
+
+    [Fact]
+    public void Bridge_RendersAmbiguousFlag()
+    {
+        var mapsTo = MakeScored(
+            BridgeKind.MapsTo,
+            SymbolRef("dto", "OrderDto", "src/OrderDto.cs"),
+            SymbolRef("ent", "Order", "src/Order.cs"),
+            ConfidenceBand.Medium, 0.7, ambiguous: true);
+
+        var index = BuildBridgeIndex(
+            new[] { ("dto", "OrderDto", "src/OrderDto.cs", 1), ("ent", "Order", "src/Order.cs", 1) },
+            new[] { mapsTo },
+            new Dictionary<string, BridgeNode>(StringComparer.Ordinal));
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "OrderDto", mode: "bridge", to: null, depth: 2, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(1, emitted);
+        Assert.Contains("[ambiguous]", outp);
+        // An ambiguous edge is never High — assert the band is rendered Medium, not silently certain.
+        Assert.Contains("(Medium)", outp);
+        Assert.DoesNotContain("(High)", outp);
+    }
+
+    [Fact]
+    public void Bridge_NotOnBridge_CleanMessage()
+    {
+        // A symbol that exists but has no bridge edges.
+        var index = BuildBridgeIndex(
+            new[] { ("x", "Loner", "src/Loner.cs", 1) },
+            Array.Empty<ScoredEdge>(),
+            new Dictionary<string, BridgeNode>(StringComparer.Ordinal));
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Loner", mode: "bridge", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("not on a cross-language bridge", outp);
+    }
+
+    [Fact]
+    public void Bridge_FullFormat_ListsFiringSignals()
+    {
+        var signals = new Signal[]
+        {
+            new StructuralSignal(SignalRule.CreateMap, Present: true),
+            new FieldSetSignal(FieldCount: 8, Jaccard: 0.6),
+            new NameSignal(NameTier.Exact),
+            new NameResolutionSignal(EndpointSide.Target, ResolutionStatus.Resolved, MatchCount: 1),
+        };
+        var mapsTo = MakeScored(
+            BridgeKind.MapsTo,
+            SymbolRef("dto", "UserDto", "src/UserDto.cs"),
+            SymbolRef("ent", "ApplicationUser", "src/ApplicationUser.cs"),
+            ConfidenceBand.High, 0.95, signals: signals);
+
+        var index = BuildBridgeIndex(
+            new[] { ("dto", "UserDto", "src/UserDto.cs", 1), ("ent", "ApplicationUser", "src/ApplicationUser.cs", 1) },
+            new[] { mapsTo },
+            new Dictionary<string, BridgeNode>(StringComparer.Ordinal));
+
+        string compact = TraceTool.Run(index, ResolverFor(index),
+            target: "UserDto", mode: "bridge", to: null, depth: 2, limit: 20, fullFormat: false,
+            out _, out _);
+        string full = TraceTool.Run(index, ResolverFor(index),
+            target: "UserDto", mode: "bridge", to: null, depth: 2, limit: 20, fullFormat: true,
+            out _, out _);
+
+        // Compact must NOT carry the signal listing; full must.
+        Assert.DoesNotContain("signals:", compact);
+        Assert.Contains("signals:", full);
+        Assert.Contains("CreateMap=present", full);
+        Assert.Contains("FieldSetJaccard(count=8, jaccard=0.60)", full);
+        Assert.Contains("NameMatch=Exact", full);
+        Assert.Contains("NameResolution(Target=Resolved, matches=1)", full);
+    }
+
+    [Fact]
+    public void Bridge_RespectsLimit()
+    {
+        // One DTO node bridging to three distinct entities -> three incident edges; limit caps the rendered count.
+        var edges = new[]
+        {
+            MakeScored(BridgeKind.MapsTo, SymbolRef("dto", "Hub", "src/Hub.cs"), SymbolRef("e1", "EntityA", "src/EntityA.cs"), ConfidenceBand.High, 0.9),
+            MakeScored(BridgeKind.MapsTo, SymbolRef("dto", "Hub", "src/Hub.cs"), SymbolRef("e2", "EntityB", "src/EntityB.cs"), ConfidenceBand.High, 0.9),
+            MakeScored(BridgeKind.MapsTo, SymbolRef("dto", "Hub", "src/Hub.cs"), SymbolRef("e3", "EntityC", "src/EntityC.cs"), ConfidenceBand.High, 0.9),
+        };
+        var index = BuildBridgeIndex(
+            new[]
+            {
+                ("dto", "Hub", "src/Hub.cs", 1),
+                ("e1", "EntityA", "src/EntityA.cs", 1),
+                ("e2", "EntityB", "src/EntityB.cs", 1),
+                ("e3", "EntityC", "src/EntityC.cs", 1),
+            },
+            edges,
+            new Dictionary<string, BridgeNode>(StringComparer.Ordinal));
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Hub", mode: "bridge", to: null, depth: 1, limit: 2, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(2, emitted);
+    }
+
+    // ---------- dispatch / guards ----------
+
+    [Fact]
+    public void UnknownMode_CleanMessage()
+    {
+        var index = BuildSymbolIndex(
+            new[] { ("a", "Alpha", "method", "src/A.cs", 1) },
+            Array.Empty<(string, string)>());
+
+        string outp = TraceTool.Run(index, ResolverFor(index),
+            target: "Alpha", mode: "sideways", to: null, depth: 3, limit: 20, fullFormat: false,
+            out int emitted, out _);
+
+        Assert.Equal(0, emitted);
+        Assert.Contains("Unknown mode 'sideways'", outp);
+    }
+
+    [Fact]
+    public void NullIndex_Throws()
+    {
+        var index = BuildSymbolIndex(
+            new[] { ("a", "Alpha", "method", "src/A.cs", 1) },
+            Array.Empty<(string, string)>());
+        var resolver = ResolverFor(index);
+
+        Assert.Throws<ArgumentNullException>(() =>
+            TraceTool.Run(null!, resolver, "Alpha", "auto", null, 3, 20, false, out _, out _));
+        Assert.Throws<ArgumentNullException>(() =>
+            TraceTool.Run(index, null!, "Alpha", "auto", null, 3, 20, false, out _, out _));
+    }
+}


### PR DESCRIPTION
## M4 — the differentiator milestone

A `trace` MCP tool (auto/path/bridge modes) backed by a **deterministic, embedding-free** cross-language structural resolver (TS ↔ C# ↔ DB), consuming julie's lean 28/2 extract contract.

7 commits, landed in phases:

- **A** `152eb99` — cross-language resolver foundation
- **B** `a5d9de1` — three bridge legs: entity↔table (EF `DbSet<T>`), DTO↔entity (AutoMapper `CreateMap`), route (TS call ↔ C# endpoint)
- **C** `6efcb7b` — `trace` tool + in-memory `BridgeGraph` (deterministic id-sorted walk) + `SymbolGraph.ShortestPath`
- **D** `0ecab17` — live Scale gate + honesty probe (the shippable gate)
- plus the julie-server 7.13.0 re-pin (schema 28 / contract 2) and the design doc.

## Verification (all independently re-run, not self-reported)

- **Build** 0 warnings / 0 errors (TreatWarningsAsErrors).
- **Fast suite** 1050 passed / 0 failed / 0 skipped, 3s wall (Scale excluded).
- **Scale gate** `LiveBridgeTraceTests` 2/2 — drives the real `julie-server extract` over throwaway polyglot fixtures and asserts the actual `BridgeGraph`.
- **ScaleTraitConvention** guard 1/1 (the fast/Scale split holds).
- **Honesty probe**: precision 6/6 = 1.00 (floor 0.75), recall 1.00 per buildable leg, measured live and written into the design-doc appendix. Four hard guards assert on the scored payload: corroborator-only, ambiguous-name-never-High (with an anti-vacuity check), test-literal-excluded, verb-unknown-not-assumed-GET.

## Honest caveats

- **Dapper-FROM entity↔table is dropped** — unbuildable on julie's lean 28/2 contract (no use-site name/kind on `type_arguments`); EF `DbSet<T>` is the sole entity↔table anchor. Restoring it needs a julie-side `type_arguments` widening. Documented in §4/§8/§9.
- **STRONG grades are single-repo (MyraNext)**; cross-repo generalization (Tycho/LabHandbookV2 + fetch/manual-mapping fixtures) is explicitly out of this milestone's scope.
- A production trace-rendering bug surfaced by the gate is fixed here (`BridgeGraphBuilder.AddNode` rendered route text instead of the action name).

`Miller.Core` stays zero-I/O throughout.