### PR TITLE
Dead-code candidates: references candidates CLI surface (gate passed 392→5)

### DIFF
--- a/.memories/2026-07-06/214322_71e4.md
+++ b/.memories/2026-07-06/214322_71e4.md
@@ -1,0 +1,41 @@
+---
+id: checkpoint_71e4a34b
+timestamp: 2026-07-06T21:43:22.751Z
+tags:
+  - assessment
+  - dashboard
+  - eros-boundary
+  - roadmap
+git:
+  branch: main
+  commit: e1fee44
+  files:
+    - docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md
+summary: Miller standalone bolstering assessment written
+briefId: miller-project-direction-amp-milestone-state
+type: decision
+decision: Bolster Miller by absorbing the deterministic Eros workflows
+  (hotspots, dead-code candidates, signals rollup, history) as CLI verbs +
+  dashboard panels; keep embeddings/semantic out.
+alternatives:
+  - "Absorb semantic/embedding retrieval into Miller — rejected for now: heavy
+    deps, changes deterministic character"
+  - Dashboard-UX-only polish without new analysis — rejected as not addressing
+    the actual Eros dependency
+next: User reviews assessment doc and green-lights priorities (P1–P4) before
+  implementation begins.
+---
+
+## Miller standalone bolstering assessment written
+
+**WHAT:** Assessed the Miller dashboard + CLI against the Eros-deferred capability list and wrote `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md` with a prioritized absorb roadmap.
+
+**WHY:** Eros isn't shipping (may never); user wants Miller complete standalone, not dependent on Eros for the analysis workflows.
+
+**HOW:**
+- Verified live dashboard (166 workspaces; detail page has transparency, health, patterns, onboarding, local metrics complexity+clones, context savings, activity)
+- Verified CLI facts: `metrics churn|clones|complexity --json`, `references export --jsonl`, `todos`, plus JSON read contracts
+- Proposed priorities: P1 `metrics hotspots` (churn×complexity join), P2 `references candidates` (deterministic dead-code with named suppression rules), P3 `miller report` signals rollup, P4 revision-keyed metric history sidecar + dashboard trends. Embeddings stay out.
+- Boundary note: CLAUDE.md/README/contracts Eros-owns wording must be updated in the same slice as each absorb; no new MCP tools — CLI + dashboard only.
+
+**IMPACT:** Ready-to-review roadmap; awaiting user pick of which priorities to green-light before any implementation.

--- a/.memories/2026-07-06/220124_3a43.md
+++ b/.memories/2026-07-06/220124_3a43.md
@@ -1,0 +1,34 @@
+---
+id: checkpoint_3a43c763
+timestamp: 2026-07-06T22:01:24.567Z
+tags:
+  - metrics-risk
+  - cli
+  - eros-absorb
+git:
+  branch: main
+  commit: 9867b4c
+  files:
+    - docs/contracts/metrics-json-v1.md
+    - src/Miller.Indexing/ComplexityRankingReader.cs
+    - src/Miller.Server/Cli/CliCapabilities.cs
+    - src/Miller.Server/Cli/CliDispatch.cs
+    - src/Miller.Server/Tools/MetricsTool.cs
+    - src/Miller.Server/Tools/RiskRanking.cs
+    - tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+    - tests/Miller.Tests/Server/RiskMetricsToolTests.cs
+summary: Shipped `miller metrics risk` (P1 of standalone bolstering plan)
+briefId: miller-project-direction-amp-milestone-state
+---
+
+## Shipped `miller metrics risk` (P1 of standalone bolstering plan)
+
+**WHAT:** New deterministic churn×complexity risk ranking: `miller metrics risk [--json] [--range] [--limit] [--include-tests|--exclude-tests]`.
+
+**HOW:**
+- `RiskRanking` (src/Miller.Server/Tools/RiskRanking.cs): joins FULL churn and complexity sets before limiting; symbol tier joins on `symbol_id`, file tier joins `file_only` churn rows to path-aggregated complexity; score = `commit_count * (decision_count + loop_count + max_nesting_depth)`; risk = intersection of evidence only.
+- `ComplexityRankingReader.ReadForPaths`: path-filtered complexity read (chunked IN, 500/query) so cost scales with churned paths, not table size.
+- Wired into MetricsTool (compact + JSON renders), CliDispatch (`risk` operation; `hotspots` remains a complexity alias — NOT reused, per Codex review), CliCapabilities, metrics-json-v1 contract doc (additive; explicit open-enum note).
+- 6 new fast-suite tests (RiskMetricsToolTests) incl. join-before-limit proof; 2843 tests green in 15s.
+
+**IMPACT:** First Eros-deferred workflow absorbed into Miller. Verified live: CliDispatch.Run tops the miller repo's own risk ranking. Next: P2 `miller report` rollup.

--- a/.memories/2026-07-06/221205_b3ca.md
+++ b/.memories/2026-07-06/221205_b3ca.md
@@ -1,0 +1,39 @@
+---
+id: checkpoint_b3ca3750
+timestamp: 2026-07-06T22:12:05.424Z
+tags:
+  - miller-report
+  - cli
+  - eros-absorb
+  - boundary-docs
+git:
+  branch: main
+  commit: 97989f7
+  files:
+    - AGENTS.md
+    - CLAUDE.md
+    - README.md
+    - docs/contracts/report-json-v1.md
+    - docs/site/index.html
+    - src/Miller.Indexing/WorkspaceIndexFactsReader.cs
+    - src/Miller.Server/Cli/CliCapabilities.cs
+    - src/Miller.Server/Cli/CliDispatch.cs
+    - src/Miller.Server/Tools/ReportTool.cs
+    - src/Miller.Server/Tools/RiskRanking.cs
+    - tests/Miller.Tests/Server/ReportToolTests.cs
+summary: Shipped `miller report` rollup (P2 of standalone bolstering plan)
+briefId: miller-project-direction-amp-milestone-state
+---
+
+## Shipped `miller report` rollup (P2 of standalone bolstering plan)
+
+**WHAT:** New `miller report [--json]` CLI verb — one composed repo-quality report: index counts, extraction health (parse diagnostics + capability gaps), bounded marker counts, top complexity hotspots, top clone groups, top churn, top churn×complexity risk. No dead-code section per consensus.
+
+**HOW:**
+- `ReportTool` (src/Miller.Server/Tools/ReportTool.cs): pure composition over existing readers; unavailable sections (no git, sidecar off) render with a reason instead of failing.
+- Perf: one git history parse feeds both churn and risk via new `RiskRanking.FromChurn`; markers explicitly bounded at MarkerSearch.MaxLimit with truncation flag; new `WorkspaceIndexFactsReader.ReadSymbolCounts` scalar read.
+- New contract doc `docs/contracts/report-json-v1.md`; capabilities advertises `report --json` + contract tuple; help text updated.
+- Boundary housekeeping per consensus: CLAUDE.md replacement-boundary rewritten (Miller owns deterministic analysis reports; Eros = semantics/fleet state only), README + site copy aligned, AGENTS.md regenerated in sync.
+- 4 new fast tests (ReportToolTests); 2847 fast + 46 scale all green.
+
+**IMPACT:** Miller now has the "signals report" capability formerly deferred to Eros. Verified live on the miller repo (all 7 sections render; markers counted; risk top = CliDispatch.Run). Remaining roadmap: P3 dead-code prototype (blocked on extractor reference resolution), P4 history/trends (design work).

--- a/.memories/2026-07-07/005856_8657.md
+++ b/.memories/2026-07-07/005856_8657.md
@@ -1,0 +1,46 @@
+---
+id: checkpoint_86575224
+timestamp: 2026-07-07T00:58:56.176Z
+tags:
+  - p3-dead-code
+  - p4-trends
+  - reference-resolution
+  - julie-extractors
+  - design
+git:
+  branch: main
+  commit: 271361a
+summary: P3/P4 direction settled + reference-resolution design drafted
+briefId: miller-project-direction-amp-milestone-state
+type: decision
+decision: Build workspace-level tiered reference resolution in
+  julie-extract-artifact first; Miller P3 dead-code and P4 trends follow after
+  the pin bump.
+alternatives:
+  - "Name-based liveness heuristic in Miller only — rejected: precision
+    permanently capped"
+  - Two-track (heuristic now + resolution later) — rejected by user in favor of
+    resolution-first
+  - "Resolution in Miller — rejected: extraction ownership boundary"
+  - "Best-guess resolve-everything — rejected: false edges in trace/impact"
+next: Triage Codex doubt-pass findings, fold survivors into the design doc,
+  commit it in julie-extractors, then user spec review; P4 design after.
+---
+
+## P3/P4 direction settled + reference-resolution design drafted
+
+User rejected deferral of P3 (dead-code) and P4 (history/trends); both are now active tracks.
+
+### Decisions (user-approved)
+- **P3 route: extractor resolution first.** Real reference resolution lands in julie-extractors before any dead-code surface ships in Miller. Name-based-only heuristic rejected.
+- **Resolution strategy: tiered + confidence.** 4 tiers (same-file 0.95 / import-guided 0.85 / receiver-typed via type_facts 0.75, 0.65 inferred / unique-global 0.55); resolve only on exactly-one kind-compatible candidate; ambiguous stays NULL with reason.
+- **P4 trigger: auto-snapshot on convergence** (writer snapshots after each converged revision, deduped, retention-trimmed), keyed by (workspace_id, artifact_id, revision, extractor_version). P4 design starts after resolution design is committed.
+- **Sequencing: resolution design first** (long pole starts earliest).
+
+### Key discoveries (live miller artifact, julie-extract 2.8.1)
+- `target_symbol_id` was NEVER populated by any code — not broken, unbuilt. But the inputs exist: `pending_relationships` 41,794 rows with rich target context (receiver, namespace, import context), `type_facts` 7,246 rows (C#-heavy: 6,719 csharp, 0 js), `relationships` 7,400 same-file-resolved calls edges from existing `ScopedSymbolIndex` local resolution.
+- 41,878 identifier rows co-locate with pending rows on (path, start_line, name) → resolver resolves pending rows and propagates; bare member_access gets unique-global tier only (identifiers.metadata_json empty everywhere).
+- Only ~21% of symbol names are workspace-unique → bare-name matching rejected with evidence.
+
+### Artifact
+Design doc drafted + self-reviewed: `julie-extractors/docs/plans/2026-07-06-workspace-reference-resolution-design.md` (not yet committed). Codex doubt pass running in background (medium architecture risk per gate).

--- a/.memories/2026-07-07/023529_0885.md
+++ b/.memories/2026-07-07/023529_0885.md
@@ -1,0 +1,41 @@
+---
+id: checkpoint_0885f116
+timestamp: 2026-07-07T02:35:29.097Z
+tags:
+  - incident
+  - workspace-root-safety
+  - mcp-roots
+  - bug-fix
+git:
+  branch: main
+  commit: 271361a
+  files:
+    - src/Miller.Server/Hosting/IndexBootstrapService.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+summary: "Fixed: sensitive-root guard bypass via MCP roots binding (home-dir
+  scan incident)"
+briefId: miller-project-direction-amp-milestone-state
+type: incident
+context: User reported Miller tool errors in julie-extractors workspace;
+  investigation found runaway home-dir scans from another session's subagents
+evidence:
+  - "ps: julie-extract scan --root /Users/murphy pids 6826/6995, parents miller
+    serve 5940/5755 with cwd=/Users/murphy"
+  - IndexBootstrapService.cs:131-133 guarded Cwd source only
+  - red test proved interceptor ran instead of guard rejecting; green after fix
+  - "scripts/test.sh: 2849 passed"
+---
+
+## Fixed: sensitive-root guard bypass via MCP roots binding (home-dir scan incident)
+
+### Incident
+Two Claude Code subagents (another session, cwd=/Users/murphy) launched `miller serve`; both spawned `julie-extract scan --root /Users/murphy` — full home-directory scans. This is exactly what WorkspaceRootSafety exists to refuse. Processes died on their own; nothing was written to ~/.miller (no symbols.db created, home never registered). User-visible symptom: Miller tool errors in their julie-extractors session while the scans hogged I/O.
+
+### Root cause
+`IndexBootstrapService.BootstrapForRoot` applied `CanonicalizeAndRejectSensitiveRoot` **only for WorkspaceSource.Cwd**. The binding precedence is env > MCP roots > cwd; a session launched in $HOME correctly defers (cwd refused), but the MCP client then offers `file://$HOME` as its root and the Roots source bound it unguarded. Env source had the same hole. Design assumption recorded in WorkspaceBindingResolver doc ("unsafe cwd refused only when cwd is the last resort") trusted clients never to offer sensitive roots — Claude Code sessions launched from ~ do exactly that.
+
+### Fix
+One chokepoint change in `BootstrapForRoot`: every source now passes `CanonicalizeAndRejectSensitiveRoot` (fromCwd only tailors the message). Two regression tests in WorkspaceBindingServiceTests prove Roots/Env sources throw before any bootstrap work. Fast suite 2,849 green.
+
+### Caveat
+Running servers (including the user-scope ~/.local/bin/miller install) carry the old code until restarted/reinstalled.

--- a/.memories/2026-07-07/032600_bb1d.md
+++ b/.memories/2026-07-07/032600_bb1d.md
@@ -1,0 +1,45 @@
+---
+id: checkpoint_bb1deb8f
+timestamp: 2026-07-07T03:26:00.641Z
+tags:
+  - miller
+  - background-bootstrap
+  - bootstrap
+  - state-machine
+  - tdd
+  - task-1
+git:
+  branch: codex/background-bootstrap
+  commit: 6f81001
+  files:
+    - docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+    - src/Miller.Server/Hosting/IndexBootstrapService.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+summary: Implemented Task 1 bootstrap state machine slice
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+impact: Unblocks the remaining plan tasks by making bootstrap state observable
+  and non-blocking without spawning julie-extract in tests.
+evidence:
+  - 'dotnet test tests/Miller.Tests/Miller.Tests.csproj --filter
+    "FullyQualifiedName~WorkspaceBindingServiceTests" passed: 10 tests, 0
+    failed'
+  - "scripts/test.sh passed: 2853 tests, 0 failed, wall time 20s"
+symbols:
+  - IndexBootstrapService.BootstrapForRoot
+  - IndexBootstrapService.Snapshot
+  - IndexBootstrapService.WaitForRunAsync
+  - WorkspaceBindingServiceTests
+next: Commit Task 1, then add the stranded-root regression for Task 2 and wire
+  `_rootsDirty` clearing to accepting `BindOutcome` values only.
+confidence: 4
+---
+
+## Implemented Task 1 bootstrap state machine slice
+
+Task 1 of `docs/plans/2026-07-06-background-bootstrap-implementation-plan.md` now has the core background bootstrap behavior in place.
+
+- **What:** Added `BootstrapPhase`, `BootstrapSnapshot`, `BindOutcome`, background dispatch from `BootstrapForRoot`, run-generation wait support, failure snapshots, retry-from-failed behavior, and atomic bound-state publication through a single bound record.
+- **Why:** Initial Miller bootstrap was synchronous on the MCP tool-call/startup path and had no fast observable running/failed state.
+- **How:** Drove the change with `WorkspaceBindingServiceTests` using `TestRunBootstrapOverride` for slow/failing background runs, preserving synchronous sensitive-root guard and `TestBootstrapInterceptor` behavior.
+- **Impact:** Task 1 is green and sets up Task 2's `BindOutcome` dirty-cache contract and Task 3's filter grace/not-ready behavior.

--- a/.memories/2026-07-07/032859_a9d2.md
+++ b/.memories/2026-07-07/032859_a9d2.md
@@ -1,0 +1,44 @@
+---
+id: checkpoint_a9d2a677
+timestamp: 2026-07-07T03:28:59.158Z
+tags:
+  - miller
+  - background-bootstrap
+  - workspace-binding
+  - rebind-deferred
+  - tdd
+  - task-2
+git:
+  branch: codex/background-bootstrap
+  commit: 46f2762
+  files:
+    - docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+    - src/Miller.Server/Hosting/WorkspaceBindingService.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+summary: Implemented Task 2 rebind-deferred dirty contract
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+impact: Closes the stranded-root failure mode required by design rev 2 review
+  blocker 2.
+evidence:
+  - 'dotnet test tests/Miller.Tests/Miller.Tests.csproj --filter
+    "FullyQualifiedName~WorkspaceBindingServiceTests" passed: 11 tests, 0
+    failed'
+  - "scripts/test.sh passed: 2854 tests, 0 failed, wall time 22s"
+symbols:
+  - WorkspaceBindingService.EnsurePrimaryBoundCoreAsync
+  - BindOutcome.RebindDeferred
+  - WorkspaceBindingServiceTests.RebindDeferred_KeepsRootsDirtyUntilInFlightRunCompletes
+next: Commit Task 2, then implement Task 3 filter grace waits, not-ready/failed
+  result text, unbound workspace snapshot rendering, and filter-order pin.
+confidence: 4
+---
+
+## Implemented Task 2 rebind-deferred dirty contract
+
+Task 2 of the background bootstrap plan now preserves root dirtiness when a rebind is deferred behind an in-flight bootstrap run.
+
+- **What:** Added the stranded-root regression and changed `WorkspaceBindingService` to clear `_rootsDirty` only when `BootstrapForRoot` returns an accepting outcome.
+- **Why:** If roots changed from A to B while A was still indexing, clearing `_rootsDirty` on `RebindDeferred` caused the next call after A completed to keep serving A forever.
+- **How:** The regression drives A as a slow background run, marks roots dirty for B, verifies B is deferred, releases A, then proves the next ensure starts and binds B.
+- **Impact:** Deferred rebinds now self-heal on the next tool call after the in-flight run completes, without scan preemption or a queue.

--- a/.memories/2026-07-07/033601_ba4c.md
+++ b/.memories/2026-07-07/033601_ba4c.md
@@ -1,0 +1,47 @@
+---
+id: checkpoint_ba4c572f
+timestamp: 2026-07-07T03:36:01.964Z
+tags:
+  - miller
+  - background-bootstrap
+  - calltool-filter
+  - not-ready
+  - telemetry-order
+  - tdd
+  - task-3
+git:
+  branch: codex/background-bootstrap
+  commit: "4620572"
+  files:
+    - docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+    - src/Miller.Server/Hosting/WorkspaceBindingService.cs
+    - src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
+summary: Implemented Task 3 binding filter behavior
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+impact: Completes the main agent-facing contract for fast not-ready and failed
+  bootstrap responses.
+evidence:
+  - 'dotnet test tests/Miller.Tests/Miller.Tests.csproj --filter
+    "FullyQualifiedName~WorkspaceBindingCallToolFilterTests" passed: 10 tests, 0
+    failed'
+  - "scripts/test.sh passed: 2863 tests, 0 failed, wall time 21s"
+symbols:
+  - WorkspaceBindingCallToolFilter.Create
+  - IWorkspaceBindingService.Snapshot
+  - IWorkspaceBindingService.WaitForRunAsync
+  - WorkspaceBindingCallToolFilterTests
+next: Commit Task 3, then implement Task 4 bound-side `workspace status` rebind
+  notice plus CLAUDE.md/AGENTS.md guidance sync and branch gate.
+confidence: 4
+---
+
+## Implemented Task 3 binding filter behavior
+
+Task 3 of the background bootstrap plan now has the user-facing unbound bootstrap responses.
+
+- **What:** Extended `IWorkspaceBindingService` with `Snapshot` and `WaitForRunAsync`, added grace waits in `WorkspaceBindingCallToolFilter`, exact not-ready and failed retry `CallToolResult` text, and filter-rendered unbound `workspace` snapshot output.
+- **Why:** Tool calls during first indexing or failed retry must return fast actionable tool results instead of blocking on bootstrap or constructing bound-only tools.
+- **How:** Added direct filter tests with scripted snapshots for bound passthrough, running-within-grace, timeout, zero grace, cancellation, failed retry, unbound `workspace`, bound `workspace`, plus a transport integration pin proving binding composes outside telemetry.
+- **Impact:** Agents now get deterministic not-ready/failure text, `workspace` works while unbound, and telemetry cannot resolve bound-only services before binding handles unbound responses.

--- a/.memories/2026-07-07/034211_c566.md
+++ b/.memories/2026-07-07/034211_c566.md
@@ -1,0 +1,51 @@
+---
+id: checkpoint_c566dd10
+timestamp: 2026-07-07T03:42:11.191Z
+tags:
+  - miller
+  - background-bootstrap
+  - workspace-status
+  - docs
+  - branch-gate
+  - task-4
+git:
+  branch: codex/background-bootstrap
+  commit: 18446eb
+  files:
+    - AGENTS.md
+    - CLAUDE.md
+    - docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+    - src/Miller.Server/Tools/WorkspaceRender.cs
+    - src/Miller.Server/Tools/WorkspaceTool.cs
+    - tests/Miller.Tests/Server/LiveWorkspaceTests.cs
+    - tests/Miller.Tests/Server/WorkspaceToolTests.cs
+summary: Implemented Task 4 status notice and docs sync
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+impact: Completes the plan implementation pending final commit/state report.
+evidence:
+  - 'dotnet test tests/Miller.Tests/Miller.Tests.csproj --filter
+    "FullyQualifiedName~WorkspaceToolTests.Status" passed: 8 tests, 0 failed'
+  - "scripts/test.sh passed: 2864 tests, 0 failed, wall time 21s"
+  - "scripts/test.sh all passed: fast 2864 passed; scale 8 passed and 38 skipped
+    because .tools/julie-extract is absent"
+  - dotnet build Miller.slnx -c Release passed with 0 warnings, 0 errors
+  - scripts/sync-agents.sh && cmp -s CLAUDE.md AGENTS.md passed
+symbols:
+  - WorkspaceTool.RenderStatus
+  - WorkspaceRender.Status
+  - WorkspaceToolTests.Status_WhenRebindRunning_RendersCompactNotice
+  - IndexBootstrapService.Snapshot
+next: Commit Task 4, then run final worktree-state check and report local
+  commits plus verification evidence.
+confidence: 4
+---
+
+## Implemented Task 4 status notice and docs sync
+
+Task 4 of the background bootstrap plan now exposes the bound-side rebind status and updates agent guidance.
+
+- **What:** Injected `IndexBootstrapService` into `WorkspaceTool`, passed `Snapshot` into `WorkspaceRender.Status`, rendered compact `rebinding: <root> (started <N>s ago)` only while a new run is `Running` on an already-bound tool, and updated `CLAUDE.md` then regenerated `AGENTS.md`.
+- **Why:** Operators need `workspace status` to show that a rebind is in flight while the old workspace is still serving, and agent docs had stale “getters throw until StartAsync” wording.
+- **How:** Added a `WorkspaceToolTests` regression that starts a blocked background rebind from a seeded bound workspace, plus an absence assertion in the normal status test. `scripts/sync-agents.sh` regenerated `AGENTS.md`; `cmp -s CLAUDE.md AGENTS.md` passed.
+- **Impact:** The implementation plan’s final surface and docs requirements are complete. Branch gate evidence is available for final review.

--- a/.memories/2026-07-07/111403_d6d8.md
+++ b/.memories/2026-07-07/111403_d6d8.md
@@ -1,0 +1,51 @@
+---
+id: checkpoint_d6d8a901
+timestamp: 2026-07-07T11:14:03.368Z
+tags:
+  - checkpoint
+  - session-wrap
+  - background-bootstrap
+  - not-ready
+  - mcp-roots
+  - sensitive-root
+  - workspace-binding
+  - reference-resolution
+  - dead-code
+  - plans-pending-approval
+git:
+  branch: main
+  commit: 6f81001
+summary: "Session wrap state: two designs + two plans authored, guard fix
+  shipped, all queued on approvals"
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+symbols:
+  - IndexBootstrapService.BootstrapForRoot
+  - WorkspaceBindingResolver.TryResolve
+  - WorkspaceBindingService.EnsurePrimaryBoundCoreAsync
+  - WorkspaceBindingCallToolFilter
+  - WorkspaceRootSafety.CanonicalizeAndRejectSensitiveRoot
+next: Await user approval on the two implementation plans (background-bootstrap
+  in miller, reference-resolution in julie-extractors), then execute via
+  subagent-driven-development; pushes also pending approval.
+---
+
+## Session wrap state: two designs + two plans authored, guard fix shipped, all queued on approvals
+
+### Delivered this session (miller, main @ 6f81001, 8 unpushed)
+- **`d225dc5` fix (shipped, tested):** sensitive-root guard now applies to every workspace binding source (Env/Roots, not just Cwd). Root-caused from live incident: subagents with cwd=$HOME → deferred bootstrap → Claude Code offered `file://$HOME` as MCP root → Roots source bound it unguarded → full home-dir julie-extract scans. 2 regression tests red-first; 2,849 fast green; Release rebuilt. Nothing durable was written by the incident (~/.miller clean, home never registered).
+- **Background-bootstrap design rev 2** (`docs/plans/2026-07-06-background-bootstrap-design.md`): scan off the tool-call path (julie parity — verified julie used spawn_blocking + fast not-ready messages), state machine Idle/Running/Bound/Failed, atomic BoundWorkspace publication, BindOutcome + rootsDirty contract (stranded-root fix), run-generation-keyed grace gate (MILLER_BOOTSTRAP_GRACE_SECONDS, default 5), filter-rendered workspace snapshot (WorkspaceTool DI can't construct unbound), failed-retry contract, binding-outside-telemetry pinned. Codex review: 4 blockers found+verified+folded.
+- **Background-bootstrap implementation plan** (`docs/plans/2026-07-06-background-bootstrap-implementation-plan.md`, 4 serial tasks, exact response texts pinned in Global Constraints, scale suite required at branch gate) — **AWAITING USER APPROVAL**.
+
+### julie-extractors (main @ 2d76908, 3 unpushed)
+- Reference-resolution design rev 4 (3-round doubt pass) + implementation plan (8 tasks, Codex plan review folded) — **AWAITING USER APPROVAL**.
+
+### Open user decisions
+1. Approve background-bootstrap plan (miller) — likely first, bites live sessions.
+2. Approve reference-resolution plan (julie-extractors).
+3. Push approvals: miller 8 ahead, julie-extractors 3 ahead.
+
+### Non-obvious facts worth keeping
+- The 30-min silent hang mechanism: first tool call runs the whole initial scan inside `_bindLock`; all other calls wait on the lock/binding gate with cancellation as the only exit.
+- `~/.local/bin/miller` is a symlink to the repo Release build (one binary, three routes: user-scope MCP full path, PATH symlink, Cursor MILLER_BINARY override).
+- Long-running pre-fix servers: pids 9648/71197 rooted in ~/.hermes dirs — safe roots, pick up fix on natural restart.

--- a/.memories/2026-07-07/113432_ffce.md
+++ b/.memories/2026-07-07/113432_ffce.md
@@ -1,0 +1,61 @@
+---
+id: checkpoint_ffce71f6
+timestamp: 2026-07-07T11:34:32.482Z
+tags:
+  - code-review
+  - background-bootstrap
+  - rebind-failure
+  - bug-fix
+  - tdd
+  - worktree
+git:
+  branch: codex/background-bootstrap
+  commit: 4a1a407
+  files:
+    - src/Miller.Server/Hosting/IndexBootstrapService.cs
+    - src/Miller.Server/Hosting/WorkspaceBindingService.cs
+    - src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
+    - tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+summary: Background-bootstrap review fixes (codex/background-bootstrap worktree)
+briefId: miller-project-direction-amp-milestone-state
+type: incident
+context: Codex implemented the approved background-bootstrap plan on
+  codex/background-bootstrap; lead review found a reachable permanent-brick
+  state on failed rebinds
+evidence:
+  - 4 regression tests RED on pre-fix code, GREEN after
+  - "scripts/test.sh: 2,868 passed"
+  - "scripts/test.sh scale: 46/46, 0 skipped"
+  - "dotnet build Miller.slnx -c Release: 0 warnings"
+symbols:
+  - WorkspaceBindingService.EnsurePrimaryBoundAsync
+  - WorkspaceBindingService.IsSettled
+  - BootstrapSnapshot
+  - WorkspaceBindingCallToolFilter.Create
+  - IndexBootstrapService.RunBootstrapInBackground
+next: Commit fixes on codex/background-bootstrap; merge to main + push remain
+  approval-gated
+---
+
+## Background-bootstrap review fixes (codex/background-bootstrap worktree)
+
+Reviewed Codex's 4-commit implementation of the background-bootstrap plan (6f81001..4a1a407) via the razorback code-reviewer agent, verified findings against code, and fixed the confirmed ones.
+
+### Review findings (verified, not taken on faith)
+- **Critical (fixed):** a failed background REBIND permanently bricked all MCP tool calls. `MarkBootstrapFailed` sets `Phase=Failed` but the old workspace stays bound (`IsBound` true), and all three `WorkspaceBindingService` early-returns keyed on `IsBound && !dirty` — so `BootstrapForRoot` was never re-entered, no retry ever started, and the filter returned a false "retry started" error forever with `workspace` also intercepted (no in-band recovery). Design explicitly required Failed → BootstrapForRoot (retry) → Running via the ensure path.
+- **Important (fixed):** the filter intercepted the `workspace` tool whenever `Phase != Bound`, including Running/Failed while still bound — making Task 4's `rebinding:` status notice unreachable over MCP and hiding full status during long rebinds.
+- **Minor (fixed):** ledger leak when `PublishBoundWorkspace` refuses a stale run without throwing.
+
+### The fixes
+- `WorkspaceBindingService.IsSettled()` = `Snapshot.Phase == Bound && !rootsDirty` replaces the `IsBound`-based early-returns (with a why-comment).
+- `BootstrapSnapshot` gained `IsBound` (read under `_gate`); filter exempts `workspace` on `IsBound`, renders the snapshot itself only when nothing is bound; non-workspace tools keep the design-mandated grace-wait/not-ready during bound rebinds (no silent serving from the old root).
+- One-line dispose guard for the refused-publish ledger path.
+
+### TDD evidence
+4 new regression tests written first and confirmed RED on pre-fix code: `RebindFailureWhileBound_NextEnsureStartsRetry` (binding service), `RebindRunningWhileBound_WorkspaceToolCallsNextHandler`, `RebindFailedWhileBound_WorkspaceToolCallsNextHandler`, `RebindRunningWhileBound_NonWorkspaceToolStillReturnsNotReady` (filter). Full gate after fix: Release build 0 warnings, fast 2,868/2,868, scale 46/46 with 0 skips (first scale run had 38 silent skips — worktree was missing `.tools/julie-extract`; copied pinned 2.8.1 in).
+
+### Deliberately NOT fixed (flagged)
+- "indexing this workspace for the first time" text also shows for bound-rebind not-ready results — text is plan-pinned verbatim; changing agent-facing text needs a plan/user call.
+- `rebinding:` notice is compact-only, absent from `workspace status --json` — design scoped it compact-only; add to Eros contract only when a concrete workflow needs it.
+- Registry SQLite writes inside `_gate` at the one-shot publish point — noted, not a live risk.

--- a/.memories/2026-07-07/132556_2491.md
+++ b/.memories/2026-07-07/132556_2491.md
@@ -1,0 +1,55 @@
+---
+id: checkpoint_2491cd2a
+timestamp: 2026-07-07T13:25:56.259Z
+tags:
+  - pin-bump
+  - julie-extract-2.9.0
+  - schema-v4
+  - reference-resolution
+  - dead-code-enablement
+git:
+  branch: main
+  commit: 5bb8b20
+  files:
+    - scripts/julie-pins.json
+    - src/Miller.Indexing/MillerExtractContract.cs
+    - tests/Miller.Tests/Indexing/MillerExtractContractTests.cs
+    - tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+summary: julie-extract 2.9.0 pin bump — schema v4 (workspace reference resolution)
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+evidence:
+  - "scripts/test.sh: 2,868 passed"
+  - "scripts/test.sh scale: 46/46 with real 2.9.0 binary"
+  - "dotnet build Miller.slnx -c Release: 0 warnings"
+  - "live 2.9.0 scan of Miller repo: 14,183/92,952 identifiers resolved"
+  - sha256 of all 4 release assets computed from live GitHub downloads
+next: Draft P3 dead-code candidates design for user review using the v4
+  resolution evidence; update user-scope Miller install when shipping
+---
+
+## julie-extract 2.9.0 pin bump — schema v4 (workspace reference resolution)
+
+Bumped Miller's pinned extractor from 2.8.1 to 2.9.0 immediately after the user published the julie-extractors v2.9.0 release ("workspace reference resolution / dead-code enablement").
+
+### What changed
+- `scripts/julie-pins.json`: version 2.9.0 + sha256 for all four platform archives, computed from the live GitHub release assets (downloaded and hashed locally; release is non-prerelease with all 4 assets).
+- `MillerExtractContract`: `ExpectedSchemaVersion`/`ExpectedSqliteSchemaVersion` 3 → 4; `ExpectedExtractContractVersion` and `ExpectedReportSchemaVersion` stay 3; pin string → 2.9.0. Verified empirically against a live 2.9.0 scan: artifact stamps `schema_version=4`, `sqlite_schema_version=4`, `extract_contract_version=3`, `report_schema_version=3`, and NEW `reference_resolution_version=1`.
+- Contract tests updated (`ContractPinsJulieExtractSchemaV4Versions`, capabilities assertion 3→4/2.9.0).
+
+### v4 artifact facts (Miller repo scratch scan, ground truth for the P3 dead-code design)
+- New tables: `pending_resolutions`, `identifier_resolutions` (CHECK `outcome='resolved' ⇔ target_symbol_id NOT NULL`, CASCADE FKs).
+- Miller repo: 92,952 identifiers → 14,183 resolved (15.3%, up from 0 on 2.8.1); outcomes: no_context 25,759 / resolved 14,183 / missing 13,889 / ambiguous 214 (honest unresolved-with-reason as designed).
+- Tiers seen live: tier1_local conf 0.95 (7,469), tier4_global conf 0.55 (6,555), tier3_receiver conf 0.65 (159).
+- Per-language resolved %: C# 15.6, Python 14.1, JS 10.1, bash 5.5, razor 2.1, css/html 0 (expected). julie-extractors' own Rust dogfood: 62,379 identifier + 4,632 pending resolutions.
+
+### Verification
+- Full gate green: Release build 0 warnings, fast 2,868/2,868, scale 46/46 with the real 2.9.0 binary.
+- **Scale suite wall time 24s → ~4m20s** — the resolution pass is a real indexing-time cost; watch bootstrap-scan latency on big repos (background bootstrap just shipped, which softens this).
+- Scan report keys unchanged (`report_schema_version` 3); no `reference_resolution` block in the report — DB tables are the consumption surface.
+
+### Operational note (not done)
+- Live workspace artifacts are still v3; the user-scope installed Miller binary expects schema 3. When a 2.9.0-pinned Miller rebuilds an artifact to v4, OLD Miller builds will refuse it (isNewer mismatch). Update the user-level install together with shipping this. No push/release done.
+
+### Next
+P3 dead-code candidates design (docs/plans needed, user spec review) — now unblocked with real resolution data; use per-language resolution rates + confidence tiers as evidence gates.

--- a/.memories/2026-07-07/145907_5de7.md
+++ b/.memories/2026-07-07/145907_5de7.md
@@ -1,0 +1,38 @@
+---
+id: checkpoint_5de77b5b
+timestamp: 2026-07-07T14:59:07.988Z
+tags:
+  - dead-code-candidates
+  - subagent-driven-development
+  - miller
+  - references-candidates
+  - schema-v4
+  - task-1-done
+git:
+  branch: feat/dead-code-candidates
+  commit: c52d3f3
+  files:
+    - .razorback/sdd/task-1-report.md
+summary: Dead-code candidates plan — Task 1 done, Task 2 running
+briefId: miller-project-direction-amp-milestone-state
+type: incident
+context: "Two mid-run incidents worth persisting: (1) subagents in this harness
+  launch with cwd=/Users/murphy (home), not the repo — the first Task 1 agent
+  started there; fixed with a mandatory cd+verify+absolute-paths guard at the
+  top of every brief/dispatch (no harm: home is not a git repo, no stray files).
+  (2) An early clean-stale-scratch rm deleted 8 task-*-report.md files that were
+  actually TRACKED in git despite the * gitignore; restored all 8 via git
+  checkout, tree clean."
+next: Review Task 2 (impl-t2) inline when it reports; confirm fixture builder
+  names; then dispatch Task 3.
+---
+
+## Dead-code candidates plan — Task 1 done, Task 2 running
+
+Executing docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md (ships `miller references candidates [--json]`) via razorback subagent-driven-development: 5 serial tasks, feature branch feat/dead-code-candidates off local main HEAD d926b48.
+
+- **NOT a worktree**: EnterWorktree default base is origin/main (18 commits behind, missing the load-bearing julie-extract 2.9.0/schema-v4 pin the feature needs); the gitignored .tools/julie-extract, build guard, scale suite, and Task 5 dogfood all key off repo-root .tools. Feature-branch escape hatch used.
+- **Task 1 (Core evaluator) COMPLETE**: commit c52d3f3. Pure zero-I/O Miller.Core/DeadCode: candidate kinds, syntax-invoked exclusions, alive-by-evidence drop, nine ordered suppression rules (first-match-wins), name/name+resolver labels, two-phase literal scan. 51 filtered tests + fast suite 2919 green, build 0/0. Lead review clean.
+- **Worker finding folded into Task 2 brief**: low_evidence_language fires only when a language is PRESENT in coverage with IdentifierCount==0, so the reader MUST emit zero-identifier languages (css/html) as coverage rows or they surface as false candidates.
+- **Task 2 (Indexing reader + v4 fixture) RUNNING**: impl-t2 building DeadCodeCandidateReader + pinned v4 fixture DDL.
+- Briefs 1-3 written under .razorback/sdd/; Task 4/5 briefs deferred until Task 3 ships verbatim JSON/resolver/capabilities strings.

--- a/.memories/2026-07-07/154158_8533.md
+++ b/.memories/2026-07-07/154158_8533.md
@@ -1,0 +1,37 @@
+---
+id: checkpoint_853344f4
+timestamp: 2026-07-07T15:41:58.254Z
+tags:
+  - dead-code-candidates
+  - miller
+  - references-candidates
+  - implementation-complete
+  - evidence-gate
+  - subagent-driven-development
+git:
+  branch: feat/dead-code-candidates
+  commit: 1fe27ca
+  files:
+    - .razorback/sdd/task-1-report.md
+    - .razorback/sdd/task-2-report.md
+    - .razorback/sdd/task-3-report.md
+summary: Dead-code candidates — all 3 coding tasks landed, evidence gate running
+briefId: miller-project-direction-amp-milestone-state
+type: checkpoint
+next: "Review Task 5 gate result: if PASS dispatch Task 4 (docs); if FAIL do
+  corrective dispatch against owning files then re-run gate. Then final branch
+  gate + finishing-a-development-branch."
+---
+
+## Dead-code candidates — all 3 coding tasks landed, evidence gate running
+
+`miller references candidates [--json]` implementation is COMPLETE on branch feat/dead-code-candidates. Tasks 1-3 done & lead-reviewed clean:
+- **Task 1** c52d3f3 — Core evaluator (Miller.Core/DeadCode), pure zero-I/O, 51 tests.
+- **Task 2** 70bd093 — Indexing reader + v4 fixture (pinned DDL verbatim, biconditional CHECK + 6 indexes asserted), reader 18 + schema-guard 19 tests.
+- **Task 3** 1fe27ca — CLI surface + capabilities + real-binary scale test. Compact resolver header verbatim (with period, per Global Constraints); JSON envelope every field via Utf8JsonWriter manual snake_case; --limit bounds only candidates[]; 8 fast tests field-complete + resolved_pct==10.0 + both exit-3 paths; scale test proves DeadPrivateHelper candidate + InvokeSecretly suppressed string_literal_match on the live 2.9.0 extract.
+
+Verification: fast suite 2951 / 0 skip; scale 47 / 0 skip; Release build 0 warn/0 err; binary runnable (1.4.5+1fe27ca).
+
+**Remaining:** Task 5 (dogfood GATE, running now — owns only docs/findings/2026-07-07-dead-code-candidates-dogfood.md, never edits code; hard gate = zero confirmed-live candidates on the Miller repo) THEN Task 4 (docs/contract + boundary amendments). Deliberately gate-before-docs so docs are written against validated behavior.
+
+WATCH-ITEM: reader runs 4 indexed subqueries per candidate-kind symbol — Task 5 measures real ~38k-symbol wall-clock; batch as fast-follow if slow (no Core contract change).

--- a/.memories/autonomous-run-2026-07-07-dead-code-candidates.md
+++ b/.memories/autonomous-run-2026-07-07-dead-code-candidates.md
@@ -1,0 +1,68 @@
+# Autonomous Run Report — dead-code candidates (feat/dead-code-candidates)
+
+**Status:** Complete
+**Plan:** docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md
+**Branch:** feat/dead-code-candidates (10 commits over main @ d926b484)
+**Scope:** Miller half of the cross-repo dead-code effort (julie-extractors v2.10.0 shipped separately the same day).
+
+## What shipped
+
+- `miller references candidates [--json]` CLI surface (Tasks 1–3): pure evaluator
+  (`DeadCodeCandidates`, Miller.Core), artifact reader (`DeadCodeCandidateReader`,
+  Miller.Indexing), CLI rendering + capabilities row.
+- ELEVEN suppression rules (nine designed + two corrective): `override_member`
+  (signature-derived, Core-owned policy) and `live_member_container` (type with
+  evidenced members), plus a test-path fallback inside `test_symbol`.
+- Contract docs (Task 4): `docs/contracts/references-candidates-v1.md` (shapes
+  copied verbatim from shipped code), Eros-ownership truth-ups in
+  `references-export-v1.md` + `cli-eros-v1.md`, CLAUDE.md/AGENTS.md boundary update.
+- Dogfood evidence (Task 5 + FINAL VERDICT): gate re-run history 392 → 15 → 10 → 9 → 5.
+- julie-extract pin 2.9.0 → 2.10.0 with real published-asset sha256s; download
+  restore path verified (sha256 OK, binary 2.10.0).
+
+## Evidence gate
+
+**PASSED.** Full-repo scan, julie-extract 2.10.0: **5 candidates, zero
+confirmed-live** (4 hand-verified dead SearchTool/WorkspaceTool members + IFS,
+a true find under the write-only rule). First run was 392 candidates at ≈1%
+precision. Details: docs/findings/2026-07-07-dead-code-candidates-dogfood.md.
+
+## External review
+
+Codex adversarial review of the julie-extractors lane: 2 findings (java FQ
+static receivers, python match-pattern bindings) — both lead-confirmed via live
+probes, both fixed and folded into v2.10.0 pre-publish. Grammar-level follow-ups
+shipped: tree-sitter-razor fork fix (upstream PR tris203/tree-sitter-razor#27) +
+C# A*B pointer-mis-parse recovery.
+
+## Judgment calls
+
+1. `override_member` matches whole-word `override`/`overrides` in signatures —
+   a method literally NAMED "override" would be suppressed (conservative
+   direction; documented in code).
+2. `test_symbol` path fallback matches whole segments (test/tests/__tests__)
+   only — `src/protest/` cannot fire it (pinned by test).
+3. `live_member_container` uses loaded candidate-kind rows only; a container
+   whose sole members are fields/ctors stays a candidate (conservative).
+4. IFS classified a TRUE find per the pre-agreed write-only rule, with the
+   shell-idiom nuance recorded in the findings doc.
+5. Pin sha256s computed from downloaded release archives (julie-extractors
+   publishes no .sha256 sidecars — same as v2.9.0).
+
+## Tests
+
+fast 2957/0 · scale 47/0 at HEAD b97ce75 (one earlier single-test flake +
+one dotnet bus error under machine load; both clean on rerun).
+
+## Blockers hit
+
+None outstanding. (Mid-run: a shared-MCP jam caused by the v2.9.0 quadratic
+scan — root-caused, binary swapped, resolved; documented in session ledger.)
+
+## Next steps
+
+- Merge the PR after review.
+- Repoint tree-sitter-razor at upstream if/when PR #27 merges.
+- Optional future: surface candidates in report/dashboard/MCP (requires
+  explicit user approval per MCP-stinginess rule).
+- Watch the 5-candidate list: the 4 dead symbols can now be safely deleted.

--- a/.razorback/sdd/task-1-report.md
+++ b/.razorback/sdd/task-1-report.md
@@ -1,53 +1,105 @@
-# Task 1 Report — NextStepHint shared nudge formatter
+# Task 1 Report — Core evaluator (`Miller.Core/DeadCode`)
 
-## Status
-Complete. Gate green (16/16).
+**Status:** DONE
+**Branch:** `feat/dead-code-candidates` · **Repo root:** `/Users/murphy/source/miller` (verified before and after commit)
+**Commit:** see final line / returned message.
 
-## Files (owned only)
-- `src/Miller.Server/Tools/NextStepHint.cs` (new)
-- `tests/Miller.Tests/Server/NextStepHintTests.cs` (new)
+## What was built
 
-## Contract implemented
-`internal static class NextStepHint` with `internal static string Render(string toolCall, string? reason = null)`:
-- `next: <toolCall>` when reason null/empty/blank
-- `next: <toolCall> — <reason>` with U+2014 em dash padded by single spaces when reason given
-- both args trimmed; single line, no trailing newline
-- throws `ArgumentException` on null/blank toolCall (via `ArgumentException.ThrowIfNullOrWhiteSpace` — null yields
-  `ArgumentNullException`, a subtype of `ArgumentException`; blank yields `ArgumentException`)
-- throws `ArgumentException` when toolCall or reason contains `\n`/`\r` (guards the single-line invariant)
+Pure-logic dead-code candidate evaluator (ZERO I/O) implementing the load-bearing public contract exactly as
+specified in the brief. Tasks 2–3 consume these shapes verbatim.
 
-## Miller-first orientation (calls made)
-- Loaded `mcp__miller__inspect` schema via ToolSearch (`select:mcp__miller__inspect`) to confirm the tool's shape
-  before use (Miller MCP server was mid-connect during orientation, so I read the exact worktree files instead of
-  issuing an inspect call — worktree content is what compiles).
-- Read `src/Miller.Server/Tools/WorkspaceRootSafety.cs` — confirmed: file-scoped namespace `Miller.Server.Tools`,
-  XML-doc `<summary>` style, and the `ArgumentException.ThrowIfNullOrWhiteSpace(...)` guard idiom used across the
-  Tools folder. Matched that guard idiom rather than a hand-rolled null/blank check.
-- Read `tests/Miller.Tests/Server/FreshnessStateTests.cs` — confirmed test namespace `Miller.Tests.Server`,
-  `using Xunit;`, `sealed class`, `[Fact]`/`[Theory]`/`[InlineData]` + `Assert` conventions for a pure-logic seam.
+Owned files (only these were created/committed):
+- `src/Miller.Core/DeadCode/DeadCodeRows.cs` — `DeadCodeSymbolRow` (18 fields, order per contract, incl.
+  `StartByte`/`EndByte` carried faithfully) and `LanguageCoverageRow`.
+- `src/Miller.Core/DeadCode/DeadCodeCandidates.cs` — `DeadCodeCandidate`, `DeadCodeResult`, and the static
+  `DeadCodeCandidates` evaluator: `CandidateKinds`, `SuppressionRuleIds`, `IsSyntaxInvokedName`,
+  `ResolvedPercent`, `Evaluate`, `ApplyLiteralScan`.
+- `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs` — 51 test cases (new `Core/` test dir + `Miller.Tests.Core`
+  namespace).
 
-## API-shape evidence
-- Neighbouring Tools files use `namespace Miller.Server.Tools;` (file-scoped) and
-  `ArgumentException.ThrowIfNullOrWhiteSpace` — NextStepHint mirrors both.
-- `internal` visibility chosen per the task contract (Tasks 2–4 consume it in-assembly). Confirmed reachable from
-  `Miller.Tests` — the test compiled and ran, so `InternalsVisibleTo(Miller.Tests)` is already configured.
+## Miller-first orientation (Miller search/inspect down — read exemplars directly with Read tool)
 
-## Gate invariant
-Proves the shared hint FORMAT contract Tasks 2–4 and the format-drift test depend on: exact shape (bare + em-dash
-reason forms), trimming, single-line / no-trailing-newline invariant, and the null/blank + newline argument guards.
+Miller `search`/`inspect` fail closed on a stale sidecar (older-extractor permanent reader), so I read the named
+exemplar files directly:
+- `src/Miller.Core/Contracts/StructuralFactRecord.cs` — confirmed row-record style: file-scoped namespace,
+  `public sealed record` with positional params, `IReadOnlyDictionary` for maps. Matched for `DeadCodeSymbolRow`.
+- `src/Miller.Core/Contracts/SymbolDetail.cs` — confirmed positional-record + XML-doc-per-param convention and
+  nullable reference fields (`string?`). Matched for the row records.
+- `src/Miller.Core/Graph/BridgeGraphBuilder.cs` — confirmed evaluator-returns-result style: `public static`
+  entry point, `ArgumentNullException.ThrowIfNull` guards, `IReadOnlyList`/`IReadOnlyDictionary` results,
+  `StringComparer.Ordinal` dictionaries, file-scoped namespace, nullable enabled. Matched for `Evaluate`/result types.
+- `tests/Miller.Tests/Graph/BridgeGraphBuilderTests.cs` — confirmed test style: `using Xunit;`,
+  `public sealed class`, static factory helpers with defaulted params, `namespace Miller.Tests.<Area>`. Matched for
+  the test file (`Row(...)`/`Coverage(...)` factories, `Miller.Tests.Core` namespace).
+- `CLAUDE.md` "Project seam" + `src/Miller.Core/Miller.Core.csproj` — confirmed Core is ZERO-I/O (no SQLite, no
+  System.IO). The new files use only `System`/`System.Collections.Generic` primitives — no I/O deps added.
 
-## TDD sequence
-1. Wrote failing tests first; initial run: 15 passed, 1 failed (`Render_NullOrBlankToolCall_Throws(null)` — guard
-   throws `ArgumentNullException`, an `ArgumentException` subtype, so exact-match `Assert.Throws<ArgumentException>`
-   rejected it).
-2. Relaxed that single assertion to `Assert.ThrowsAny<ArgumentException>` (contract promises `ArgumentException`;
-   the standard subtype satisfies it) — kept the implementation on the idiomatic `ThrowIfNullOrWhiteSpace` guard.
-3. Green.
+No other symbol/signature was relied upon; all shapes come from the brief's contract, not invented.
 
-## Test output summary
-`dotnet test tests/Miller.Tests --filter "FullyQualifiedName~NextStepHintTests"` →
-**Passed! Failed: 0, Passed: 16, Skipped: 0, Total: 16.**
+## Public-contract fidelity (Tasks 2–3 depend on these)
 
-## Concerns
-None. Render-layer-only pure string seam; no I/O, no new dependencies. Downstream tasks call
-`NextStepHint.Render(...)` from within `Miller.Server`.
+- `DeadCodeSymbolRow` / `LanguageCoverageRow` field names + order: exact.
+- `DeadCodeCandidate` (12 fields) / `DeadCodeResult` (4 fields): exact.
+- `CandidateKinds` = {function, method, class, struct, interface, enum, delegate, property, constant} (Ordinal set).
+- `SuppressionRuleIds` (table order, single-sourced from private const ids): public_api, visibility_unknown,
+  test_symbol, entry_point, framework_bound, annotated, generated_path, low_evidence_language,
+  string_literal_match.
+- `IsSyntaxInvokedName(name, kind)` / `ResolvedPercent(int, int)` / `Evaluate(...)` / `ApplyLiteralScan(...)`
+  signatures: exact.
+
+## Decision-logic notes / decisions taken
+
+- **Exclusion** (`kind ∉ CandidateKinds` OR `IsSyntaxInvokedName`) drops before `examined++`; alive-by-evidence
+  drops silently after `examined++`.
+- **First-match-wins**: `FirstSuppressionRule` returns the first matching rule id in table order; each suppressed
+  symbol bumps exactly one count.
+- **`low_evidence_language`** fires ONLY when the language is PRESENT in coverage with `IdentifierCount == 0`. A
+  language ABSENT from coverage does NOT fire it — this is required for consistency with the documented
+  evidence-label rule ("language absent from coverage → treat as 0 → `name`"), which would be unreachable if
+  absent-language symbols were auto-suppressed. Stated here because the brief left the absent case implicit; this
+  is the only interpretation that keeps both documented behaviors reachable. Present-with-0 (css/html) is the
+  designed path and is covered by a test.
+- **`public_api`** guards null/whitespace before the exported-visibility set lookup (OrdinalIgnoreCase set throws on
+  a null probe); null visibility therefore correctly falls through to `visibility_unknown` (rule 2).
+- **Two-phase**: `LiteralMatch == null` → provisional candidate in both `Candidates` and `NeedsLiteralScan`;
+  `== false` → candidate, not in scan list; `== true` → suppressed under `string_literal_match`.
+  `ApplyLiteralScan` removes matched candidates, bumps `string_literal_match`, empties `NeedsLiteralScan`, and
+  preserves all nine suppression keys.
+- **`ResolvedPercent`** single-sources the 10% label threshold and output rendering (one decimal,
+  MidpointRounding.AwayFromZero, identifiers==0 → 0.0).
+
+## Verification (each gate + the invariant it proves)
+
+- **worker-red-green** — `dotnet test tests/Miller.Tests -c Release --filter "FullyQualifiedName~DeadCodeCandidates"`.
+  - RED: initial run failed to compile (CS0234/CS0246 — the `Miller.Core.DeadCode` types did not exist).
+    Proves the tests exercise the not-yet-built contract.
+  - GREEN: `Passed! Failed: 0, Passed: 51, Total: 51` (35 ms). Proves the evaluator satisfies every asserted
+    behavior (candidate found, four alive-by-evidence paths, all nine rules counted, first-match-wins,
+    finalizer/indexer/operator/`op_`/`Finalize` exclusions, evidence-label 9.9/10.0 split + absent-coverage,
+    NULL visibility, parent-only test + structural-fact closures, two-phase null→scan + ApplyLiteralScan,
+    ResolvedPercent rounding).
+- **worker-ceiling** — `scripts/test.sh` (fast suite). `Passed! Failed: 0, Passed: 2919, Total: 2919`, wall time
+  15s (< 30s ceiling). Proves the change did not break the fast suite and stays within the time budget. The known-
+  flaky `IndexerServiceScanTests.StartAsync_WhenEnabledLeaderAndSidecarBuildFails_StillMarksRegistryScanned`
+  PASSED inside this run — no isolation re-run needed.
+- **Build** — 0 warnings / 0 errors (warnings-are-errors; the Release build the test runs through is clean).
+  Proves Core stays warning-free and zero-I/O (compiles under `Directory.Build.props` `TreatWarningsAsErrors`).
+
+## Git hygiene
+
+`git status --short` before commit showed ONLY the two owned trees untracked
+(`src/Miller.Core/DeadCode/`, `tests/Miller.Tests/Core/`). Committed exactly the three owned files. No push, no
+branch switch. This report lives under `.razorback/sdd/` and is intentionally NOT part of the code commit.
+
+## Concerns / handoff notes for Tasks 2–3
+
+- Row-field semantics the reader (Task 2) must honor: `IsTestSelfOrAncestor` and
+  `HasStructuralFactSelfOrAncestor` are ANCESTOR-CLOSED closures the reader computes via the `parent_symbol_id`
+  walk — Core trusts them. `HasAnnotation` is SELF-only. `NameMatchesOutside`/`ResolvedInbound`/
+  `PendingResolvedInbound`/`CallsInbound` must already exclude S's own definition span (the "inside" test).
+- `LanguageCoverageRow` for a zero-identifier language (css/html) MUST be emitted with `IdentifierCount == 0` for
+  `low_evidence_language` to fire — do not omit zero-identifier languages from the coverage list (see decision note
+  above).
+- `ApplyLiteralScan` is the only sanctioned way to fold literal-scan results back in; the reader should scan only
+  `NeedsLiteralScan` survivors and pass the matched `SymbolId` set.

--- a/.razorback/sdd/task-2-report.md
+++ b/.razorback/sdd/task-2-report.md
@@ -1,97 +1,136 @@
-# Task 2 — search success nudge
+# Task 2 Report — Indexing reader + v4 fixture extension
 
-**Status:** complete
-**Commit:** 44d286d `feat(search): next-step inspect nudge on symbol hits`
-**Branch/worktree:** guidance-delivery @ `/Users/murphy/source/miller/.worktrees/guidance-delivery`
+**Status:** DONE
+**Branch:** `feat/dead-code-candidates`
+**Commit mode:** serial-worker-commit (owned files only; not pushed)
 
-## What shipped
+## What was built
 
-When compact (non-JSON) symbol search returns hits, `SearchTool.Run` now appends one final line:
+`DeadCodeCandidateReader` (Miller.Indexing) — the read-side of `miller references candidates`. It opens the
+artifact read-only, runs `JulieSchemaGate.Verify`, then does the ordered pipeline from the brief:
 
+1. **Required-table validation** (after the metadata gate): `sqlite_master` check for
+   `identifier_resolutions`, `pending_resolutions`, `pending_relationships`; any missing ⇒
+   `IncompatibleExtractException` (→ CLI exit 3). One reader test per table.
+2. **Closure inputs over ALL symbols**: `parent_symbol_id` map + `is_test` set (one pass), plus the DISTINCT
+   `structural_facts.containing_symbol_id` set and DISTINCT `symbol_annotations.symbol_id` set.
+3. **Candidate rows** (`kind IN DeadCodeCandidates.CandidateKinds`): read tuples first (reader closed), then per
+   candidate compute the ancestor closures (`IsTestSelfOrAncestor`, `HasStructuralFactSelfOrAncestor`, cycle-safe
+   walk) and the four inbound counts via **per-symbol indexed subqueries** (never materializing all identifiers).
+   Inside-S test is NULL-safe (`COALESCE(... , 0) = 0`) so a NULL span / NULL containing-symbol reads as "outside".
+   - `NameMatchesOutside`, `ResolvedInbound` (identifier_resolutions JOIN identifiers, outside S),
+     `PendingResolvedInbound` (pending_resolutions JOIN pending_relationships, outside S — independent of
+     identifier_resolutions), `CallsInbound` (relationships to S from ≠ S). `LiteralMatch = null`.
+4. **Coverage universe** = UNION of `symbols.language` and `files.language`, LEFT-joined to identifier/resolved
+   counts. A language with symbols but zero identifiers (css/html) is emitted with `IdentifierCount = 0` so Core's
+   `low_evidence_language` fires. Proven by `Read_LanguageWithSymbolsButZeroIdentifiers_...`.
+5. `DeadCodeCandidates.Evaluate(rows, coverage)`.
+6. **Literal scan LAST**, only over `result.NeedsLiteralScan` survivors; skipped entirely when empty. Reads each
+   literal-bearing file at most once (path-keyed cache), mirrors `SearchIndexWriter.ReadVerifiedFileText`
+   (blake3 + content_bytes freshness guard); stale/missing ⇒ `FilesSkippedStale++` and NO suppression. Slices with
+   `SourceTextDecoder.SliceUtf8ByteSpan`, Ordinal substring match ⇒ `ApplyLiteralScan`.
+7. **Artifact block**: `artifact_id`, `MAX(revision_id)`, `reference_resolution_status` (fallback `"unknown"`),
+   `reference_resolution_version` (null when absent).
+
+### Reader API produced (Task 3 renders exactly this — stable)
+- `DeadCodeCandidateReader.Read(string symbolsDbPath, string workspaceRoot) -> DeadCodeCandidateReport`
+- `DeadCodeCandidateReport(DeadCodeResult Result, IReadOnlyList<LanguageCoverageRow> LanguageCoverage,
+  DeadCodeLiteralScan LiteralScan, DeadCodeArtifact Artifact)`
+- `DeadCodeLiteralScan(int FilesScanned, int FilesSkippedStale)`
+- `DeadCodeArtifact(string? ArtifactId, long? Revision, string ReferenceResolutionStatus,
+  string? ReferenceResolutionVersion)`
+
+`Read` returns the FINAL report (two-phase literal scan already applied). Task 3 only renders.
+
+## Fixture builder method names + signatures added (Task 3 needs these)
+
+All are **public instance methods on `JulieDbFixture`** that mutate the already-created DB over a fresh
+`ReadWrite`, `Pooling=false`, `ForeignKeys=false` connection (same precedent as `ReplaceFileBytesAndRefreshHash`;
+FKs relaxed like `Create`, but the `identifier_resolutions` CHECK is still enforced):
+
+```csharp
+public void AddIdentifierResolution(
+    string identifierId, string? targetSymbolId, string outcome = "resolved",
+    int tier = 1, double confidence = 1.0, string method = "exact", int candidates = 1,
+    long resolvedAtRevision = 1);
+
+public void AddPendingRelationship(
+    string pendingRelationshipId, string fromSymbolId, string filePath,
+    string? callerScopeSymbolId = null, int? startByte = null, int? endByte = null,
+    string kind = "call", string targetDisplayName = "Target", string targetTerminalName = "Target",
+    int startLine = 1, double confidence = 1.0);
+
+public void AddPendingResolution(
+    string pendingRelationshipId, string targetSymbolId,
+    int tier = 1, double confidence = 1.0, string method = "exact", long resolvedAtRevision = 1);
+
+public void AddStructuralFact(
+    string structuralFactId, string? containingSymbolId, string path,
+    string language = "csharp", string patternId = "custom.pattern.v1",
+    string captureName = "attribute", string nodeKind = "attribute");
+
+public void AddSymbolAnnotation(
+    string annotationId, string symbolId, string annotation = "Obsolete", string annotationKey = "obsolete");
 ```
-next: inspect target="<top-hit name>" depth=overview
+
+`JulieDbFixture.Create(...)` gained two trailing optional params (default-included for v4 fidelity; pass `null` to
+omit and exercise the reader's `unknown`/null fallbacks):
+```csharp
+string? referenceResolutionStatus = "partial",
+string? referenceResolutionVersion = "1"
 ```
 
-rendered through the shared `NextStepHint.Render` formatter (Task 1). The hint is the last line,
-exactly once per response, and names the top-ranked kept hit (`kept[0].Name`).
+### Fixture DDL changes
+- `pending_relationships` upgraded to the pinned v4 shape: added the three FKs (`from_symbol_id`,
+  `caller_scope_symbol_id`, `file_id`) and the four indexes (`idx_pending_terminal`, `idx_pending_file`,
+  `idx_pending_from`, `idx_pending_caller_scope`).
+- New tables `identifier_resolutions` (with the `CHECK ((outcome='resolved') = (target_symbol_id IS NOT NULL))`)
+  and `pending_resolutions`, plus indexes `idx_identifier_resolutions_target`, `idx_pending_resolutions_target`.
+- New v4 metadata keys `reference_resolution_status` / `reference_resolution_version`.
 
-### Suppression (verified by tests)
-- **JSON output** — returned before the nudge branch; byte-identical.
-- **File-path top hit** — `fileMode` returns via `RenderFileCompact` before the nudge branch.
-- **Empty results** — the `total == 0` failure paths return earlier and own their own hints.
-- **Text mode** — routes through `Run` and renders symbol shape, but is gated out; only
-  `mode is Auto or Symbol` nudges.
-- **content/source/external/web/all-text/markers/regions modes** — structurally never reach `Run`
-  (they route through `RunContent`/`RunContentCorpus`/`RunTextContent`/`RunRegions`/`RunMarkers`),
-  so no nudge is possible.
+## Verification
+- **worker-red-green** — RED first (guard tests failed on missing tables/indexes/CHECK; reader tests failed via
+  `NotImplementedException`), then GREEN:
+  `dotnet test ... --filter "FullyQualifiedName~DeadCodeCandidateReader"` → **18 passed**;
+  `... ~JulieDbFixtureCurrentSchema` → **19 passed** (14 pre-existing + 5 new v4 guards).
+- **worker-ceiling** — `scripts/test.sh` (fast suite, `Category!=Scale`): **2943 passed, 0 failed** (17s wall,
+  under the 30s ceiling). Invariant: the fast suite stays green and pure (no julie subprocess). The
+  `ScaleTraitConventionTests` guard passed — the new fixture-based tests correctly carry NO `[Trait("Category",
+  "Scale")]` and do not spawn julie-extract.
+- **Build** — Release with `TreatWarningsAsErrors`: **0 warnings / 0 errors**.
+- Known-flaky `IndexerServiceScanTests.StartAsync_WhenEnabledLeaderAndSidecarBuildFails_StillMarksRegistryScanned`
+  did not fail in this run.
 
-### Escaping
-Symbol name is escaped via a new private `EscapeCallString` (backslash-first, then quote) mirroring
-`ContextTool.NextInspectLine`, so a name containing `"` or `\` stays a single well-formed line.
+## Seam files read directly (Miller search/inspect down) + what they confirmed
+- `src/Miller.Indexing/ReferenceExportReader.cs` — `SqliteReadOnlyAccess.Open` + `JulieSchemaGate.Verify` first,
+  `artifact_id` metadata read, `MAX(revision_id) FROM extraction_revisions`. Mirrored for the artifact block.
+- `src/Miller.Indexing/JulieSchemaGate.cs` — reuse of `IncompatibleExtractException` and its missing-table message
+  style; confirmed the gate checks metadata VALUES only, not table presence (hence the required-table step).
+- `src/Miller.Indexing/SqliteSourceRegionReader.cs` + `SourceRegionRow.cs` — the `source_regions`⋈`files`
+  (content_hash/content_bytes) shape and `kind='string_literal'` filter.
+- `src/Miller.Indexing/SearchIndexWriter.cs` (`ReadVerifiedFileText`, ~691–722) — the exact freshness guard
+  (`ResolveUnderRoot` → `File.ReadAllBytes` → length + `Blake3Hex`/`NormalizeHash` match → `TryDecode`) mirrored
+  verbatim for the literal scan.
+- `src/Miller.Indexing/SourceTextDecoder.cs` — `SliceUtf8ByteSpan` returns `null` on an out-of-range/empty span.
+- `src/Miller.Indexing/IncompatibleExtractException.cs` — public sealed, `(string)` and `(string, Exception)` ctors.
+- `tests/Miller.Tests/Indexing/PatternFactsReaderTests.cs` — the `Create(...)` + post-creation `Exec`/`DROP TABLE`
+  convention the reader tests follow (structural_facts INSERT column set, missing-table test pattern).
 
-## Design decision — placement inside `Run`
-File ownership was decisive. `SearchTool.Search` dispatches the symbol route through
-`SearchRouteExecutor.RunSymbols` (a file I do not own), which passes `Run`'s output through
-unchanged. `Run` is the only place in `SearchTool.cs` with access to `kept[0]`, `fileMode`, `mode`,
-and `json`, so the nudge is computed there and flows straight to the response. This also matches the
-sibling precedent (InspectTool/TraceTool append their nudge inside the pure render path).
+## Concerns / notes for downstream
+- **Per-candidate subqueries at scale.** Four indexed subqueries per candidate-kind symbol, as the brief
+  prescribed ("do NOT materialize all identifiers"). Fixture-fast; on a ~38k-symbol real artifact this is many
+  round-trips. Task 3's Scale test should confirm the wall-clock is acceptable; if it is not, the fix is a batched
+  aggregate query, not a change to the Core contract.
+- **FK enforcement is ON by default in Microsoft.Data.Sqlite.** The new fixture write helpers set
+  `ForeignKeys=false` to match `Create`'s `PRAGMA foreign_keys=OFF`, so a builder row may reference an unseeded
+  symbol/file. The `identifier_resolutions` CHECK is enforced regardless — `AddIdentifierResolution` callers must
+  keep `outcome='resolved'` consistent with a non-null target.
+- **Report not committed.** Per the strict `serial-worker-commit` "owned files only" instruction, this report and
+  the pre-existing `task-1-report.md` / `.memories/` changes were left unstaged. (This path previously held an
+  unrelated stale report; overwritten per the lead's explicit instruction to write here.)
 
-Auto-mode rescue (`RenderAutoTextRescueCompact`) wraps `Run`'s primary output when symbol results are
-weak; in that case the nudge concludes the primary symbol block and the rescue's own `Rerun with
-mode=…` addendum follows. Existing rescue tests use `Assert.Contains` and remain green. Still exactly
-one `next:` line per response.
-
-## Miller-first orientation (calls made)
-- `inspect src/Miller.Server/Tools/SearchTool.cs kind=method` — confirmed the symbol map: `Run :592`
-  is the symbol-route core; `RunContent*`/`RunTextContent`/`RunRegions` are separate methods (so
-  content/markers modes never reach `Run`); confirmed my added `EscapeCallString :1565` and the
-  `RenderCompact`/`RenderFileCompact`/`RenderDefinitionCompact` renderers. Validated the API shape
-  used for placement.
-- Cross-checked `SearchRouteExecutor.RunSymbols` (read-only) — verified it returns `Run`'s output
-  verbatim in `SearchRouteExecutionResult`, so a nudge added in `Run` reaches the client unmodified.
-- Used Read/Edit only on worktree paths; never used Miller `edit`.
-
-## Tests (TDD: red → green)
-Added to `SearchToolTests.cs`:
-- `Run_SymbolSuccess_AppendsInspectNudgeNamingTopHit` (Theory: Auto, Symbol) — hint is last line,
-  names real top hit, exactly one `next:` line.
-- `Run_SymbolNudge_EscapesQuotesAndBackslashesInName` — quote/backslash escaping.
-- `Run_TextMode_DoesNotAppendInspectNudge`
-- `Run_FileTopHit_DoesNotAppendInspectNudge`
-- `Run_EmptySymbolResults_DoNotAppendInspectNudge`
-- `Run_SymbolJson_RemainsByteIdenticalWithoutNudge`
-- `RunContentCorpus_Compact_DoesNotAppendInspectNudge`
-
-Updated two existing tests for the new (correct) behavior:
-- `Run_SymbolModes_RenderExactCompactShape` — now mode-aware (Auto/Symbol expect the nudge suffix;
-  Text does not).
-- `Run_PreservesIndexOrdering_DoesNotReSort` — line parser skips the `next:` nudge line.
-
-### Verification
-- `dotnet test --filter FullyQualifiedName~SearchToolTests` → **Passed! 92/0/0**.
-- `scripts/test.sh` (full fast suite) → **Passed! 2750/0/0**, 9s (under the 30s budget).
-
-## Concerns
-- Under auto-mode source/docs rescue the `next:` nudge is not the literal final line (the rescue
-  addendum follows it); it still appears exactly once and concludes the primary block. This is
-  one-line-max compliant. If the plan intends the nudge strictly after the rescue addendum, that
-  would require touching the rescue wrapper — flagged rather than silently changed.
-- No other files touched. Sibling report files (`task-1/3/4/5-report.md`) were left dirty and out of
-  my commit.
-
-## Fix follow-up — rescue owns its closing affordance (lead ruling)
-Lead ruled the nudge must be **suppressed entirely** when the auto-mode source/docs/config rescue
-fires, not merely precede it. Design rule: max one next-step affordance per output; the rescue's
-`Rerun with mode=…` line is the single closing affordance, and it only fires when symbol results look
-weak, so a `next: inspect` on a weak top hit competes with it.
-
-- `RenderAutoTextRescueCompact` (SearchTool.cs) now strips the trailing `next: ` line from
-  `primaryOutput` via new helper `StripTrailingNextHint` before composing the rescue block.
-  Deterministic: NextStepHint emits the hint as one line with no trailing newline, so dropping the
-  final line iff it starts with `"next: "` is unambiguous. Rationale recorded in a code comment.
-- New TDD tests (SearchToolTests.cs): `Search_AutoMode_SourceRescue_SuppressesInspectNudge` and
-  `Search_AutoMode_DocsConfigRescue_SuppressesInspectNudge` — assert the rescue output contains NO
-  `next: ` line and still carries `Rerun with mode=source`/`mode=content`. Non-rescue symbol
-  successes keep the nudge (existing tests stay green).
-- Verification: `dotnet test tests/Miller.Tests --filter FullyQualifiedName~SearchToolTests` →
-  **Passed! 94/0/0**.
+## Files
+- Create: `src/Miller.Indexing/DeadCodeCandidateReader.cs`
+- Modify: `tests/Miller.Tests/Indexing/JulieDbFixture.cs`
+- Modify: `tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs`
+- Create: `tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs`

--- a/.razorback/sdd/task-3-report.md
+++ b/.razorback/sdd/task-3-report.md
@@ -1,35 +1,198 @@
-# Task 3 — inspect impact nudge
+# Task 3 Report — CLI surface + capabilities + Scale test
 
-## Status
-Complete. Committed `399936173e8f9185bc160d5b73856ef8718735d9` on branch `guidance-delivery`.
+**Status:** DONE
+**Branch:** `feat/dead-code-candidates`
+**Commit mode:** serial-worker-commit (owned files only; not pushed)
 
-## What changed
-- `src/Miller.Server/Tools/InspectTool.cs`
-  - Added `ImpactHintMinReferences = 4` constant near the renderer (no inline magic number).
-  - In `RenderSymbolCompact`, after the body/body-preview section and before the final `TrimEnd`,
-    append one nudge line when `!sym.IsTest && refs.Count >= ImpactHintMinReferences`:
-    `NextStepHint.Render($"impact target=\"{sym.Name}\"", $"{refs.Count} dependents")`.
-    This tail runs only for overview/full (summary returns early); JSON has a separate renderer,
-    so JSON output is byte-identical.
-- `tests/Miller.Tests/Server/InspectToolTests.cs`
-  - Added `HotSymbolFixture(refCount, isTest, name)` and 7 TDD tests: hint fires at overview + full
-    with real name and count (and is the last line); absent at 3 refs, at depth=summary, for `IsTest`
-    symbols, for file listings; JSON omits the hint and stays valid.
+## What was built
 
-## Miller-first orientation (API-shape evidence)
-Miller MCP tools were not reachable in this subagent session; equivalent evidence gathered via Read/Grep:
-- `RenderSymbolCompact` (InspectTool.cs:375) — refs come from `ExtractReader.ReadReferences(dbPath, sym.Name)`
-  (line 415); `refs.Count` is in method scope at the render tail (~line 470). Summary returns early at line 389,
-  so the tail is overview/full only. Confirms where the hint attaches and that it renders last.
-- `IndexedSymbol.IsTest` (IndexedSymbol.cs:23) — `bool` record property (julie typed `is_test`, all langs).
-  Confirms the test-symbol suppression check.
-- `NextStepHint.Render` (NextStepHint.cs:29) — returns single line `next: <call> — <reason>`. Confirms the shared formatter shape.
-- File listings (`RenderFile`) and JSON (`RenderSymbolJson`) are separate methods — untouched, so file/JSON output is unaffected.
+Wired the Task 2 `DeadCodeCandidateReader` to a new `miller references candidates` CLI verb (compact +
+`--json`), advertised the surface in `capabilities`, and added a real-binary Scale test. TDD: failing tests
+first (7 red), then implementation (green).
+
+### Files changed (ONLY owned files)
+- `src/Miller.Server/Cli/CliDispatch.cs` — route `references candidates` inside `case "references":` on
+  `rest[0]` (else the existing `ArtifactExport(... ReferenceExportReader.WriteJsonLines)` export path is
+  unchanged); `ReferencesCandidates` handler; `RenderCandidatesCompact` / `RenderCandidatesJson`
+  (`Utf8JsonWriter` manual snake_case, mirroring `ReferenceExportReader`); help text updated.
+- `src/Miller.Server/Cli/CliCapabilities.cs` — `optional_features.references_candidates` (JSON + compact),
+  `references candidates --json` in `json_commands`, `references_candidates` entry in `json_contracts`.
+- `tests/Miller.Tests/Server/Cli/CliDispatchTests.cs` — 8 new fast tests (compact, JSON field-complete,
+  `resolved_pct==10.0`, `--limit`, v3-schema exit 3, v4-missing-table exit 3, export-path-unchanged control,
+  capabilities).
+- `tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs` — NEW, `[Trait("Category","Scale")]`,
+  binary via `ScaleTestSupport.RequireJulieServer()`.
+
+### Routing
+`--limit` (default 50) bounds ONLY the candidate list (sorted by `path` then `start_line`, stable take N).
+`examined`, `suppressions`, `literal_scan`, `language_coverage` are always full totals. The reader's
+`IncompatibleExtractException` (schema gate OR a missing resolution table) propagates to `Run`'s catch →
+`references failed: …` + exit 3.
+
+---
+
+## VERBATIM artifacts for Task 4 (copy these exactly)
+
+### 1. Exact JSON field names emitted (`references candidates --json`)
+
+Top-level keys, in emit order:
+```
+schema_version
+candidates          (array)
+suppressions        (object)
+literal_scan        (object)
+language_coverage   (array)
+examined
+artifact            (object)
+```
+
+`candidates[]` object fields (in emit order):
+```
+symbol_id
+name
+kind
+language
+path
+start_line
+visibility            (JSON string, or JSON null when absent)
+evidence_label        ("name" | "name+resolver")
+evidence              (object)
+```
+`candidates[].evidence` object fields (in emit order):
+```
+name_matches
+resolved_inbound
+pending_resolved_inbound
+calls_inbound
+```
+
+`suppressions` object — all nine keys ALWAYS present, in `DeadCodeCandidates.SuppressionRuleIds` order:
+```
+public_api
+visibility_unknown
+test_symbol
+entry_point
+framework_bound
+annotated
+generated_path
+low_evidence_language
+string_literal_match
+```
+
+`literal_scan` object fields:
+```
+files_scanned
+files_skipped_stale
+```
+
+`language_coverage[]` object fields:
+```
+language
+identifiers
+resolved_pct        (0–100 number, one decimal; 1-of-10 → 10.0, NOT 0.1)
+```
+
+`artifact` object fields (in emit order):
+```
+artifact_id                    (JSON string, or JSON null when absent)
+revision                       (JSON number, or JSON null when absent)
+reference_resolution_status    (JSON string; falls back to "unknown" in the reader)
+reference_resolution_version   (JSON string, or JSON null when absent)
+```
+
+`schema_version` value = `1`.
+
+### 2. Exact compact resolver header string (VERBATIM, incl. trailing period)
+
+Full header line format:
+```
+candidates: <candidateCount> of <examined> symbols examined · resolver: <status> — candidates are facts to check, not deletions to make.
+```
+The clause after `· ` is verbatim (`<status>` = `report.Artifact.ReferenceResolutionStatus`, e.g. `partial`):
+```
+resolver: <status> — candidates are facts to check, not deletions to make.
+```
+(Separator between the two clauses is a middle-dot `·`; the dash before "candidates are facts" is an
+em-dash `—`.)
+
+Compact candidate line format (one per shown candidate):
+```
+<name> <kind> <language> <path>:<start_line> <visibility> evidence=<label> [name_matches=0 resolved_in=0 pending_in=0 calls_in=0]
+```
+(Note the compact evidence keys `resolved_in` / `pending_in` / `calls_in` differ from the JSON
+`resolved_inbound` / `pending_resolved_inbound` / `calls_inbound`.)
+
+Compact footer lines:
+```
+showing top <limit> of <candidateCount> by path      (only when candidateCount > shown count)
+suppressed: public_api=0 visibility_unknown=0 test_symbol=0 entry_point=0 framework_bound=0 annotated=0 generated_path=0 low_evidence_language=0 string_literal_match=0
+literal_scan: files_scanned=0 files_skipped_stale=0
+coverage: <lang>: <pct>% resolved; <lang>: <pct>% — name-evidence only
+```
+Coverage per-language: `<pct>% resolved` when `resolved_pct >= 10.0`, else `<pct>% — name-evidence only`.
+
+### 3. Exact capabilities keys/strings added
+
+- `optional_features.references_candidates` — JSON boolean `true`.
+- Compact optional-feature line (next to `reference_aware_context: enabled`):
+  ```
+  references_candidates: enabled
+  ```
+- `json_commands` new entry (exact string):
+  ```
+  references candidates --json
+  ```
+- `json_contracts` new entry tuple:
+  ```
+  ("references_candidates", "references candidates --json", 1, "docs/contracts/references-candidates-v1.md")
+  ```
+  JSON object shape: `{ "name":"references_candidates", "command":"references candidates --json",
+  "schema_version":1, "doc":"docs/contracts/references-candidates-v1.md" }`.
+  Compact rendering:
+  ```
+  - references_candidates v1: `references candidates --json` (docs/contracts/references-candidates-v1.md)
+  ```
+
+> Task 4 creates `docs/contracts/references-candidates-v1.md`; naming it now in `json_contracts` is correct
+> per the brief. Task 4 also amends the stale Eros-ownership sentences in `references-export-v1.md` and
+> `cli-eros-v1.md`.
+
+---
 
 ## Verification
-`dotnet test tests/Miller.Tests --filter "FullyQualifiedName~InspectToolTests"` → Passed! 49/49, 0 failed (7 new).
-Gate invariant proven: the impact nudge fires only above the dependent threshold (≥4) on non-test symbols in
-compact overview/full output, and never in summary, file listings, test symbols, or JSON.
 
-## Concerns
-None. Touched only the two assigned source/test files (the report path was a stale prior-run artifact, overwritten here).
+- **worker-red-green** (`dotnet test … --filter FullyQualifiedName~CliDispatchTests`): RED first (7 new
+  tests failed; the export-path control passed), then GREEN — **132 passed, 0 failed, Skipped: 0**.
+- **Scale** (`scripts/test.sh scale`): full scale suite **47 passed, Skipped: 0**; the new
+  `DeadCodeCandidatesScaleTests` runs green in isolation (**1 passed, Skipped: 0**). It scans a tiny temp
+  workspace (public class with two private methods: `InvokeSecretly`, referenced only by the reflection
+  string `"InvokeSecretly"`, and `DeadPrivateHelper`, referenced by nothing) with the real 2.9.0 binary,
+  runs the CLI end-to-end, and asserts: `DeadPrivateHelper` surfaces as a candidate, `InvokeSecretly` is
+  suppressed under `string_literal_match` (two-phase literal scan over real `source_regions`), and
+  per-language coverage renders (compact + JSON). **CLI `references candidates` wall-clock: 23 ms** (7
+  symbols extracted). The real string-literal suppression path works against the live binary.
+- **worker-ceiling** (`scripts/test.sh`, fast suite): **2951 passed, 0 failed, Skipped: 0**, 12–16s.
+  (First run had ONE transient failure in `IndexerServiceLeadershipTests.StartAsync_ArtifactOlderThanOwn_…`
+  — a leadership/scan timing test in the same known-flaky family, unrelated to this CLI-only change; it took
+  5s under parallel load, passed in isolation (73 ms) and on a clean full re-run.)
+- **Build** (`dotnet build Miller.slnx -c Release`): **0 Warnings, 0 Errors** (warnings-as-errors).
+
+### Gate invariants
+- red-green: the candidates handler + capabilities entries did not exist → tests fail; after implementation
+  they pass, proving the tests exercise the new behavior.
+- Scale: `Skipped: 0` for the new test confirms the pinned 2.9.0 binary was present and the end-to-end path
+  ran with the real extract.
+- ceiling: the fast suite stays fast and pure; no new subprocess in the fast path.
+- build: zero warnings/errors under `TreatWarningsAsErrors`.
+
+## Concerns / notes
+- **Design-doc §Output vs Global Constraints (resolved):** design §Output (line 105–106) prints the header
+  clause WITHOUT a trailing period, but the implementation-plan Global Constraints (line 20) and design line
+  101 require the trailing period. Followed Global Constraints (with period) per the brief; the design
+  §Output example is the only spot missing it. Not a redesign — a doc example inconsistency.
+- **String-literal suppression depends on real `source_regions`:** the Scale test proves julie-extract 2.9.0
+  emits C# `string_literal` regions and the two-phase scan suppresses the reflection-named member. If a
+  future language/extractor stops emitting these, that language's reflection-only symbols would surface as
+  candidates — the honest signal Task 5's dogfood gate exists to catch.
+- **Perf:** the reader runs 4 indexed subqueries per candidate-kind symbol. On the tiny Scale fixture the CLI
+  is 23 ms; Task 5 must judge this on the real ~38k-symbol repo.

--- a/.razorback/sdd/task-4-report.md
+++ b/.razorback/sdd/task-4-report.md
@@ -1,64 +1,76 @@
-# Task 4 — trace refs nudge
+# Task 4 report — contract docs + boundary amendments (dead-code candidates)
 
-**Status:** ✅ Complete
-**Commit:** `a6f9029` — `feat(trace): impact nudge after non-empty refs`
-**Branch/worktree:** `guidance-delivery` @ `/Users/murphy/source/miller/.worktrees/guidance-delivery`
+**Branch:** `feat/dead-code-candidates` · **Start HEAD:** b9c7bdb · **Commit mode:** serial-worker-commit
+**Status:** COMPLETE — all gates green.
 
-> Note: this file previously held an unrelated "inspect depth=overview strips doc-comment lines"
-> report (a different plan run). Overwritten per the Task 4 assignment, which designated this path.
+## What changed (owned files)
 
-## What changed
+1. **Created `docs/contracts/references-candidates-v1.md`** — full contract for `references candidates`:
+   status experimental/evidence-gated (gate PASSED 2026-07-07, cites the findings doc); invocation/selectors;
+   exit codes (0/2/3, v3 + v4-missing-resolution both exit 3); candidate rule summary; ALL ELEVEN suppression
+   rules in table order with semantics + source; evidence-label section ("provenance, not certainty", the
+   ≥10% query-time threshold, the partial-resolver caveat, and the write-only/comment-only "facts to check,
+   not verdicts" stance); compact + `--json` envelope with a field table and a worked JSON example;
+   capabilities keys; boundary.
+2. **`docs/contracts/references-export-v1.md`** — replaced the stale "Eros owns candidate ranking,
+   generated/framework suppression…" sentence (lines 5–8) per the 2026-07-06 consensus: Miller owns the
+   deterministic candidate listing; persistence/history/dashboards/cross-workspace stay out.
+3. **`docs/contracts/cli-eros-v1.md`** — added a `references candidates --json` row to the Stable JSON
+   commands table; amended the bottom Boundary paragraph and the references-export feed description so no
+   sentence assigns dead-code candidate listing to Eros.
+4. **`docs/README.md`** — contracts-map entry for the new doc.
+5. **`CLAUDE.md`** — 1.0-boundary sentence rewritten: dead-code candidates SHIPPED as an evidence-gated CLI
+   surface, gate PASSED 2026-07-07 with julie-extract 2.10.0 variable_ref emission (392→5, zero
+   confirmed-live), report/dashboard/MCP surfacing still needs explicit approval. `scripts/sync-agents.sh`
+   ran; `cmp -s CLAUDE.md AGENTS.md` clean.
 
-In `TraceTool.RunRefs` compact (non-JSON) `mode=refs` output, when at least one reference is
-shown AND the resolved target is not a test symbol (`targetSymbol.IsTest == false`), a single
-final line is appended after the references block and after any truncation note:
+## Shapes verified against shipped code (file:line — read raw, index not trusted)
 
-```
-next: impact target="<target name>" — before editing
-```
+Copied verbatim from Task 3 code, not from memory:
 
-Rendered via `NextStepHint.Render($"impact target=\"{targetSymbol.Name}\"", "before editing")`.
+- **Eleven suppression rule ids + table order** — `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:59-63`
+  (`SuppressionRuleIds`): public_api, visibility_unknown, test_symbol, entry_point, override_member,
+  live_member_container, framework_bound, annotated, generated_path, low_evidence_language,
+  string_literal_match. Per-rule semantics from `FirstSuppressionRule` (`DeadCodeCandidates.cs:219-264`) and
+  helpers (test-path 269-283, override 292-299, entry_point 301-308, generated 310-325, evidence label
+  329-339).
+- **Compact header string** — `CliDispatch.cs:772-774`: `candidates: N of M symbols examined · resolver:
+  <status> — candidates are facts to check, not deletions to make.`
+- **Compact candidate line / suppressed / literal_scan / coverage** — `CliDispatch.cs:776-808`
+  (`unknown` for null visibility :781; `showing top K of N by path` :788-790; coverage ` resolved` vs
+  ` — name-evidence only` at pct≥10 :807).
+- **JSON envelope** — `CliDispatch.cs:813-896`: `schema_version` (:823, =1 at :899); `candidates[]` fields
+  symbol_id/name/kind/language/path/start_line/visibility(null-safe)/evidence_label (:830-837) + nested
+  `evidence{name_matches, resolved_inbound, pending_resolved_inbound, calls_inbound}` (:838-844);
+  `suppressions{rule_id:count}` (:849-853); `literal_scan{files_scanned, files_skipped_stale}` (:855-859);
+  `language_coverage[]{language, identifiers, resolved_pct}` (:861-871); `examined` (:873);
+  `artifact{artifact_id(null-safe), revision(null-safe), reference_resolution_status,
+  reference_resolution_version(null-safe)}` (:875-890).
+- **resolved_pct convention** — 0–100, one decimal (`ResolvedPercent`, `DeadCodeCandidates.cs:102-108`).
+- **Capabilities keys** — `optional_features.references_candidates: true` (`CliCapabilities.cs:186`, compact
+  :129); `json_commands` has `references candidates --json` (:68); `json_contracts` `references_candidates`
+  v1 → `docs/contracts/references-candidates-v1.md` (:103).
+- **`--limit` bounds only the candidate list** — `CliDispatch.cs:757-764, 729-730`; default 50 (:755).
+- **Exit-code mapping** — reader validation → `IncompatibleExtractException` → exit 3 (`CliDispatch.cs:726-728`).
 
-- **JSON byte-identical** — the JSON branch returns earlier (before the compact `StringBuilder`
-  render), so it is untouched.
-- **Empty refs unchanged** — the `shown.Length == 0` branch (existing recovery hint + `next_actions`)
-  is the `if` arm; the nudge lives only in the `else` (non-empty) arm.
-- **Test targets suppressed** — `if (!targetSymbol.IsTest)` guard.
-- **Exactly one hint line max** — appended once at the tail; `TrimEnd('\n')` keeps it as the last line.
+## Miller MCP usage
 
-Files touched (only these two):
-- `src/Miller.Server/Tools/TraceTool.cs` — the `else` branch of the compact refs render.
-- `tests/Miller.Tests/Tools/TraceToolTests.cs` — 5 new tests.
+Did not rely on the Miller index for shapes (index may lag the last commits, per brief) — all field names and
+strings were verified by raw `Read`/`grep` on the source files cited above.
 
-## Miller-first orientation (calls + evidence)
+## Gates
 
-- `inspect src/Miller.Server/Tools/TraceTool.cs` → located `RunRefs` (:492) and `ReferenceLine`
-  (:600); confirmed the compact refs render lives inside `RunRefs`, JSON path exits earlier.
-- Read `src/Miller.Server/Tools/NextStepHint.cs` → confirmed
-  `internal static string Render(string toolCall, string? reason = null)` yields
-  `next: <toolCall> — <reason>` (U+2014, single line, no trailing newline).
-- Read `TraceTool.cs` refs region → confirmed `targetSymbol` is non-null at the render (guarded at
-  :526), carries `IsTest`, and that the truncation note (`"reference trace truncated by limit."`)
-  is appended inside the same `else` arm before the tail.
+- `scripts/test.sh` (fast suite): **Passed! Failed: 0, Passed: 2957, Skipped: 0** (incl. AgentInstructionsTests
+  and the capabilities/doc gates). Wall 21s.
+- `cmp -s CLAUDE.md AGENTS.md`: **clean** after `scripts/sync-agents.sh`.
+- New contract doc: **no TBDs**.
 
-## TDD
+## Judgment calls
 
-Tests written first (red), then implementation (green):
-1. `Refs_NonEmpty_AppendsImpactNudge_ForNonTestTarget` — hint present, real target name, ends the output, exactly one `next:` line.
-2. `Refs_NonEmpty_TruncationNote_KeepsImpactNudgeAsFinalLine` — nudge renders after the truncation note.
-3. `Refs_NonEmpty_TestTarget_SuppressesImpactNudge` — no `next:` for an `IsTest` target.
-4. `Refs_Empty_HasNoImpactNudge` — empty path emits no `next: impact`.
-5. `Refs_NonEmpty_Json_HasNoImpactNudge` — JSON still well-formed, no `next: impact`.
-
-## Verification
-
-`dotnet test tests/Miller.Tests --filter "FullyQualifiedName~TraceToolTests"` →
-**Passed! Failed: 0, Passed: 91, Skipped: 0** (188 ms). Build clean under warnings-as-errors.
-
-Gate invariant satisfied: the refs→impact nudge fires only on non-empty, non-test compact refs
-output.
-
-## Concerns
-
-None. Scope stayed within the two owned files; other worktree changes
-(`.razorback/sdd/task-1-report.md`, `task-5-report.md`) are other agents' and were left untouched.
+- Plan text said "nine" suppression rules and the older CLAUDE wording; used the brief's correction + the code
+  as single source → documented **eleven** in code order.
+- Beyond the two required contract edits, also softened one adjacent references-export feed sentence in
+  `cli-eros-v1.md` that implied Eros owns dead-code, to keep the doc internally consistent. Surgical; no
+  scope creep — persistence/history/ranking/fleet remain Eros's in every amended sentence.
+- Contract states the gate PASSED (per the findings FINAL VERDICT), and keeps the surface explicitly
+  CLI-only with report/dashboard/MCP gated on user approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,16 @@ current-vs-historical documentation map.
 
 The Julie replacement story is Miller + `julie-extractors` + Eros, not Miller alone. Miller replaces Julie's
 deterministic local agent-tool core: search, inspect, context, refs, trace/path, impact, editing, workspace
-lifecycle, content/web/text import, patterns, marker audits, telemetry, and JSON/JSONL feeds.
+lifecycle, content/web/text import, patterns, marker audits, telemetry, JSON/JSONL feeds, **and deterministic
+local analysis reports** (`metrics churn|clones|complexity|risk`, the composed `miller report` rollup).
 `julie-extractors` / `julie-extract` owns parser-backed extraction and standalone extract workflows. Eros owns
-semantic/vector retrieval, guidance, confidence/evidence views, signals reports, dead-code/hotspot/clone workflows,
-history, and commercial orchestration. Do not add Miller surfaces merely to absorb Eros-level reports or
-`julie-extractors` extraction ownership.
+what requires semantics or fleet state: semantic/vector retrieval and embeddings, guidance and
+confidence/evidence views, cross-workspace/fleet ranking, suppression persistence, and commercial orchestration.
+(2026-07-06 consensus, Eros not shipping: Miller absorbed the deterministic signals/hotspot workflows —
+see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates stay out until
+extractor reference resolution earns them; metric history/trends are a designed-not-built P4.) Do not add
+Miller surfaces that need embeddings or semantic ranking, and do not absorb `julie-extractors` extraction
+ownership.
 
 Adding a new MCP tool requires **explicit user approval** before implementation. Keep the MCP surface stingy:
 prefer improving an existing tool, adding a CLI/export contract, writing a skill, or surfacing data on the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,12 @@ scripts/test.ps1 all
 - **Host lifecycle gotcha (load-bearing).** The .NET Generic Host CONSTRUCTS every `IHostedService` up
   front, then calls `StartAsync` on each in registration order. Registration order orders `StartAsync`, NOT
   construction. So **no hosted-service constructor may read an `IndexBootstrapService` getter**
-  (`Holder`/`Resolver`/`Workspace`/`Ledger`) — they throw until the bootstrap's `StartAsync` has run. The
-  M3 services take only the bootstrap and read its getters lazily inside `ExecuteAsync`. The whole host
-  graph is registered in one testable place,
+  (`Holder`/`Resolver`/`Workspace`/`Ledger`) — they throw until the bootstrap is BOUND, not merely until
+  `StartAsync` has returned. The initial scan runs in the background; tool calls wait only for the
+  `MILLER_BOOTSTRAP_GRACE_SECONDS` window (default `5`, `0` = immediate fail-fast) and then return an
+  actionable not-ready/failed tool result. The `workspace` tool's unbound status is rendered by the binding
+  filter because the real tool cannot construct until bound. The M3 services take only the bootstrap and read
+  its getters lazily inside `ExecuteAsync`. The whole host graph is registered in one testable place,
   [`MillerServiceRegistration.AddMillerServices`](src/Miller.Server/Hosting/MillerServiceRegistration.cs);
   `HostStartupRegistrationTests` resolves the hosted-service set before bootstrap to guard this.
 - **Version-aware leadership (load-bearing invariant).** The artifact's `artifact_metadata.binary_version`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,12 @@ local analysis reports** (`metrics churn|clones|complexity|risk`, the composed `
 what requires semantics or fleet state: semantic/vector retrieval and embeddings, guidance and
 confidence/evidence views, cross-workspace/fleet ranking, suppression persistence, and commercial orchestration.
 (2026-07-06 consensus, Eros not shipping: Miller absorbed the deterministic signals/hotspot workflows —
-see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates stay out until
-extractor reference resolution earns them; metric history/trends are a designed-not-built P4.) Do not add
+see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates SHIPPED as an
+evidence-gated CLI surface (`miller references candidates`, `docs/contracts/references-candidates-v1.md`); the
+gate PASSED 2026-07-07 with julie-extract 2.10.0 `variable_ref` emission (392 → 5 candidates, zero
+confirmed-live — `docs/findings/2026-07-07-dead-code-candidates-dogfood.md`), but report/dashboard/MCP
+surfacing still requires explicit user approval per the MCP-stinginess rule; metric history/trends are a
+designed-not-built P4.) Do not add
 Miller surfaces that need embeddings or semantic ranking, and do not absorb `julie-extractors` extraction
 ownership.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,16 @@ current-vs-historical documentation map.
 
 The Julie replacement story is Miller + `julie-extractors` + Eros, not Miller alone. Miller replaces Julie's
 deterministic local agent-tool core: search, inspect, context, refs, trace/path, impact, editing, workspace
-lifecycle, content/web/text import, patterns, marker audits, telemetry, and JSON/JSONL feeds.
+lifecycle, content/web/text import, patterns, marker audits, telemetry, JSON/JSONL feeds, **and deterministic
+local analysis reports** (`metrics churn|clones|complexity|risk`, the composed `miller report` rollup).
 `julie-extractors` / `julie-extract` owns parser-backed extraction and standalone extract workflows. Eros owns
-semantic/vector retrieval, guidance, confidence/evidence views, signals reports, dead-code/hotspot/clone workflows,
-history, and commercial orchestration. Do not add Miller surfaces merely to absorb Eros-level reports or
-`julie-extractors` extraction ownership.
+what requires semantics or fleet state: semantic/vector retrieval and embeddings, guidance and
+confidence/evidence views, cross-workspace/fleet ranking, suppression persistence, and commercial orchestration.
+(2026-07-06 consensus, Eros not shipping: Miller absorbed the deterministic signals/hotspot workflows —
+see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates stay out until
+extractor reference resolution earns them; metric history/trends are a designed-not-built P4.) Do not add
+Miller surfaces that need embeddings or semantic ranking, and do not absorb `julie-extractors` extraction
+ownership.
 
 Adding a new MCP tool requires **explicit user approval** before implementation. Keep the MCP surface stingy:
 prefer improving an existing tool, adding a CLI/export contract, writing a skill, or surfacing data on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,12 @@ scripts/test.ps1 all
 - **Host lifecycle gotcha (load-bearing).** The .NET Generic Host CONSTRUCTS every `IHostedService` up
   front, then calls `StartAsync` on each in registration order. Registration order orders `StartAsync`, NOT
   construction. So **no hosted-service constructor may read an `IndexBootstrapService` getter**
-  (`Holder`/`Resolver`/`Workspace`/`Ledger`) — they throw until the bootstrap's `StartAsync` has run. The
-  M3 services take only the bootstrap and read its getters lazily inside `ExecuteAsync`. The whole host
-  graph is registered in one testable place,
+  (`Holder`/`Resolver`/`Workspace`/`Ledger`) — they throw until the bootstrap is BOUND, not merely until
+  `StartAsync` has returned. The initial scan runs in the background; tool calls wait only for the
+  `MILLER_BOOTSTRAP_GRACE_SECONDS` window (default `5`, `0` = immediate fail-fast) and then return an
+  actionable not-ready/failed tool result. The `workspace` tool's unbound status is rendered by the binding
+  filter because the real tool cannot construct until bound. The M3 services take only the bootstrap and read
+  its getters lazily inside `ExecuteAsync`. The whole host graph is registered in one testable place,
   [`MillerServiceRegistration.AddMillerServices`](src/Miller.Server/Hosting/MillerServiceRegistration.cs);
   `HostStartupRegistrationTests` resolves the hosted-service set before bootstrap to guard this.
 - **Version-aware leadership (load-bearing invariant).** The artifact's `artifact_metadata.binary_version`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,12 @@ local analysis reports** (`metrics churn|clones|complexity|risk`, the composed `
 what requires semantics or fleet state: semantic/vector retrieval and embeddings, guidance and
 confidence/evidence views, cross-workspace/fleet ranking, suppression persistence, and commercial orchestration.
 (2026-07-06 consensus, Eros not shipping: Miller absorbed the deterministic signals/hotspot workflows —
-see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates stay out until
-extractor reference resolution earns them; metric history/trends are a designed-not-built P4.) Do not add
+see `docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md`. Dead-code candidates SHIPPED as an
+evidence-gated CLI surface (`miller references candidates`, `docs/contracts/references-candidates-v1.md`); the
+gate PASSED 2026-07-07 with julie-extract 2.10.0 `variable_ref` emission (392 → 5 candidates, zero
+confirmed-live — `docs/findings/2026-07-07-dead-code-candidates-dogfood.md`), but report/dashboard/MCP
+surfacing still requires explicit user approval per the MCP-stinginess rule; metric history/trends are a
+designed-not-built P4.) Do not add
 Miller surfaces that need embeddings or semantic ranking, and do not absorb `julie-extractors` extraction
 ownership.
 

--- a/README.md
+++ b/README.md
@@ -231,12 +231,13 @@ Design choices that follow from this:
 The 1.0 replacement story is the product family, not Miller alone:
 
 - **Miller** replaces Julie's deterministic local agent-tool core: search, inspect, context, references, trace/path,
-  impact, editing, workspace lifecycle, content/web/text import, structural facts, marker audits, telemetry, and
-  JSON/JSONL feeds.
+  impact, editing, workspace lifecycle, content/web/text import, structural facts, marker audits, telemetry,
+  JSON/JSONL feeds, and deterministic local analysis reports (`metrics churn|clones|complexity|risk` and the
+  composed `miller report` repo-quality rollup).
 - **`julie-extractors` / `julie-extract`** owns parser-backed extraction. Miller consumes its artifacts and ships a
   pinned extractor for its own indexing workflow; standalone extraction workflows belong in `julie-extractors`.
-- **Eros** owns higher-level intelligence: semantic/vector retrieval, guidance, confidence/evidence views, signals
-  reports, dead-code/hotspot/clone workflows, history, and commercial orchestration.
+- **Eros** owns what requires semantics or fleet state: semantic/vector retrieval and embeddings, guidance,
+  confidence/evidence views, cross-workspace ranking, suppression persistence, and commercial orchestration.
 
 That boundary is deliberate. Miller should stay predictable and local; the product layer above it decides what the
 facts mean and what to do next.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Use this page to avoid treating old milestone plans as the current product contr
 - [`contracts/trace-json-v1.md`](contracts/trace-json-v1.md) - active trace JSON contract for auto/path/refs/bridge output and additive `next_actions`.
 - [`contracts/content-corpus-v1.md`](contracts/content-corpus-v1.md) - active content corpus schema/export contract.
 - [`contracts/references-export-v1.md`](contracts/references-export-v1.md) - active references/usage JSONL export contract.
+- [`contracts/references-candidates-v1.md`](contracts/references-candidates-v1.md) - experimental, evidence-gated dead-code candidate listing CLI contract (`references candidates`).
 - [`contracts/patterns-json-v1.md`](contracts/patterns-json-v1.md) - active patterns JSON contract over extractor structural facts.
 - [`contracts/metrics-json-v1.md`](contracts/metrics-json-v1.md) - active metrics JSON contract for churn, clone groups, and complexity ranking.
 - [`plans/2026-06-26-miller-five-gap-implementation-plan.md`](plans/2026-06-26-miller-five-gap-implementation-plan.md) - historical implementation plan for metrics, empty-state recovery, leader handoff, dashboard panels, and clone/complexity discovery; the metrics MCP-tool portions were superseded by the CLI-only metrics contract.

--- a/docs/contracts/cli-eros-v1.md
+++ b/docs/contracts/cli-eros-v1.md
@@ -66,6 +66,7 @@ Current `json_commands` include:
 | `telemetry export --jsonl` | Export raw Miller telemetry rows for Eros dashboard/history ingestion. |
 | `symbols export --jsonl` | Bulk-export one row per symbol for fleet rollups (counts, kinds, doc coverage, clones). |
 | `references export --jsonl` | Bulk-export one row per identifier/reference usage fact for dead-code candidate workflows. |
+| `references candidates --json` | Deterministic dead-code candidate listing with named suppressions (experimental, evidence-gated; CLI-only). See [`references-candidates-v1.md`](references-candidates-v1.md). |
 | `complexity export --jsonl` | Bulk-export per-symbol/per-file complexity metric rows for fleet hotspot ranking. |
 | `patterns export --jsonl` | Bulk-export structural fact rows for fleet code-shape inventory. |
 | `dashboard --json` | Start/reuse the local dashboard helper and return its URL. |
@@ -156,8 +157,9 @@ with the standard rebuild message. Fields (`schema_version` 1):
 - `is_test` — boolean; julie's cross-language test signal (prod/test splits).
 
 `miller references export --jsonl [--workspace-id SELECTOR] [--workspace DIR]` emits one JSON line per
-`identifiers` row, ordered `(path, start_byte, identifier_id)`. This is a fact feed for Eros dead-code and
-usage workflows, not a Miller ranking/workflow surface. See [`references-export-v1.md`](references-export-v1.md)
+`identifiers` row, ordered `(path, start_byte, identifier_id)`. This is a raw usage fact feed, not a ranking
+surface; Miller's own deterministic dead-code candidate listing is `references candidates`
+([`references-candidates-v1.md`](references-candidates-v1.md)). See [`references-export-v1.md`](references-export-v1.md)
 for field-level guarantees. Fields (`schema_version` 1):
 
 - `identifier_id` — julie's identifier-row ID; this is the source fact ID.
@@ -270,6 +272,8 @@ result such as `workspace remove` returning `not_found` with exit code `0`.
 Miller should add new CLI JSON/export surfaces when Eros needs stable code facts or operations. Do not add a
 private Eros-to-Miller protocol until documented JSON, JSONL, and local artifacts are proven insufficient.
 
-The references export is intentionally narrow: Miller exports deterministic usage facts, while Eros owns
-dead-code ranking, generated/framework suppression, history, cleanup tasks, confidence views, and
-multi-workspace reporting.
+The references export is intentionally narrow: Miller exports deterministic usage facts. Per the 2026-07-06
+consensus, Miller also owns the deterministic dead-code **candidate** listing with named suppressions
+(`references candidates`; [`references-candidates-v1.md`](references-candidates-v1.md), experimental and
+CLI-only). Ranking beyond the deterministic rule, suppression **persistence**, candidate history, cleanup
+tasks, confidence views, and multi-workspace reporting stay out of Miller.

--- a/docs/contracts/metrics-json-v1.md
+++ b/docs/contracts/metrics-json-v1.md
@@ -1,6 +1,6 @@
 # Metrics JSON contract v1
 
-Status: active additive contract for the CLI-only `miller metrics <churn|clones|complexity> --json` commands.
+Status: active additive contract for the CLI-only `miller metrics <churn|clones|complexity|risk> --json` commands.
 
 Miller metrics are deterministic local facts over the selected workspace. They are not semantic rankings, cleanup
 recommendations, suppressions, fleet history, or Eros workflow orchestration.
@@ -12,7 +12,7 @@ All responses include:
 | Field | Type | Description |
 |---|---|---|
 | `schema_version` | number | Contract version. Currently `1`. |
-| `operation` | string | `churn`, `clones`, or `complexity`. |
+| `operation` | string | `churn`, `clones`, `complexity`, or `risk`. The set is additive: v1 consumers must ignore operations they do not recognize rather than treating the enum as closed (`risk` was added 2026-07-06). |
 
 The command accepts the normal single-workspace selectors: `--workspace-id SELECTOR` and `--workspace DIR`.
 
@@ -139,3 +139,48 @@ Each hotspot:
 
 `miller complexity export --jsonl` remains the raw streaming feed. `metrics complexity --json` is a bounded
 interactive/top-N report over existing extracted facts.
+
+## Risk
+
+Command:
+
+```bash
+miller metrics risk --json [--range REV..REV] [--limit N] [--include-tests|--exclude-tests]
+```
+
+Deterministic churn×complexity ranking. A risk row exists only where churn evidence and complexity
+evidence intersect on the current index; churn-only rows stay in `metrics churn` and
+complexity-only rows stay in `metrics complexity`. Churn and complexity are joined over their full
+sets for the range BEFORE `--limit` is applied, so a low-churn/high-complexity symbol can outrank a
+high-churn/trivial one. `hotspots` remains an alias of `complexity` and is NOT this operation.
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `range` | string | Git revision range that was read. Defaults to `HEAD~20..HEAD`. |
+| `score_formula` | string | Always `commit_count * (decision_count + loop_count + max_nesting_depth)`. |
+| `mapping_note` | string | States the intersection semantics. |
+| `rows` | array | Rows ordered by score, changed lines, commit count, path, then symbol name. |
+
+Each row:
+
+| Field | Type | Description |
+|---|---|---|
+| `basis` | string | `symbol` when a symbol-mapped churn row joined complexity by `symbol_id`; `file` when a `file_only` churn row joined the path-level complexity aggregate. |
+| `symbol_id` / `symbol_name` / `symbol_kind` | string or null | Current symbol identity for `basis=symbol`; null for `basis=file`. |
+| `path` | string | Workspace-relative path. |
+| `line` | number or null | Current symbol line when mapped. |
+| `commit_count` | number | Distinct commits in the range touching the row. |
+| `changed_lines` | number | Added plus deleted lines touching the row. |
+| `last_commit_at_utc` | string | Latest commit timestamp in UTC. |
+| `decision_count` / `loop_count` | number | Summed over the joined complexity rows (one row for most symbols; the whole path for `basis=file`). |
+| `max_nesting_depth` | number | Maximum over the joined complexity rows. |
+| `severity` | string | `low`, `moderate`, or `high`, classified from the aggregated counters with the complexity thresholds above. |
+| `is_test` | boolean | True when any joined complexity row belongs to a test symbol. |
+| `score` | number | `commit_count * (decision_count + loop_count + max_nesting_depth)`. |
+
+Performance: cost is bounded by the git range (churn parse) plus one complexity read filtered to the
+churned paths. The default `HEAD~20..HEAD` range keeps this interactive; very large explicit ranges
+pay proportionally in git history parsing, not in complexity table scans. Non-git workspaces return
+the same command error as `metrics churn`.

--- a/docs/contracts/references-candidates-v1.md
+++ b/docs/contracts/references-candidates-v1.md
@@ -1,0 +1,248 @@
+# References Candidates Contract v1
+
+Status: experimental, evidence-gated. The evidence gate **PASSED 2026-07-07** (Miller repo: 392 → 5
+candidates, zero confirmed-live after julie-extract 2.10.0 `variable_ref` emission and the eleven
+suppression rules; see
+[`findings/2026-07-07-dead-code-candidates-dogfood.md`](../findings/2026-07-07-dead-code-candidates-dogfood.md),
+FINAL VERDICT). The surface is a **CLI-only prototype**: it is cleared to ship as
+`miller references candidates`, but it is **not** in `miller report`, the dashboard, or any MCP tool.
+Adding it to those surfaces requires explicit user approval (MCP-stinginess rule).
+
+`miller references candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]` lists
+deterministic dead-code *candidates* from one workspace's schema-v4 artifact: definition symbols that
+survived exclusion, showed no inbound evidence of use, and were not caught by any named suppression rule.
+
+**Posture: facts, not a verdict.** A candidate is a *fact to check*, never a deletion to make. Output pairs
+the candidate list with named-rule suppression counts, literal-scan coverage, and per-language resolver
+coverage so no consumer can mistake a list built on a *partial* resolver for a certainty grade. Miller owns
+this deterministic candidate listing with named suppressions; ranking beyond the deterministic rule,
+suppression **persistence**, history, and fleet/cross-workspace workflows stay out of Miller (Eros's, if it
+ships).
+
+## Invocation And Selectors
+
+The command is an operation on the existing `references` CLI verb (no new MCP tool). It accepts the normal
+read-command selectors:
+
+- `--workspace-id SELECTOR` — display ID, unique prefix, full workspace ID, registered root path, `current`,
+  or `primary`.
+- `--workspace DIR` — path alias, normalized before selection.
+- `--limit N` — bounds ONLY the candidate list (default 50). `examined`, `suppressions`, `literal_scan`, and
+  `language_coverage` always report full totals, never a limited subset.
+- `--json` — emit the JSON envelope below instead of compact text.
+
+A selector flag supplied without a value is a usage error (exit `2`).
+
+## Exit Codes
+
+Same process-level contract as `symbols export --jsonl` / `references export --jsonl`:
+
+- `0` — the payload is ingestable.
+- `2` — usage or selector error.
+- `3` — operational index failure: a missing index, or an incompatible artifact. A pre-v4 (schema 3)
+  artifact and a v4 artifact missing the required resolution tables both exit `3` with the standard rebuild
+  message (the Indexing reader validates the artifact and surfaces `IncompatibleExtractException`, mapped to
+  exit `3` like other artifact commands).
+
+## Candidate Rule (summary)
+
+A symbol is examined, then flagged as a candidate, iff ALL hold. See
+[`plans/2026-07-07-dead-code-candidates-design.md`](../plans/2026-07-07-dead-code-candidates-design.md) for
+the full logic.
+
+1. **Definition kind.** Kind is one of `function, method, class, struct, interface, enum, delegate,
+   property, constant`. Any other kind is excluded entirely — not examined, not suppressed. **Syntax-invoked
+   member shapes** are also excluded up front: names starting `~` (finalizers/destructors), containing
+   `this[` (indexers), starting `operator` / `op_` (operator overloads), and `Finalize`. These are invoked
+   by syntax, not by an identifier bearing their own name.
+2. **No inbound evidence.** All four inbound counts are zero: `name_matches` (same-name identifier outside
+   the symbol's own definition span), `resolved_inbound` (`identifier_resolutions` / `relationships` edges),
+   `pending_resolved_inbound` (`pending_resolutions` inbound), and `calls_inbound`. A symbol with any inbound
+   evidence is *alive-by-evidence* and is **silently dropped — that is not a suppression** (it is not counted
+   in `suppressions`). The rule is one-directional by construction: resolution and literal evidence can only
+   SAVE a symbol from being flagged, never add a flag. This preserves the conservative stance — collisions
+   hide dead code rather than flag live code.
+3. **No named suppression applies** (the eleven rules below).
+
+## Suppression Rules
+
+The reader applies the eleven rules in the exact TABLE ORDER below (`DeadCodeCandidates.SuppressionRuleIds`
+in `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:59` is the single source of the ids and their order).
+**First match wins** — a suppressed symbol increments exactly one rule's count. Every rule id is always
+present in the output, even at count 0.
+
+| # | Rule id | Suppresses when | Source |
+|---:|---|---|---|
+| 1 | `public_api` | visibility is `public` or `exported` (case-insensitive) — publicly reachable, cannot be judged dead from this workspace. | `symbols.visibility` |
+| 2 | `visibility_unknown` | visibility is NULL/blank — the extractor did not record visibility for this symbol/language, so public exposure cannot be ruled out. The honesty rule the live data forces. | `symbols.visibility` |
+| 3 | `test_symbol` | `is_test` on the symbol or any ancestor via `parent_symbol_id`, OR the path contains a whole `test` / `tests` / `__tests__` segment (whole-segment match — `src/protest/` does not fire). | `symbols.is_test` + path |
+| 4 | `entry_point` | name is `Main` / `main`, or the file is a `Program.cs`-style startup file. | `symbols.name` / `path` |
+| 5 | `override_member` | the signature carries an `override`-family modifier (C#/Kotlin/Swift/Scala `override`, VB `Overrides`; whole-word match). Invoked through a base contract, so zero inbound name/graph evidence is expected. Java's `@Override` is an annotation, covered by `annotated`. | `symbols.signature` |
+| 6 | `live_member_container` | a type-kind row (`class`/`struct`/`interface`/`enum`) whose own name shows no inbound evidence but at least one of its loaded candidate-kind members does — the classic static extension-class shape (`outcome.ToStorageString()`; the class name appears nowhere). The container is alive through its members. | computed over loaded rows |
+| 7 | `framework_bound` | the symbol (or an ancestor) is the `containing_symbol_id` of any `structural_facts` row — routes, handlers, bindings, DI registrations. Broad on purpose. | `structural_facts` |
+| 8 | `annotated` | the symbol carries any `symbol_annotations` row (attributes/decorators frequently mean reflection/framework discovery — `[Fact]`, `[JsonProperty]`, `@app.route`). | `symbol_annotations` |
+| 9 | `generated_path` | the path matches conservative generated/vendored globs: `obj/`, `bin/`, `node_modules/`, `wwwroot/lib/` (as a leading or `/`-prefixed segment), or a filename ending `.g.cs` / `.designer.cs` or containing `.generated.`. | `symbols.path` |
+| 10 | `low_evidence_language` | the symbol's language is present in coverage with **zero** identifier rows — nothing to test liveness against (e.g. css/html). A language ABSENT from coverage does NOT fire this rule; it can still be a candidate with the `name` evidence label. | computed |
+| 11 | `string_literal_match` | the symbol's name appears in workspace string-literal text — reflection/config/DI-by-name usage (`GetMethod("Foo")`, route strings, serialized member names). Implemented by scanning `string_literal` `source_regions` spans and re-reading only those spans from source under the `files.content_hash` freshness guard, over the surviving-candidate set only. Files whose content hash is stale are counted and reported as unscanned (`files_skipped_stale`), not silently skipped. | `source_regions` + source re-read |
+
+## Evidence Labels — Provenance, Not Certainty
+
+Each candidate carries an `evidence_label` that states **which evidence was consulted, never how certain the
+finding is.** There is no `strong`/`weak` grade — a certainty word over a partial resolver would read as
+deletion-grade confidence the data cannot deliver.
+
+- `name` — name-based liveness plus literal-scan found nothing, and the resolver was effectively blind for
+  this language (below 10% measured resolution coverage in this artifact).
+- `name+resolver` — the above AND the symbol's language has ≥ 10% measured resolution coverage in this
+  artifact, so resolver silence carries some additional weight.
+
+The 10% threshold is computed from the artifact at query time (resolved identifiers / identifiers per
+language) — never hardcoded, never a static language list. It is single-sourced with the `resolved_pct`
+rendered in `language_coverage` (`DeadCodeCandidates.ResolvedPercent`), so the label threshold and the
+reported percentage cannot drift apart.
+
+### Partial-resolver caveat (load-bearing)
+
+On every current real scan `reference_resolution_status = partial`: measured resolution coverage is ~15% for
+C#, lower for most languages. Therefore:
+
+- **Absence of a resolved inbound edge is weak evidence of death** (~85% of usage sites are unresolved).
+- **Presence of a resolved inbound edge is strong evidence of life** — which is why rule 2's inbound checks
+  only ever SAVE a symbol.
+
+Both the compact header and the JSON `artifact` object carry `reference_resolution_status` and
+`reference_resolution_version` verbatim so no consumer can mistake a candidate list built on a partial
+resolver for a verdict. The compact header states it in words:
+`resolver: partial — candidates are facts to check, not deletions to make.`
+
+### Write-only and comment-only symbols are facts to check, not verdicts
+
+The surface does not classify a candidate as "safe to delete." A candidate may be write-only (e.g. bash
+`IFS` in `while IFS= read` — set is consumed by the shell runtime, idiomatic rather than removable),
+comment-only, or invoked by a runtime/binding the extractor cannot see. These are exactly the cases the
+"fact to check, not a verdict" framing covers: the consumer confirms usage before acting. Miller does not
+emit a deletion recommendation.
+
+## Compact Output
+
+```
+candidates: <N> of <M> symbols examined · resolver: <status> — candidates are facts to check, not deletions to make.
+<name> <kind> <language> <path>:<line> <visibility> evidence=<label> [name_matches=0 resolved_in=0 pending_in=0 calls_in=0]
+...
+showing top <K> of <N> by path            # only when the candidate list is limited
+suppressed: public_api=… visibility_unknown=… test_symbol=… entry_point=… override_member=… live_member_container=… framework_bound=… annotated=… generated_path=… low_evidence_language=… string_literal_match=…
+literal_scan: files_scanned=… files_skipped_stale=…
+coverage: <lang>: <pct>% resolved; <lang>: <pct>% — name-evidence only; …
+```
+
+- Candidate lines are sorted by `(path, start_line)` with a stable `symbol_id` tiebreak, then the first
+  `--limit` are shown. `visibility` renders `unknown` when NULL.
+- The four per-candidate counts are definitionally all-zero (rule 2 requires it); they are printed for
+  transparency, not as signal.
+- `coverage` renders ` resolved` when `pct ≥ 10.0`, else ` — name-evidence only`, matching the evidence
+  label threshold.
+
+## `--json` Envelope
+
+A single JSON object with `schema_version: 1`.
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | number | Envelope schema version. Currently `1`. |
+| `candidates` | array | The shown candidates (bounded by `--limit`), sorted `(path, start_line, symbol_id)`. |
+| `candidates[].symbol_id` | string | Julie's stable symbol id. |
+| `candidates[].name` | string | Symbol name. |
+| `candidates[].kind` | string | Definition kind (one of the candidate kinds). |
+| `candidates[].language` | string | Source language. |
+| `candidates[].path` | string | Workspace-relative source path. |
+| `candidates[].start_line` | number | 1-based definition start line. |
+| `candidates[].visibility` | string or null | Symbol visibility; `null` when the extractor recorded none. |
+| `candidates[].evidence_label` | string | `name` or `name+resolver` — provenance, not certainty. |
+| `candidates[].evidence` | object | The four inbound-evidence counts (all `0` by construction). |
+| `candidates[].evidence.name_matches` | number | Same-name identifier occurrences outside the definition. |
+| `candidates[].evidence.resolved_inbound` | number | Resolved inbound edges (`identifier_resolutions` / `relationships`). |
+| `candidates[].evidence.pending_resolved_inbound` | number | Inbound `pending_resolutions` edges. |
+| `candidates[].evidence.calls_inbound` | number | Inbound call edges. |
+| `suppressions` | object | `{ rule_id: count }` for ALL eleven rule ids, in table order, always present (even at `0`). Full totals, never limited. |
+| `literal_scan` | object | Literal-scan coverage. |
+| `literal_scan.files_scanned` | number | Literal-bearing files re-read for `string_literal_match`. |
+| `literal_scan.files_skipped_stale` | number | Files skipped because their `content_hash` was stale (reported, not silently dropped). |
+| `language_coverage` | array | Per-language resolver coverage, computed at query time. |
+| `language_coverage[].language` | string | Source language. |
+| `language_coverage[].identifiers` | number | Identifier rows for this language in the artifact. |
+| `language_coverage[].resolved_pct` | number | Resolved identifiers / identifiers, 0–100, one decimal (`10.0`, not `0.1`). |
+| `examined` | number | Symbols that survived exclusion (candidate kinds, non-syntax-invoked). Full total. |
+| `artifact` | object | Artifact identity and resolver status. |
+| `artifact.artifact_id` | string or null | Current artifact identity from `artifact_metadata`. |
+| `artifact.revision` | number or null | Workspace revision for the artifact. |
+| `artifact.reference_resolution_status` | string | `partial` on all current real scans. |
+| `artifact.reference_resolution_version` | string or null | Resolver version recorded by the artifact. |
+
+### Example
+
+```json
+{
+  "schema_version": 1,
+  "candidates": [
+    {
+      "symbol_id": "sym_abc123",
+      "name": "SearchBackendMetadata",
+      "kind": "method",
+      "language": "csharp",
+      "path": "src/Miller.Server/Tools/SearchTool.cs",
+      "start_line": 436,
+      "visibility": "private",
+      "evidence_label": "name+resolver",
+      "evidence": {
+        "name_matches": 0,
+        "resolved_inbound": 0,
+        "pending_resolved_inbound": 0,
+        "calls_inbound": 0
+      }
+    }
+  ],
+  "suppressions": {
+    "public_api": 3357,
+    "visibility_unknown": 709,
+    "test_symbol": 0,
+    "entry_point": 3,
+    "override_member": 0,
+    "live_member_container": 0,
+    "framework_bound": 0,
+    "annotated": 6,
+    "generated_path": 0,
+    "low_evidence_language": 0,
+    "string_literal_match": 88
+  },
+  "literal_scan": { "files_scanned": 479, "files_skipped_stale": 0 },
+  "language_coverage": [
+    { "language": "csharp", "identifiers": 92952, "resolved_pct": 16.0 },
+    { "language": "razor", "identifiers": 4100, "resolved_pct": 2.1 }
+  ],
+  "examined": 9186,
+  "artifact": {
+    "artifact_id": "artifact-2026-07-07",
+    "revision": 42,
+    "reference_resolution_status": "partial",
+    "reference_resolution_version": "1"
+  }
+}
+```
+
+## Capabilities
+
+`miller capabilities --json` advertises the surface via three keys (verify with `capabilities --json`):
+
+- `optional_features.references_candidates: true` — boolean feature flag, same pattern as
+  `reference_aware_context`.
+- `json_commands` includes `references candidates --json`.
+- `json_contracts` includes `references_candidates` at schema version `1`, pointing at this doc
+  (`docs/contracts/references-candidates-v1.md`).
+
+## Boundary
+
+Miller owns the deterministic candidate listing and its named suppressions. It does **not** own: ranking
+beyond the deterministic rule, suppression **persistence** / ignore-lists / per-repo config, candidate
+history or trends, cross-workspace candidates, or any confidence/evidence ranking view — those require
+semantics or fleet state and stay out of Miller. Surfacing candidates in `miller report`, the dashboard, or
+an MCP tool is gated behind explicit user approval even though the CLI evidence gate has passed.

--- a/docs/contracts/references-export-v1.md
+++ b/docs/contracts/references-export-v1.md
@@ -3,9 +3,11 @@
 Status: active Eros-facing JSONL export contract.
 
 `miller references export --jsonl [--workspace-id SELECTOR] [--workspace DIR]` emits deterministic usage facts
-from one workspace's `identifiers` table. The export is a raw fact feed, not a dead-code verdict. Eros owns
-candidate ranking, generated/framework suppression, history, tasks, dashboards, and cross-workspace workflow
-state.
+from one workspace's `identifiers` table. The export is a raw fact feed, not a dead-code verdict. Per the
+2026-07-06 standalone-bolstering consensus, Miller owns the deterministic dead-code **candidate** listing with
+named suppressions — the CLI surface `miller references candidates` (see
+[`references-candidates-v1.md`](references-candidates-v1.md)). Ranking beyond the deterministic rule,
+suppression **persistence**, history, tasks, dashboards, and cross-workspace workflow state stay out of Miller.
 
 ## Ordering And Selectors
 

--- a/docs/contracts/report-json-v1.md
+++ b/docs/contracts/report-json-v1.md
@@ -1,0 +1,90 @@
+# Report JSON contract v1
+
+Status: active additive contract for the CLI-only `miller report --json` command.
+
+`miller report` is one composed repo-quality rollup over facts Miller already extracts for the
+selected workspace. It is pure composition: no new extraction, no semantic ranking, no cleanup
+recommendations, no suppressions, and no fleet history. There is deliberately **no dead-code
+section**: reference resolution in current artifacts is not strong enough to support one (see the
+2026-07-06 standalone bolstering assessment); it will be added only when candidate quality earns it.
+
+## Command
+
+```bash
+miller report --json [--workspace-id SELECTOR] [--workspace DIR] [--range REV..REV] [--limit N] [--include-tests|--exclude-tests]
+```
+
+- `--range` feeds the churn and risk sections. Defaults to `HEAD~20..HEAD`.
+- `--limit` is the per-section top-N (default 10, max 100).
+- Exit codes match other read commands: `0` renderable report, `2` usage/selector errors,
+  `3` operational index failures.
+
+## Envelope
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | number | Contract version. Currently `1`. |
+| `operation` | string | Always `report`. |
+| `range` | string | Git range used by churn/risk sections. |
+| `section_limit` | number | Applied per-section top-N. |
+
+Every section object carries `available` (boolean). An unavailable section carries a human-readable
+`reason` and omits its data fields; the report itself still exits `0`. Consumers must ignore
+sections and fields they do not recognize — the contract is additive.
+
+## Sections
+
+### `index`
+
+| Field | Type | Description |
+|---|---|---|
+| `symbols` | number | Named symbol rows in the artifact. |
+| `files` | number | Distinct symbol-bearing paths. |
+| `languages` | number | Distinct languages. |
+
+### `extraction_health`
+
+| Field | Type | Description |
+|---|---|---|
+| `parse_diagnostic_count` | number | Total extractor parse diagnostics. |
+| `capability_gap_count` | number | Total open capability gaps. |
+
+### `markers`
+
+Marker counts ride the region search sidecar; when the sidecar is disabled or `search.db` cannot be
+opened the section is unavailable with a reason.
+
+| Field | Type | Description |
+|---|---|---|
+| `bounded_at` | number | Region fetch bound; counts saturate here. |
+| `truncated` | boolean | True when the total hit the bound. |
+| `counts` | array | `{marker, count}` for `TODO`, `FIXME`, `HACK`, `XXX`. A region matching several markers counts once per marker. |
+| `total` | number | Distinct marker regions found (bounded). |
+
+### `complexity`
+
+Top-N complexity hotspots at `min_severity=moderate`, same ordering as `metrics complexity`. Each
+hotspot: `severity`, `path`, `symbol_name`, `decision_count`, `loop_count`, `max_nesting_depth`,
+`start_line`, `is_test`.
+
+### `clones`
+
+Top-N body-hash clone groups, same ordering as `metrics clones`. Each group: `body_hash`, `count`,
+and a `sample` of up to 3 `{path, line, name}` symbols.
+
+### `churn`
+
+Top-N churn rows for `range`, same semantics as `metrics churn` (`mapping_basis`, `symbol_name`,
+`path`, `line`, `commit_count`, `changed_lines`). Unavailable with a reason on non-git workspaces.
+
+### `risk`
+
+Top-N churn×complexity risk rows for `range`, same semantics and `score_formula` as `metrics risk`
+(see `docs/contracts/metrics-json-v1.md`). Unavailable with a reason on non-git workspaces. The
+underlying git history is parsed once and shared with the churn section.
+
+## Performance
+
+Cost is one bounded SQLite read per non-git section plus a single git history parse for
+churn+risk. The default `HEAD~20..HEAD` range keeps the report interactive; large explicit ranges
+pay proportionally in git history parsing.

--- a/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
+++ b/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
@@ -1,0 +1,696 @@
+# Dead-code candidates dogfood — evidence gate (Task 5)
+
+**Date:** 2026-07-07 · **Status:** ❌ **GATE FAILED — do not surface `references candidates`** ·
+**Feature under test:** `miller references candidates [--json]` (design
+`docs/plans/2026-07-07-dead-code-candidates-design.md` rev 2) ·
+**Binary:** `1.4.5+1fe27ca2f833` (Release) · **Extractor:** `julie-extract 2.9.0` (schema v4,
+`reference_resolution_status=partial`, `reference_resolution_version=1`)
+
+## Verdict
+
+**The evidence gate FAILS.** The design's hard gate is *zero confirmed-live symbols among Miller-repo
+candidates*. The Miller repo produced **392 candidates, of which ≈388 (99%) are confirmed live** — real,
+referenced production symbols — and only **≈4 are plausibly dead**. Precision ≈ **1%**. This is not a
+short, high-signal list; it is dominated by false positives.
+
+The failure is **not** a bug in the Task 1–3 implementation. The code faithfully implements the design.
+The design's **rule 2 (name-based liveness)** rests on an assumption about julie-extract's `identifiers`
+table that does not hold for C# (or Rust): **the extractor keys a reference identifier by the *terminal*
+token of the reference, not by the referenced symbol's own name.** So a symbol used only as
+`TypeName.Member(...)`, as a bare `const` inside an expression/collection, or as an extension-method
+receiver has **zero** `identifiers` rows carrying its name and is falsely flagged. See
+[Root cause](#root-cause) for the decisive evidence.
+
+Per the Task 5 brief this is a **stop-and-report gate**, not a fix lane. The findings below are recorded;
+no "success" commit is made; the false positives are reported to the lead as a design/data mismatch. The
+lead owns any corrective dispatch against Core/Indexing/CLI. Task 5 edits no code.
+
+---
+
+## Headline numbers
+
+| Repo | Examined | Candidates | Confirmed live (false positive) | Plausibly dead (correct) | Precision | CLI wall-clock (compact / --json) |
+|------|---------:|-----------:|--------------------------------:|-------------------------:|----------:|-----------------------------------|
+| **miller** (`/Users/murphy/source/miller`) | 9,186 | **392** | **≈388** | ≈4 | **≈1.0%** | **4.80 s** / 3.71 s |
+| **julie-extractors** (`/Users/murphy/source/julie-extractors`) | 11,267 | **653** | **≈627+** | ≈0 (26 "maybe-dead" are QML runtime handlers + 2 test helpers) | **≈0%** | **5.64 s** / 5.77 s |
+
+CLI performance is **acceptable** and does **not** fail the gate: the reader's 4 indexed subqueries per
+candidate-kind symbol complete in ~5 s on the real ~38.9k-symbol Miller artifact (38,927 symbols total;
+9,186 of candidate kinds examined) and the ~122k-symbol julie-extractors artifact. Wall-clock is a
+report-only metric; it is fine. `files_skipped_stale=0` in both runs (fresh scans, no stale content
+hashes).
+
+---
+
+## Reproduction recipe (live-artifact-safe)
+
+Both live repos and the user-scope registry were left untouched. Everything ran against throwaway
+`git clone --local` copies scanned into `<copy>/.miller/symbols.db`, with the copy as cwd so
+`WorkspaceContext` resolves `<cwd>/.miller/symbols.db` — no registry entry, no live-state contact.
+
+```
+scratch=$(mktemp -d)                       # /private/tmp/dogfood-dead-code.d7Yk9N (deleted at end)
+git clone --local /Users/murphy/source/miller           $scratch/miller
+git clone --local /Users/murphy/source/julie-extractors $scratch/julie-extractors
+# per repo:
+mkdir -p $scratch/<name>/.miller
+/Users/murphy/source/miller/.tools/julie-extract scan \
+    --root $scratch/<name> --db $scratch/<name>/.miller/symbols.db
+cd $scratch/<name> && \
+    /Users/murphy/source/miller/src/Miller.Server/bin/Release/net10.0/miller \
+    references candidates [--json] [--limit N]
+rm -rf $scratch                            # cleanup
+```
+
+Extractor scan times (context only, not the metric under test): miller ≈ 4 m 08 s; julie-extractors ≈ 6 m 60 s.
+Artifact metadata (both): `schema_version=4`, `binary_version=2.9.0`, `hash_algorithm=blake3`,
+`reference_resolution_status=partial`, `reference_resolution_version=1`.
+
+**Hand-verification method.** Miller's own `search`/`inspect` MCP tools were not used (stale sidecar).
+Every Miller-repo candidate was cross-referenced against the clone's source with a word-boundary,
+binary-safe `rg -w -a` sweep across all code files, excluding only the candidate's own definition line and
+excluding non-code hits (`*.md`, `docs/`, `.memories/`). A candidate with any code reference outside its
+definition is **confirmed live**. The 6 that survived that automated sweep were then inspected by hand
+(read source + targeted `grep -a`) and classified individually. This IS the gate's hand-verification: it
+reads real references, not Miller's index.
+
+---
+
+## Miller repo — full results
+
+Compact header:
+
+```
+candidates: 392 of 9186 symbols examined · resolver: partial — candidates are facts to check, not deletions to make.
+```
+
+Suppression counts (all nine rule ids):
+
+```
+suppressed: public_api=3357 visibility_unknown=709 test_symbol=0 entry_point=3 framework_bound=0
+            annotated=6 generated_path=0 low_evidence_language=0 string_literal_match=88
+literal_scan: files_scanned=479 files_skipped_stale=0
+```
+
+Per-language coverage (resolved identifiers / identifiers, computed at query time):
+
+```
+bash: 5.5% — name-evidence only;   csharp: 16.0% resolved;   css: 0.0% — name-evidence only;
+html: 0.0% — name-evidence only;   javascript: 10.1% resolved;   json: 0.0% — name-evidence only;
+markdown: 0.0% — name-evidence only;   powershell: 4.2% — name-evidence only;   python: 14.1% resolved;
+razor: 2.1% — name-evidence only;   yaml: 0.0% — name-evidence only
+```
+
+Candidate composition: by kind — constant 288, method 38, class 38, property 26, enum 1, function 1. By
+language — csharp 368, razor 23, bash 1. By evidence label — `name+resolver` 368, `name` 24. By visibility
+— private 390, protected 2. **Every candidate has evidence counts `[name_matches=0 resolved_in=0
+pending_in=0 calls_in=0]`** — that is definitional (rules 2 + 3 require all four to be zero), so the
+per-candidate counts add no information; the `example reference` column in Appendix A is the real signal.
+
+### Precision summary (hand-verified)
+
+| Verdict | Count | Meaning |
+|---------|------:|---------|
+| confirmed-live — cross-file reference | **101** | Symbol name used in code in a *different* file. Unambiguously alive. |
+| confirmed-live — same-file reference | **285** | Symbol name used elsewhere in its own file (other class member / method body). Alive. |
+| plausibly dead / correct find | **4** | Genuinely unreferenced private/internal member — the tool's true positives. |
+| syntax/runtime-invoked (live but name never recurs) | **2** | `IFS` (bash builtin), `TelemetryOutcomeExtensions` (extension-method container). |
+| **Total** | **392** | |
+
+Confirmed-live: 101 + 285 + 2 = **388**. Gate requires 0. **FAIL.**
+
+### The 6 candidates that survived the automated sweep (hand-inspected)
+
+| Candidate | path:line | Real status | Evidence |
+|-----------|-----------|-------------|----------|
+| `IFS` (constant, bash) | `scripts/release-promote.sh:167` | **live (false positive)** | Bash special variable, `while IFS= read -r -d ''`. Extractor captured a shell builtin as a `constant` symbol; it actively controls `read`. |
+| `TelemetryOutcomeExtensions` (class) | `src/Miller.Server/Telemetry/TelemetryOutcome.cs:20` | **live (false positive)** | Extension-method container. Its method `ToStorageString` is called at `TelemetryScope.cs:274`, `TelemetryCallToolFilter.cs:249,256`. The class name never appears at call sites — a structural blind spot for name-based liveness. |
+| `RegionBackendMetadata` (internal const) | `src/Miller.Server/Tools/SearchTool.cs:431` | **plausibly dead (correct)** | `internal const string`; the only repo-wide occurrence is its declaration. Declared alongside `DiskBackendMetadata`/`MemoryBackendMetadata` but never wired into `SearchBackendMetadata`. |
+| `TextContentBackendMetadata` (internal const) | `src/Miller.Server/Tools/SearchTool.cs:434` | **plausibly dead (correct)** | Same as above — declared, never referenced. |
+| `SearchBackendMetadata` (private method) | `src/Miller.Server/Tools/SearchTool.cs:436` | **plausibly dead (correct)** | `private static string SearchBackendMetadata(...)`; no call site in code (one mention in a `.memories/*.md` note only). Unused private method. |
+| `UnknownWorkspaceIdNote` (private method) | `src/Miller.Server/Tools/WorkspaceTool.cs:968` | **plausibly dead (correct)** | `private static string`; only occurrence repo-wide is its declaration. Unused private method. |
+
+> **Tooling caveat, not a product finding:** the file `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs`
+> contains 2 embedded NUL bytes, so `file`/`grep`/`rg` classify it as *binary* and skip it by default. An
+> initial (non-`-a`) sweep therefore mis-listed its 6 route-table constants (`ConventionalActions`,
+> `CollectionRoutes`, `SingularRoutes`, `LaravelResourceRoutes`, `LaravelApiResourceRoutes`,
+> `PhoenixResourceRoutes`) as "maybe-dead". The binary-safe (`rg -a`) re-sweep confirmed all six are used
+> in-file (e.g. `CollectionRoutes` at line 608, `ConventionalActions` at 815/822) — **live**. The final
+> numbers above use the binary-safe sweep. (The NUL bytes are a pre-existing quirk of the Miller source,
+> unrelated to this feature.)
+
+### Representative confirmed-live false positives (deep-dived)
+
+All of these are `private`/`protected`, `evidence=name+resolver`, and were flagged with `name_matches=0`
+because their name never appears in the `identifiers` table:
+
+| Candidate | Flagged at | Actually referenced at | Reference form |
+|-----------|-----------|------------------------|----------------|
+| `GraphTraversal` (class) | `Graph/GraphTraversal.cs:3` | `SqliteSymbolGraphIndex.cs:40,43`, `SymbolGraph.cs:171,187` | `GraphTraversal.Reach(...)` — static-class access (6 refs) |
+| `StructuralRouteFactAdapter` (class) | `Graph/StructuralRouteFactAdapter.cs:6` | `DotnetWebBridgeProvider.cs:255,256,297,…` (45 refs) | `StructuralRouteFactAdapter.MetadataString(...)` — static access |
+| `VisibilityUnknown` (const) | `DeadCode/DeadCodeCandidates.cs:34` | `DeadCodeCandidates.cs:59,205` | bare `const` inside a collection expression / return |
+| `IsCSharpUserType` (method) | `Graph/DotnetWebBridgeProvider.cs:716` | `DotnetWebBridgeProvider.cs:66` | `.Where(IsCSharpUserType)` — method-group argument |
+| `AspNetMinimalApiRoutePattern` (const) | `Graph/DotnetWebBridgeProvider.cs:14` | `DotnetWebBridgeProvider.cs:252` | `string.Equals(fact.PatternId, AspNetMinimalApiRoutePattern, …)` |
+| `ContextLines` (const) | `Editing/UnifiedDiff.cs:15` | `UnifiedDiff.cs:153,169` (+ doc-comment refs) | arithmetic use inside methods |
+
+---
+
+## Root cause
+
+The `identifiers` table on the live v4 Miller artifact holds **94,700 rows across only three kinds** —
+`call` (52,495), `member_access` (26,253), `type_usage` (15,952) — spanning **5,373 distinct names**. A
+reference is stored keyed by the **terminal token**, not by the referenced symbol's declared name:
+
+```
+-- GraphTraversal.Reach(...)  →  identifier name = 'Reach', kind = 'call'
+sqlite> SELECT name, kind, start_line FROM identifiers WHERE name='Reach' LIMIT 3;
+Reach|call|171
+Reach|call|40
+Reach|call|330
+-- The receiver/type name is NOT stored in identifiers.name:
+sqlite> SELECT COUNT(*) FROM identifiers WHERE name='GraphTraversal';       -- 0
+sqlite> SELECT COUNT(*) FROM identifiers WHERE name='VisibilityUnknown';    -- 0
+sqlite> SELECT COUNT(*) FROM identifiers WHERE name='StructuralRouteFactAdapter'; -- 0
+sqlite> SELECT COUNT(*) FROM identifiers WHERE name='IsCSharpUserType';     -- 0
+```
+
+Design rule 2 declares a symbol name-dead when *"no row in `identifiers` has `name = S.name` outside S's
+own definition."* But for the reference forms that dominate C# — and Rust (`Type::method()`,
+`path::to::CONST`) — the referenced symbol's own name is **never** the identifier's `name`:
+
+- **Static-class / type access** (`X.Foo()`, `X.Bar`, `X::y`) → identifier `name='Foo'/'Bar'/'y'`, never `X`.
+  Kills every helper class used statically (`GraphTraversal`, `StructuralRouteFactAdapter`,
+  `JulieSchemaGate`, …) and every route-pattern/config `const` compared by value.
+- **Bare `const`/field in an expression or collection literal** (`[ …, VisibilityUnknown, … ]`) →
+  frequently **no** identifier row at all.
+- **Extension-method receiver** (`x.ToStorageString()`) → the container class name never recurs.
+
+The v4 resolver overlay cannot rescue these: measured resolution coverage is **15–16% for C#** (design's
+own load-bearing measurement), so `identifier_resolutions` / `pending_resolutions` are silent for ~85% of
+real edges. Rule 3 (resolved/pending/calls inbound) is correctly one-directional — it can only *save* a
+symbol — so it does not compensate for rule 2's blind spot; it just leaves the false positive standing.
+
+**Net:** rule 2 is not a name-liveness test on this data; it is a *"is this symbol the terminal token of
+some reference"* test, which almost no type, static helper, `const`, or extension class satisfies. The
+design's expectation — *"non-public C# symbols with zero name matches are rare in a heavily-tested
+codebase"* — is contradicted by the artifact: they are the common case.
+
+---
+
+## julie-extractors repo — results (summarized)
+
+Compact header:
+
+```
+candidates: 653 of 11267 symbols examined · resolver: partial — candidates are facts to check, not deletions to make.
+```
+
+```
+suppressed: public_api=343 visibility_unknown=701 test_symbol=3157 entry_point=0 framework_bound=52
+            annotated=4 generated_path=0 low_evidence_language=0 string_literal_match=51
+literal_scan: files_scanned=1222 files_skipped_stale=0
+```
+
+Coverage spans ~37 languages (bash 10.5%, c 57.1%, cpp 70.0%, csharp 9.3% name-only, go 30.8%, java 20.5%,
+python 19.2%, rust 16.0%, swift 41.2%, vbnet 71.4%, zig 69.2%, … css/html/json/sql/toml/yaml 0.0%
+name-only). Candidate composition: rust 621, qml 32; by kind constant 459, function 174, property 20.
+Here `test_symbol` (3,157) did the heavy suppression lifting rather than `public_api`.
+
+Automated cross-reference sweep of all 653 candidates: **194 cross-file live, 433 same-file live, 26
+"maybe-dead"**. The 26 (Appendix B) are **not** genuine dead code either: 24 are QML declarative signal
+handlers / `Action` properties (`onDrop`, `onXChanged`, `onDragMove`, `quitAction`, …) invoked by the QML
+runtime by binding, and 2 are Rust test debug helpers in `src/tests/r/`. So julie-extractors is **~653
+false positives, ~0 true dead code** — the same failure mode, driven by Rust's `Type::method` / path-const
+reference forms.
+
+---
+
+## `visibility_unknown` honesty rule
+
+The design forecast `visibility_unknown` would dominate. On these two artifacts it did **not** — it fired
+709 (miller) / 701 (julie-extractors) times, well behind `public_api` (3,357, miller) and `test_symbol`
+(3,157, julie-extractors). It is doing useful work but is not the load-bearing suppressor. That is a minor
+observation; it does not change the verdict. The dominant problem is upstream of suppression: rule 2 admits
+hundreds of live symbols as candidates before any suppression rule runs.
+
+---
+
+## Recommendation to the lead (design/data mismatch — not an implementation bug)
+
+The gate blocks surfacing `references candidates` in `miller report`, the dashboard, README, or agent
+guidance — as designed. Options for the corrective dispatch (all touch Core/Indexing, which Task 5 does not
+own):
+
+1. **Strengthen name-liveness to match the extractor's identifier model.** Rule 2 must treat a symbol as
+   alive when its name appears as the *receiver/qualifier* of a `member_access`/`call`/`type_usage`
+   identifier, not only as the identifier's terminal `name`. The receiver text is available in
+   `identifiers.code_context` (and `metadata_json`); alternatively julie-extractors could emit a
+   receiver/qualifier column. Until name-liveness sees `X` in `X.Foo()`, the rule cannot work for C#/Rust.
+2. **Require resolved-edge coverage the design does not yet have.** At 15–16% C# resolution the resolver
+   cannot carry liveness; candidacy on `name+resolver` languages is still ~99% false. Gating candidacy on
+   *presence of a resolvable reference model per language* (not just ≥10% for the evidence *label*) would
+   shrink the surface honestly.
+3. **Keep the feature CLI-only and undocumented** (design's stated fallback for a noisy list) until (1) or
+   (2) lands and this gate is re-run green.
+
+This is a plan/design mismatch: the shipped code matches the plan; the plan's rule 2 does not match
+julie-extract 2.9.0's `identifiers` semantics. Re-run this gate after a fix.
+
+---
+
+## Appendix A — full Miller candidate list (392, hand-verified)
+
+Sorted by path then line. `verdict` is the hand-verification result; `example reference` is one real code
+reference outside the definition (for live rows). All rows have `[name_matches=0 resolved_in=0 pending_in=0
+calls_in=0]` by construction (omitted). "see manual notes" rows are detailed in
+[the 6-candidate table above](#the-6-candidates-that-survived-the-automated-sweep-hand-inspected).
+
+| # | name | kind | lang | evidence | path:line | verdict | example reference |
+|--:|------|------|------|----------|-----------|---------|-------------------|
+| 1 | `IFS` | constant | bash | name | `scripts/release-promote.sh:167` | **see manual notes** | — |
+| 2 | `CamelRx` | constant | csharp | name+resolver | `spike/Codesearch.Spike/CodeTokenizer.cs:78` | confirmed-live (same-file) | `spike/Codesearch.Spike/CodeTokenizer.cs:89` |
+| 3 | `VisibilityUnknown` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:34` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:59` |
+| 4 | `EntryPoint` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:36` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:59` |
+| 5 | `FrameworkBound` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:37` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:59` |
+| 6 | `Annotated` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:38` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:60` |
+| 7 | `GeneratedPath` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:39` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:60` |
+| 8 | `LowEvidenceLanguage` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:40` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:60` |
+| 9 | `StringLiteralMatch` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:41` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:60` |
+| 10 | `ExportedVisibilities` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:64` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:201` |
+| 11 | `GeneratedSegments` | constant | csharp | name+resolver | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:68` | confirmed-live (same-file) | `src/Miller.Core/DeadCode/DeadCodeCandidates.cs:246` |
+| 12 | `ContextLines` | constant | csharp | name+resolver | `src/Miller.Core/Editing/UnifiedDiff.cs:15` | confirmed-live (same-file) | `src/Miller.Core/Editing/UnifiedDiff.cs:10` |
+| 13 | `ConventionalActions` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:470` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:815` |
+| 14 | `CollectionRoutes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:476` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:608` |
+| 15 | `SingularRoutes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:489` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:608` |
+| 16 | `LaravelResourceRoutes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:503` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:637` |
+| 17 | `LaravelApiResourceRoutes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:517` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:638` |
+| 18 | `PhoenixResourceRoutes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:530` | confirmed-live (same-file) | `src/Miller.Core/Graph/BackendHttpBridgeProvider.cs:686` |
+| 19 | `NoEdges` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BridgeGraph.cs:74` | confirmed-live (same-file) | `src/Miller.Core/Graph/BridgeGraph.cs:262` |
+| 20 | `NoProviders` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BridgeGraph.cs:75` | confirmed-live (same-file) | `src/Miller.Core/Graph/BridgeGraph.cs:116` |
+| 21 | `NoProvenance` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BridgeGraph.cs:76` | confirmed-live (same-file) | `src/Miller.Core/Graph/BridgeGraph.cs:186` |
+| 22 | `DefaultProviders` | constant | csharp | name+resolver | `src/Miller.Core/Graph/BridgeGraphBuilder.cs:23` | confirmed-live (cross-file) | `src/Miller.Indexing/BridgeProviderSelection.cs:8` |
+| 23 | `AspNetMinimalApiRoutePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:14` | confirmed-live (same-file) | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:252` |
+| 24 | `AspNetAttributeRoutePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:15` | confirmed-live (same-file) | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:294` |
+| 25 | `IsCSharpUserType` | method | csharp | name+resolver | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:716` | confirmed-live (same-file) | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:66` |
+| 26 | `HttpVerbKeys` | constant | csharp | name+resolver | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:729` | confirmed-live (same-file) | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:736` |
+| 27 | `BodyBearingVerbKeys` | constant | csharp | name+resolver | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:744` | confirmed-live (same-file) | `src/Miller.Core/Graph/DotnetWebBridgeProvider.cs:748` |
+| 28 | `GraphTraversal` | class | csharp | name+resolver | `src/Miller.Core/Graph/GraphTraversal.cs:3` | confirmed-live (cross-file) | `src/Miller.Indexing/SqliteSymbolGraphIndex.cs:40` |
+| 29 | `EmptyObservationNodes` | constant | csharp | name+resolver | `src/Miller.Core/Graph/IBridgeProvider.cs:47` | confirmed-live (same-file) | `src/Miller.Core/Graph/IBridgeProvider.cs:40` |
+| 30 | `VueRouteDefinitionPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:10` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:279` |
+| 31 | `ReactRouteReferencePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:11` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:274` |
+| 32 | `ReactRouteDefinitionPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:12` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:280` |
+| 33 | `NextJsRouteReferencePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:13` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:275` |
+| 34 | `NextJsFileRoutePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:14` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:281` |
+| 35 | `NuxtRouteReferencePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:15` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:276` |
+| 36 | `NuxtFileRoutePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:16` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:282` |
+| 37 | `HttpClientRequestPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:17` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:106` |
+| 38 | `NextJsRouteHandlerPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:18` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:285` |
+| 39 | `NuxtServerRoutePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:19` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:286` |
+| 40 | `SpringRequestMappingPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:20` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:195` |
+| 41 | `ExpressRouterMountPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:21` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:294` |
+| 42 | `FastApiIncludeRouterPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:22` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:295` |
+| 43 | `FlaskBlueprintRegistrationPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:23` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:296` |
+| 44 | `DjangoUrlIncludePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:24` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:297` |
+| 45 | `AxumNestPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:26` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:301` |
+| 46 | `ActixMountPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:27` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:302` |
+| 47 | `PhoenixForwardPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:28` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:303` |
+| 48 | `LaravelRoutePrefixPattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:29` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:304` |
+| 49 | `StructuralRouteFactAdapter` | class | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:6` | confirmed-live (cross-file) | `src/Miller.Core/Resolver/RouteBridge.cs:231` |
+| 50 | `HtmxAttributePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:8` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:44` |
+| 51 | `VueRouteReferencePattern` | constant | csharp | name+resolver | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:9` | confirmed-live (same-file) | `src/Miller.Core/Graph/StructuralRouteFactAdapter.cs:273` |
+| 52 | `HighBase` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:56` | confirmed-live (same-file) | `src/Miller.Core/Resolver/BridgeScorer.cs:165` |
+| 53 | `HighCeiling` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:57` | confirmed-live (same-file) | `src/Miller.Core/Resolver/BridgeScorer.cs:165` |
+| 54 | `MediumBase` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:58` | confirmed-live (same-file) | `src/Miller.Core/Resolver/BridgeScorer.cs:166` |
+| 55 | `MediumCeiling` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:59` | confirmed-live (same-file) | `src/Miller.Core/Resolver/BridgeScorer.cs:166` |
+| 56 | `CorroboratorStep` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:60` | confirmed-live (same-file) | `src/Miller.Core/Resolver/BridgeScorer.cs:169` |
+| 57 | `MinAnchoringFieldCount` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/BridgeScorer.cs:64` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:1181` |
+| 58 | `Wrappers` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/FieldSetExtractor.cs:22` | confirmed-live (same-file) | `src/Miller.Core/Resolver/FieldSetExtractor.cs:36` |
+| 59 | `ParamModifiers` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/FieldSetExtractor.cs:249` | confirmed-live (same-file) | `src/Miller.Core/Resolver/FieldSetExtractor.cs:258` |
+| 60 | `MemberModifiers` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/FieldSetExtractor.cs:252` | confirmed-live (same-file) | `src/Miller.Core/Resolver/FieldSetExtractor.cs:170` |
+| 61 | `BareNonTypes` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/FieldSetExtractor.cs:37` | confirmed-live (same-file) | `src/Miller.Core/Resolver/FieldSetExtractor.cs:103` |
+| 62 | `FileRouteBridge` | class | csharp | name+resolver | `src/Miller.Core/Resolver/FileRouteBridge.cs:8` | confirmed-live (cross-file) | `src/Miller.Core/Graph/FileRouteBridgeProvider.cs:69` |
+| 63 | `Suffixes` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/NameNormalizer.cs:18` | confirmed-live (same-file) | `src/Miller.Core/Resolver/NameNormalizer.cs:59` |
+| 64 | `HttpVerbs` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/RouteNormalizer.cs:31` | confirmed-live (same-file) | `src/Miller.Core/Resolver/RouteNormalizer.cs:119` |
+| 65 | `ParamPattern` | constant | csharp | name+resolver | `src/Miller.Core/Resolver/RouteNormalizer.cs:41` | confirmed-live (same-file) | `src/Miller.Core/Resolver/RouteNormalizer.cs:186` |
+| 66 | `TokenPhraseBoost` | constant | csharp | name+resolver | `src/Miller.Core/Search/ContentSearchIndex.cs:21` | confirmed-live (cross-file) | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:12` |
+| 67 | `WindowRadius` | constant | csharp | name+resolver | `src/Miller.Core/Search/ContentSearchIndex.cs:24` | confirmed-live (same-file) | `src/Miller.Core/Search/ContentSearchIndex.cs:110` |
+| 68 | `CoverageStopWords` | constant | csharp | name+resolver | `src/Miller.Core/Search/TextSearchQueryPlan.cs:8` | confirmed-live (same-file) | `src/Miller.Core/Search/TextSearchQueryPlan.cs:72` |
+| 69 | `MachineWide` | property | razor | name | `src/Miller.Dashboard/Components/ActivityFeedPanel.razor:86` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/ActivityFeedPanel.razor:33` |
+| 70 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/ActivityFeedPanel.razor:88` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 71 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:75` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 72 | `MaxSavedBytes` | property | razor | name | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:79` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:82` |
+| 73 | `ToolWidth` | method | razor | name | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:81` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:56` |
+| 74 | `EffectiveActivity` | property | razor | name | `src/Miller.Dashboard/Components/DashboardContent.razor:11` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspacesShell.razor:46` |
+| 75 | `HealthStateClass` | method | razor | name | `src/Miller.Dashboard/Components/PatternInventoryPanel.razor:51` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:11` |
+| 76 | `AllWorkspaces` | property | razor | name | `src/Miller.Dashboard/Components/TelemetryPanel.razor:144` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/TelemetryPanel.razor:27` |
+| 77 | `WindowLabel` | property | razor | name | `src/Miller.Dashboard/Components/TelemetryPanel.razor:146` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/TelemetryPanel.razor:12` |
+| 78 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:211` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 79 | `MaxLanguageFiles` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:215` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:221` |
+| 80 | `MaxSymbolKindCount` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:217` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:224` |
+| 81 | `LanguageWidth` | method | razor | name | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:220` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:165` |
+| 82 | `KindWidth` | method | razor | name | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:223` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceDetailPanel.razor:191` |
+| 83 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:103` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/ContextSavingsPanel.razor:7` |
+| 84 | `HealthStateClass` | method | razor | name | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:107` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/PatternInventoryPanel.razor:11` |
+| 85 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceLocalMetricsPanel.razor:90` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 86 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceOnboardingPanel.razor:132` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 87 | `EffectiveActivity` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceShell.razor:58` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/DashboardContent.razor:4` |
+| 88 | `Heading` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceShell.razor:61` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceShell.razor:14` |
+| 89 | `Subtitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceShell.razor:66` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/WorkspaceHealthPanel.razor:7` |
+| 90 | `PageTitle` | property | razor | name | `src/Miller.Dashboard/Components/WorkspaceShell.razor:71` | confirmed-live (same-file) | `src/Miller.Dashboard/Components/WorkspaceShell.razor:6` |
+| 91 | `EffectiveActivity` | property | razor | name | `src/Miller.Dashboard/Components/WorkspacesShell.razor:70` | confirmed-live (cross-file) | `src/Miller.Dashboard/Components/DashboardContent.razor:4` |
+| 92 | `JsonContext` | constant | csharp | name+resolver | `src/Miller.Dashboard/DashboardData.cs:329` | confirmed-live (same-file) | `src/Miller.Dashboard/DashboardData.cs:365` |
+| 93 | `DefaultTtl` | constant | csharp | name+resolver | `src/Miller.Dashboard/DashboardIndexFactsCache.cs:15` | confirmed-live (same-file) | `src/Miller.Dashboard/DashboardIndexFactsCache.cs:23` |
+| 94 | `ContentSidecar` | constant | csharp | name+resolver | `src/Miller.Dashboard/DashboardIndexFactsReader.cs:9` | confirmed-live (same-file) | `src/Miller.Dashboard/DashboardIndexFactsReader.cs:269` |
+| 95 | `BridgeProviderSelection` | class | csharp | name+resolver | `src/Miller.Indexing/BridgeProviderSelection.cs:6` | confirmed-live (cross-file) | `src/Miller.Indexing/RepositoryIndexLoader.cs:79` |
+| 96 | `DefaultProviders` | constant | csharp | name+resolver | `src/Miller.Indexing/BridgeProviderSelection.cs:8` | confirmed-live (cross-file) | `src/Miller.Core/Graph/BridgeGraphBuilder.cs:23` |
+| 97 | `StrictUtf8` | constant | csharp | name+resolver | `src/Miller.Indexing/ContentCorpusExternalStore.cs:15` | confirmed-live (cross-file) | `src/Miller.Indexing/SourceTextDecoder.cs:7` |
+| 98 | `MaxWorkspaceFileBytes` | constant | csharp | name+resolver | `src/Miller.Indexing/ContentCorpusWriter.cs:10` | confirmed-live (same-file) | `src/Miller.Indexing/ContentCorpusWriter.cs:263` |
+| 99 | `ProseExtensions` | constant | csharp | name+resolver | `src/Miller.Indexing/ContentFileClassifier.cs:11` | confirmed-live (same-file) | `src/Miller.Indexing/ContentFileClassifier.cs:43` |
+| 100 | `ConfigExtensions` | constant | csharp | name+resolver | `src/Miller.Indexing/ContentFileClassifier.cs:17` | confirmed-live (same-file) | `src/Miller.Indexing/ContentFileClassifier.cs:43` |
+| 101 | `ContentFileClassifier` | class | csharp | name+resolver | `src/Miller.Indexing/ContentFileClassifier.cs:9` | confirmed-live (cross-file) | `src/Miller.Indexing/ContentCorpusWriter.cs:261` |
+| 102 | `MaxContentBytes` | constant | csharp | name+resolver | `src/Miller.Indexing/ContentSearchProjectionLoader.cs:16` | confirmed-live (same-file) | `src/Miller.Indexing/ContentSearchProjectionLoader.cs:54` |
+| 103 | `RequiredResolutionTables` | constant | csharp | name+resolver | `src/Miller.Indexing/DeadCodeCandidateReader.cs:40` | confirmed-live (same-file) | `src/Miller.Indexing/DeadCodeCandidateReader.cs:80` |
+| 104 | `ExtractVersionMismatch` | class | csharp | name+resolver | `src/Miller.Indexing/ExtractVersionMismatch.cs:12` | confirmed-live (cross-file) | `src/Miller.Indexing/JulieExtractVersionProbe.cs:7` |
+| 105 | `FilePathSymbolLookup` | class | csharp | name+resolver | `src/Miller.Indexing/FilePathSymbolLookup.cs:3` | confirmed-live (cross-file) | `src/Miller.Indexing/MillerRepositoryIndex.cs:255` |
+| 106 | `SnippetMaxChars` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsRegionSearchIndex.cs:13` | confirmed-live (same-file) | `src/Miller.Indexing/FtsRegionSearchIndex.cs:442` |
+| 107 | `TestSegments` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsRegionSearchIndex.cs:15` | confirmed-live (cross-file) | `src/Miller.Server/Resolution/IsTestPath.cs:26` |
+| 108 | `FileNameInfixes` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsRegionSearchIndex.cs:20` | confirmed-live (cross-file) | `src/Miller.Server/Resolution/IsTestPath.cs:32` |
+| 109 | `PascalSuffixes` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsRegionSearchIndex.cs:22` | confirmed-live (cross-file) | `src/Miller.Server/Resolution/IsTestPath.cs:36` |
+| 110 | `TrigramWindow` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsSymbolSearchIndex.cs:271` | confirmed-live (same-file) | `src/Miller.Indexing/FtsSymbolSearchIndex.cs:249` |
+| 111 | `LoadPaths` | method | csharp | name+resolver | `src/Miller.Indexing/FtsSymbolSearchIndex.cs:516` | confirmed-live (same-file) | `src/Miller.Indexing/FtsSymbolSearchIndex.cs:34` |
+| 112 | `SnippetRadius` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:10` | confirmed-live (same-file) | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:427` |
+| 113 | `WidenedCandidateLimit` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:11` | confirmed-live (same-file) | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:159` |
+| 114 | `TokenPhraseBoost` | constant | csharp | name+resolver | `src/Miller.Indexing/FtsTextContentSearchIndex.cs:12` | confirmed-live (cross-file) | `src/Miller.Core/Search/ContentSearchIndex.cs:21` |
+| 115 | `DefaultInitialDelay` | constant | csharp | name+resolver | `src/Miller.Indexing/FullRebuildPromotion.cs:15` | confirmed-live (same-file) | `src/Miller.Indexing/FullRebuildPromotion.cs:26` |
+| 116 | `DefaultMaxDelay` | constant | csharp | name+resolver | `src/Miller.Indexing/FullRebuildPromotion.cs:16` | confirmed-live (same-file) | `src/Miller.Indexing/FullRebuildPromotion.cs:27` |
+| 117 | `Semver` | constant | csharp | name+resolver | `src/Miller.Indexing/JulieExtractVersionProbe.cs:17` | confirmed-live (cross-file) | `src/Miller.Indexing/LeadershipEligibility.cs:29` |
+| 118 | `MaxEnumeratedFiles` | constant | csharp | name+resolver | `src/Miller.Indexing/JulieIgnoreSeeder.cs:24` | confirmed-live (same-file) | `src/Miller.Indexing/JulieIgnoreSeeder.cs:110` |
+| 119 | `WalkSkipDirectories` | constant | csharp | name+resolver | `src/Miller.Indexing/JulieIgnoreSeeder.cs:29` | confirmed-live (same-file) | `src/Miller.Indexing/JulieIgnoreSeeder.cs:137` |
+| 120 | `JulieSchemaGate` | class | csharp | name+resolver | `src/Miller.Indexing/JulieSchemaGate.cs:14` | confirmed-live (cross-file) | `src/Miller.Indexing/CloneGroupReader.cs:24` |
+| 121 | `SqliteGenericError` | constant | csharp | name+resolver | `src/Miller.Indexing/JulieSchemaGate.cs:17` | confirmed-live (same-file) | `src/Miller.Indexing/JulieSchemaGate.cs:111` |
+| 122 | `Semver` | constant | csharp | name+resolver | `src/Miller.Indexing/LeadershipEligibility.cs:31` | confirmed-live (cross-file) | `src/Miller.Indexing/JulieExtractVersionProbe.cs:17` |
+| 123 | `SeparatorChars` | constant | csharp | name+resolver | `src/Miller.Indexing/MillerRepositoryIndex.cs:222` | confirmed-live (cross-file) | `src/Miller.Indexing/WorkspaceIndexFactsReader.cs:70` |
+| 124 | `EmptyBridgeGraph` | constant | csharp | name+resolver | `src/Miller.Indexing/MillerRepositoryIndex.cs:44` | confirmed-live (same-file) | `src/Miller.Indexing/MillerRepositoryIndex.cs:111` |
+| 125 | `PatternDirectory` | class | csharp | name+resolver | `src/Miller.Indexing/PatternFactsReader.cs:637` | confirmed-live (same-file) | `src/Miller.Indexing/PatternFactsReader.cs:358` |
+| 126 | `PatternMetadataSql` | class | csharp | name+resolver | `src/Miller.Indexing/PatternMetadataSql.cs:11` | confirmed-live (cross-file) | `src/Miller.Indexing/PatternFactsReader.cs:238` |
+| 127 | `PatternPathGlobMatcher` | class | csharp | name+resolver | `src/Miller.Indexing/PatternPathGlobMatcher.cs:9` | confirmed-live (cross-file) | `src/Miller.Indexing/PatternFactsReader.cs:260` |
+| 128 | `PatternPathGlobSql` | class | csharp | name+resolver | `src/Miller.Indexing/PatternPathGlobSql.cs:10` | confirmed-live (cross-file) | `src/Miller.Indexing/PatternFactsReader.cs:235` |
+| 129 | `MaxIdentifierFallbackTargets` | constant | csharp | name+resolver | `src/Miller.Indexing/RepositoryIndexLoader.cs:30` | confirmed-live (same-file) | `src/Miller.Indexing/RepositoryIndexLoader.cs:72` |
+| 130 | `ParameterChunkSize` | constant | csharp | name+resolver | `src/Miller.Indexing/SearchIndexWriter.cs:30` | confirmed-live (cross-file) | `src/Miller.Indexing/SqliteSymbolReader.cs:21` |
+| 131 | `StrictUtf16Le` | constant | csharp | name+resolver | `src/Miller.Indexing/SourceTextDecoder.cs:10` | confirmed-live (same-file) | `src/Miller.Indexing/SourceTextDecoder.cs:35` |
+| 132 | `StrictUtf16Be` | constant | csharp | name+resolver | `src/Miller.Indexing/SourceTextDecoder.cs:13` | confirmed-live (same-file) | `src/Miller.Indexing/SourceTextDecoder.cs:37` |
+| 133 | `SourceTextDecoder` | class | csharp | name+resolver | `src/Miller.Indexing/SourceTextDecoder.cs:5` | confirmed-live (cross-file) | `src/Miller.Indexing/ContentCorpusWriter.cs:312` |
+| 134 | `StrictUtf8` | constant | csharp | name+resolver | `src/Miller.Indexing/SourceTextDecoder.cs:7` | confirmed-live (cross-file) | `src/Miller.Indexing/ContentCorpusExternalStore.cs:15` |
+| 135 | `SqliteReadOnlyAccess` | class | csharp | name+resolver | `src/Miller.Indexing/SqliteReadOnlyAccess.cs:18` | confirmed-live (cross-file) | `src/Miller.Indexing/ContentCorpusContextReader.cs:25` |
+| 136 | `WritableDirs` | constant | csharp | name+resolver | `src/Miller.Indexing/SqliteReadOnlyAccess.cs:80` | confirmed-live (same-file) | `src/Miller.Indexing/SqliteReadOnlyAccess.cs:87` |
+| 137 | `DefaultMaxNameResolutionTargets` | constant | csharp | name+resolver | `src/Miller.Indexing/SqliteSymbolGraphIndex.cs:12` | confirmed-live (same-file) | `src/Miller.Indexing/SqliteSymbolGraphIndex.cs:26` |
+| 138 | `Connection` | property | csharp | name+resolver | `src/Miller.Indexing/SqliteSymbolGraphIndex.cs:159` | confirmed-live (same-file) | `src/Miller.Indexing/SqliteSymbolGraphIndex.cs:76` |
+| 139 | `ParameterChunkSize` | constant | csharp | name+resolver | `src/Miller.Indexing/SqliteSymbolReader.cs:21` | confirmed-live (cross-file) | `src/Miller.Indexing/SearchIndexWriter.cs:30` |
+| 140 | `ExportJson` | class | csharp | name+resolver | `src/Miller.Indexing/SymbolExportReader.cs:88` | confirmed-live (cross-file) | `src/Miller.Indexing/ReferenceExportReader.cs:90` |
+| 141 | `SeparatorChars` | constant | csharp | name+resolver | `src/Miller.Indexing/SymbolLookupTables.cs:15` | confirmed-live (cross-file) | `src/Miller.Indexing/MillerRepositoryIndex.cs:218` |
+| 142 | `VendorDirectoryNames` | constant | csharp | name+resolver | `src/Miller.Indexing/VendorScan.cs:26` | confirmed-live (same-file) | `src/Miller.Indexing/VendorScan.cs:93` |
+| 143 | `ReadFileStatuses` | method | csharp | name+resolver | `src/Miller.Indexing/WorkspaceHealthReader.cs:180` | confirmed-live (same-file) | `src/Miller.Indexing/WorkspaceHealthReader.cs:26` |
+| 144 | `ReadComplexityMetrics` | method | csharp | name+resolver | `src/Miller.Indexing/WorkspaceHealthReader.cs:225` | confirmed-live (same-file) | `src/Miller.Indexing/WorkspaceHealthReader.cs:25` |
+| 145 | `ReadParseDiagnostics` | method | csharp | name+resolver | `src/Miller.Indexing/WorkspaceHealthReader.cs:49` | confirmed-live (same-file) | `src/Miller.Indexing/WorkspaceHealthReader.cs:21` |
+| 146 | `ReadCapabilityGaps` | method | csharp | name+resolver | `src/Miller.Indexing/WorkspaceHealthReader.cs:71` | confirmed-live (same-file) | `src/Miller.Indexing/WorkspaceHealthReader.cs:22` |
+| 147 | `ReadLanguageCapabilities` | method | csharp | name+resolver | `src/Miller.Indexing/WorkspaceHealthReader.cs:94` | confirmed-live (same-file) | `src/Miller.Indexing/WorkspaceHealthReader.cs:23` |
+| 148 | `SeparatorChars` | constant | csharp | name+resolver | `src/Miller.Indexing/WorkspaceIndexFactsReader.cs:74` | confirmed-live (cross-file) | `src/Miller.Indexing/MillerRepositoryIndex.cs:218` |
+| 149 | `CreateTableDdl` | constant | csharp | name+resolver | `src/Miller.Indexing/WorkspaceRegistry.cs:8` | confirmed-live (cross-file) | `src/Miller.Server/Telemetry/TelemetryLedger.cs:18` |
+| 150 | `WorkspaceRelativePath` | class | csharp | name+resolver | `src/Miller.Indexing/WorkspaceRelativePath.cs:11` | confirmed-live (cross-file) | `src/Miller.Indexing/ContentCorpusWriter.cs:269` |
+| 151 | `CliCapabilities` | class | csharp | name+resolver | `src/Miller.Server/Cli/CliCapabilities.cs:10` | confirmed-live (cross-file) | `src/Miller.Server/Cli/CliDispatch.cs:228` |
+| 152 | `JsonCommands` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliCapabilities.cs:41` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliCapabilities.cs:141` |
+| 153 | `JsonContracts` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliCapabilities.cs:90` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliCapabilities.cs:144` |
+| 154 | `ImpactUsage` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:1070` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:1025` |
+| 155 | `ImpactDeltaUsage` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:1075` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:1089` |
+| 156 | `HelpText` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:2178` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:94` |
+| 157 | `WorkspaceHelpText` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:2239` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:1196` |
+| 158 | `DeadCodeCandidatesDefaultLimit` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:755` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:747` |
+| 159 | `DeadCodeCandidatesSchemaVersion` | constant | csharp | name+resolver | `src/Miller.Server/Cli/CliDispatch.cs:899` | confirmed-live (same-file) | `src/Miller.Server/Cli/CliDispatch.cs:823` |
+| 160 | `IsHealthy` | method | csharp | name+resolver | `src/Miller.Server/Cli/DashboardCliLauncher.cs:257` | confirmed-live (same-file) | `src/Miller.Server/Cli/DashboardCliLauncher.cs:48` |
+| 161 | `TryAcquireLaunchLock` | method | csharp | name+resolver | `src/Miller.Server/Cli/DashboardCliLauncher.cs:278` | confirmed-live (same-file) | `src/Miller.Server/Cli/DashboardCliLauncher.cs:49` |
+| 162 | `WriteMetadata` | method | csharp | name+resolver | `src/Miller.Server/Cli/DashboardCliLauncher.cs:338` | confirmed-live (same-file) | `src/Miller.Server/Cli/DashboardCliLauncher.cs:50` |
+| 163 | `HealthBody` | constant | csharp | name+resolver | `src/Miller.Server/Cli/DashboardCliLauncher.cs:37` | confirmed-live (same-file) | `src/Miller.Server/Cli/DashboardCliLauncher.cs:270` |
+| 164 | `UnixLaunchScript` | constant | csharp | name+resolver | `src/Miller.Server/Cli/DashboardCliLauncher.cs:441` | confirmed-live (same-file) | `src/Miller.Server/Cli/DashboardCliLauncher.cs:421` |
+| 165 | `UnitSeparator` | constant | csharp | name+resolver | `src/Miller.Server/Git/GitHistoryReader.cs:25` | confirmed-live (same-file) | `src/Miller.Server/Git/GitHistoryReader.cs:42` |
+| 166 | `AtomicTempMove` | method | csharp | name+resolver | `src/Miller.Server/Hosting/EditApplier.cs:140` | confirmed-live (same-file) | `src/Miller.Server/Hosting/EditApplier.cs:60` |
+| 167 | `TempSuffix` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/EditApplier.cs:32` | confirmed-live (same-file) | `src/Miller.Server/Hosting/EditApplier.cs:151` |
+| 168 | `ExecuteAsync` | method | csharp | name+resolver | `src/Miller.Server/Hosting/FreshnessService.cs:68` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/MillerServiceRegistration.cs:22` |
+| 169 | `BindOutcome` | enum | csharp | name+resolver | `src/Miller.Server/Hosting/IndexBootstrapService.cs:30` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/WorkspaceToolTests.cs:383` |
+| 170 | `CurrentBound` | property | csharp | name+resolver | `src/Miller.Server/Hosting/IndexBootstrapService.cs:93` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexBootstrapService.cs:100` |
+| 171 | `KeepPriorCodes` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerCore.cs:139` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerCore.cs:179` |
+| 172 | `OnRenamed` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:1026` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:961` |
+| 173 | `OnError` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:1056` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:962` |
+| 174 | `OnHeadChanged` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:1063` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:965` |
+| 175 | `OnIgnorePolicyChanged` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:1069` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:966` |
+| 176 | `ExecuteAsync` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:207` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/MillerServiceRegistration.cs:22` |
+| 177 | `DefaultLeaderRetryInterval` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:35` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:98` |
+| 178 | `ProbeBundledExtractorVersion` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:471` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:166` |
+| 179 | `OnChanged` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:969` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:960` |
+| 180 | `OnDirectoryChanged` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerService.cs:995` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerService.cs:963` |
+| 181 | `OnHeadRenamed` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerWatcherSet.cs:145` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerWatcherSet.cs:78` |
+| 182 | `OnIgnorePolicyRenamed` | method | csharp | name+resolver | `src/Miller.Server/Hosting/IndexerWatcherSet.cs:148` | confirmed-live (same-file) | `src/Miller.Server/Hosting/IndexerWatcherSet.cs:95` |
+| 183 | `ProbeProcess` | method | csharp | name+resolver | `src/Miller.Server/Hosting/LeaderIdentityFile.cs:140` | confirmed-live (same-file) | `src/Miller.Server/Hosting/LeaderIdentityFile.cs:118` |
+| 184 | `PidReuseStartTolerance` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/LeaderIdentityFile.cs:85` | confirmed-live (same-file) | `src/Miller.Server/Hosting/LeaderIdentityFile.cs:122` |
+| 185 | `SidecarCorruptionRecovery` | class | csharp | name+resolver | `src/Miller.Server/Hosting/SidecarCorruptionRecovery.cs:7` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/IndexerSidecarConverger.cs:38` |
+| 186 | `SegmentComparer` | property | csharp | name+resolver | `src/Miller.Server/Hosting/WatchPathFilter.cs:125` | confirmed-live (same-file) | `src/Miller.Server/Hosting/WatchPathFilter.cs:32` |
+| 187 | `SkipSegments` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/WatchPathFilter.cs:32` | confirmed-live (same-file) | `src/Miller.Server/Hosting/WatchPathFilter.cs:82` |
+| 188 | `IgnorePolicyFiles` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/WatchPathFilter.cs:48` | confirmed-live (same-file) | `src/Miller.Server/Hosting/WatchPathFilter.cs:102` |
+| 189 | `PathComparison` | property | csharp | name+resolver | `src/Miller.Server/Hosting/WorkspaceBindingResolver.cs:171` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:83` |
+| 190 | `WorkspaceIgnorePolicy` | class | csharp | name+resolver | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:11` | confirmed-live (cross-file) | `src/Miller.Indexing/JulieIgnoreSeeder.cs:12` |
+| 191 | `SeparatorChars` | constant | csharp | name+resolver | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:13` | confirmed-live (cross-file) | `src/Miller.Indexing/MillerRepositoryIndex.cs:218` |
+| 192 | `PathComparison` | property | csharp | name+resolver | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:213` | confirmed-live (cross-file) | `src/Miller.Server/Tools/WorkspaceRootSafety.cs:78` |
+| 193 | `DirectoryOnly` | property | csharp | name+resolver | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:241` | confirmed-live (same-file) | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:226` |
+| 194 | `Ellipsis` | constant | csharp | name+resolver | `src/Miller.Server/Logging/ExtractErrorLog.cs:32` | confirmed-live (same-file) | `src/Miller.Server/Logging/ExtractErrorLog.cs:67` |
+| 195 | `HumanOutputTemplate` | constant | csharp | name+resolver | `src/Miller.Server/Logging/MillerLoggingSetup.cs:45` | confirmed-live (same-file) | `src/Miller.Server/Logging/MillerLoggingSetup.cs:76` |
+| 196 | `TestSegments` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/IsTestPath.cs:26` | confirmed-live (cross-file) | `src/Miller.Indexing/FtsRegionSearchIndex.cs:15` |
+| 197 | `FileNameInfixes` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/IsTestPath.cs:32` | confirmed-live (cross-file) | `src/Miller.Indexing/FtsRegionSearchIndex.cs:20` |
+| 198 | `PascalSuffixes` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/IsTestPath.cs:36` | confirmed-live (cross-file) | `src/Miller.Indexing/FtsRegionSearchIndex.cs:22` |
+| 199 | `MaxSuggestions` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/SmartTargetResolver.cs:142` | confirmed-live (same-file) | `src/Miller.Server/Resolution/SmartTargetResolver.cs:145` |
+| 200 | `IsPreferredSourceSegment` | method | csharp | name+resolver | `src/Miller.Server/Resolution/SmartTargetResolver.cs:197` | confirmed-live (same-file) | `src/Miller.Server/Resolution/SmartTargetResolver.cs:182` |
+| 201 | `IsAuxiliaryCodeSegment` | method | csharp | name+resolver | `src/Miller.Server/Resolution/SmartTargetResolver.cs:202` | confirmed-live (same-file) | `src/Miller.Server/Resolution/SmartTargetResolver.cs:184` |
+| 202 | `SymbolSuggestionEngine` | class | csharp | name+resolver | `src/Miller.Server/Resolution/SymbolSuggestionEngine.cs:6` | confirmed-live (cross-file) | `src/Miller.Server/Resolution/SmartTargetResolver.cs:236` |
+| 203 | `SearchCandidateMultiplier` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/SymbolSuggestionEngine.cs:8` | confirmed-live (same-file) | `src/Miller.Server/Resolution/SymbolSuggestionEngine.cs:26` |
+| 204 | `MaxEditDistance` | constant | csharp | name+resolver | `src/Miller.Server/Resolution/SymbolSuggestionEngine.cs:9` | confirmed-live (same-file) | `src/Miller.Server/Resolution/SymbolSuggestionEngine.cs:86` |
+| 205 | `MissingParameterMarker` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:150` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:178` |
+| 206 | `ToolUsageExamples` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:156` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:192` |
+| 207 | `BudgetLoggerCategory` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:34` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryCallToolFilter.cs:214` |
+| 208 | `SelectSql` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryExportReader.cs:48` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryExportReader.cs:35` |
+| 209 | `CreateTableDdl` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryLedger.cs:18` | confirmed-live (cross-file) | `src/Miller.Indexing/WorkspaceRegistry.cs:8` |
+| 210 | `TelemetryOutcomeExtensions` | class | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryOutcome.cs:20` | **see manual notes** | — |
+| 211 | `MaxErrorTextChars` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryScope.cs:17` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryScope.cs:253` |
+| 212 | `CurrentScope` | constant | csharp | name+resolver | `src/Miller.Server/Telemetry/TelemetryScope.cs:298` | confirmed-live (same-file) | `src/Miller.Server/Telemetry/TelemetryScope.cs:303` |
+| 213 | `CandidateOutput` | class | csharp | name+resolver | `src/Miller.Server/Tools/CandidateOutput.cs:6` | confirmed-live (cross-file) | `src/Miller.Server/Tools/ImpactTool.cs:775` |
+| 214 | `SignatureMaxLength` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:145` | confirmed-live (cross-file) | `src/Miller.Server/Tools/InspectTool.cs:116` |
+| 215 | `SearchSeedLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:146` | confirmed-live (same-file) | `src/Miller.Server/Tools/ContextTool.cs:328` |
+| 216 | `ReachCap` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:149` | confirmed-live (same-file) | `src/Miller.Server/Tools/ContextTool.cs:358` |
+| 217 | `PathSeparators` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:406` | confirmed-live (same-file) | `src/Miller.Server/Tools/ContextTool.cs:456` |
+| 218 | `MaxNeighbourCandidates` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:623` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:147` |
+| 219 | `NextInspectCount` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ContextTool.cs:624` | confirmed-live (same-file) | `src/Miller.Server/Tools/ContextTool.cs:683` |
+| 220 | `ReplaceTextPlanResult` | class | csharp | name+resolver | `src/Miller.Server/Tools/EditService.cs:1116` | confirmed-live (same-file) | `src/Miller.Server/Tools/EditService.cs:282` |
+| 221 | `CompactLikelyTestsLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/ImpactTool.cs:39` | confirmed-live (same-file) | `src/Miller.Server/Tools/ImpactTool.cs:694` |
+| 222 | `SignatureMaxLength` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:116` | confirmed-live (cross-file) | `src/Miller.Server/Tools/ContextTool.cs:145` |
+| 223 | `RefLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:117` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:409` |
+| 224 | `OverviewRelationLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:118` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:409` |
+| 225 | `OverviewChildLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:119` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:415` |
+| 226 | `OverviewBodyPreviewMaxLines` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:120` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:660` |
+| 227 | `OverviewBodyPreviewMaxChars` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:121` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:663` |
+| 228 | `ImpactHintMinReferences` | constant | csharp | name+resolver | `src/Miller.Server/Tools/InspectTool.cs:125` | confirmed-live (same-file) | `src/Miller.Server/Tools/InspectTool.cs:479` |
+| 229 | `MarkerSearch` | class | csharp | name+resolver | `src/Miller.Server/Tools/MarkerSearch.cs:10` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/MarkerSearchTests.cs:19` |
+| 230 | `DefaultMarkers` | constant | csharp | name+resolver | `src/Miller.Server/Tools/MarkerSearch.cs:14` | confirmed-live (same-file) | `src/Miller.Server/Tools/MarkerSearch.cs:15` |
+| 231 | `AllowedMarkers` | constant | csharp | name+resolver | `src/Miller.Server/Tools/MarkerSearch.cs:15` | confirmed-live (same-file) | `src/Miller.Server/Tools/MarkerSearch.cs:123` |
+| 232 | `CommentKinds` | constant | csharp | name+resolver | `src/Miller.Server/Tools/MarkerSearch.cs:16` | confirmed-live (same-file) | `src/Miller.Server/Tools/MarkerSearch.cs:63` |
+| 233 | `NextStepHint` | class | csharp | name+resolver | `src/Miller.Server/Tools/NextStepHint.cs:13` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/NextStepHintTests.cs:7` |
+| 234 | `ParseSingleWhere` | method | csharp | name+resolver | `src/Miller.Server/Tools/PatternsTool.cs:189` | confirmed-live (same-file) | `src/Miller.Server/Tools/PatternsTool.cs:185` |
+| 235 | `MetadataPriority` | constant | csharp | name+resolver | `src/Miller.Server/Tools/PatternsTool.cs:19` | confirmed-live (same-file) | `src/Miller.Server/Tools/PatternsTool.cs:917` |
+| 236 | `ReadToolWorkspaceRouting` | class | csharp | name+resolver | `src/Miller.Server/Tools/ReadToolWorkspaceRouting.cs:7` | confirmed-live (cross-file) | `src/Miller.Server/Tools/PatternsTool.cs:74` |
+| 237 | `DiskBackendMetadata` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:425` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:427` |
+| 238 | `MemoryBackendMetadata` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:428` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:437` |
+| 239 | `RegionBackendMetadata` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:431` | **see manual notes** | — |
+| 240 | `TextContentBackendMetadata` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:434` | **see manual notes** | — |
+| 241 | `SearchBackendMetadata` | method | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:436` | **see manual notes** | — |
+| 242 | `EmptyHintQueryLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:567` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:573` |
+| 243 | `SymbolNoResultsHint` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:60` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:1698` |
+| 244 | `EmptySuggestionLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:62` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:753` |
+| 245 | `OutsideScopeHintLimit` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:620` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:717` |
+| 246 | `SignatureMaxLength` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:621` | confirmed-live (cross-file) | `src/Miller.Server/Tools/InspectTool.cs:116` |
+| 247 | `RegionsUsageHint` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:63` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:403` |
+| 248 | `OverFetchEscalationWindows` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:642` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:655` |
+| 249 | `WorkspaceContentSearchKinds` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:66` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:857` |
+| 250 | `PathQueryExtensions` | constant | csharp | name+resolver | `src/Miller.Server/Tools/SearchTool.cs:72` | confirmed-live (same-file) | `src/Miller.Server/Tools/SearchTool.cs:1432` |
+| 251 | `FileRouteDiagnosticProviders` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:1018` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:835` |
+| 252 | `ModeAuto` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:138` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:184` |
+| 253 | `ModePath` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:139` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:188` |
+| 254 | `ModeRefs` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:140` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:189` |
+| 255 | `ModeBridge` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:141` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:190` |
+| 256 | `MaxNextActions` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:142` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:1795` |
+| 257 | `KnownReferenceKinds` | constant | csharp | name+resolver | `src/Miller.Server/Tools/TraceTool.cs:171` | confirmed-live (same-file) | `src/Miller.Server/Tools/TraceTool.cs:627` |
+| 258 | `WorkspaceFactsAssembler` | class | csharp | name+resolver | `src/Miller.Server/Tools/WorkspaceFactsAssembler.cs:15` | confirmed-live (cross-file) | `src/Miller.Server/Cli/CliDispatch.cs:1253` |
+| 259 | `WorkspaceOnboardingAssembler` | class | csharp | name+resolver | `src/Miller.Server/Tools/WorkspaceOnboardingAssembler.cs:7` | confirmed-live (cross-file) | `src/Miller.Server/Cli/CliDispatch.cs:1485` |
+| 260 | `PathComparison` | property | csharp | name+resolver | `src/Miller.Server/Tools/WorkspaceRootSafety.cs:157` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:83` |
+| 261 | `PathComparison` | property | csharp | name+resolver | `src/Miller.Server/Tools/WorkspaceSafety.cs:63` | confirmed-live (cross-file) | `src/Miller.Server/Hosting/WorkspaceIgnorePolicy.cs:83` |
+| 262 | `UnknownWorkspaceIdNote` | method | csharp | name+resolver | `src/Miller.Server/Tools/WorkspaceTool.cs:968` | **see manual notes** | — |
+| 263 | `DefaultLockBusyWait` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:11` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:44` |
+| 264 | `DefaultFullScanRequestWait` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:12` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:51` |
+| 265 | `DefaultLockBusyPollInterval` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:13` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:45` |
+| 266 | `IneligibleRemedy` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:32` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/CrossWorkspaceRefreshService.cs:176` |
+| 267 | `OperationFullScan` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:72` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:109` |
+| 268 | `OperationFileConverge` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:73` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:206` |
+| 269 | `OperationYield` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:74` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:312` |
+| 270 | `OperationLeaderHandoff` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:75` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:422` |
+| 271 | `RequestDirectoryName` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:76` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:590` |
+| 272 | `ClaimedSuffix` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:81` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:531` |
+| 273 | `StampFormat` | constant | csharp | name+resolver | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:82` | confirmed-live (same-file) | `src/Miller.Server/Workspaces/LeaderScanRequestQueue.cs:104` |
+| 274 | `WorkspaceFreshnessView` | class | csharp | name+resolver | `src/Miller.Server/Workspaces/WorkspaceFreshnessView.cs:5` | confirmed-live (cross-file) | `src/Miller.Server/Tools/WorkspaceFactsAssembler.cs:209` |
+| 275 | `WorkspaceRegistryRootMatcher` | class | csharp | name+resolver | `src/Miller.Server/Workspaces/WorkspaceRegistryRootMatcher.cs:6` | confirmed-live (cross-file) | `src/Miller.Server/Cli/CliDispatch.cs:1891` |
+| 276 | `ExemptFileNames` | constant | csharp | name+resolver | `tests/Miller.Tests/Conventions/ScaleTraitConventionTests.cs:34` | confirmed-live (same-file) | `tests/Miller.Tests/Conventions/ScaleTraitConventionTests.cs:60` |
+| 277 | `BetaCriticalScripts` | constant | csharp | name+resolver | `tests/Miller.Tests/Conventions/ScriptPlatformConventionTests.cs:11` | confirmed-live (same-file) | `tests/Miller.Tests/Conventions/ScriptPlatformConventionTests.cs:25` |
+| 278 | `CSharpResolverCovered` | constant | csharp | name+resolver | `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs:62` | confirmed-live (same-file) | `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs:113` |
+| 279 | `FileA` | constant | csharp | name+resolver | `tests/Miller.Tests/Editing/RenamePlannerTests.cs:17` | confirmed-live (same-file) | `tests/Miller.Tests/Editing/RenamePlannerTests.cs:31` |
+| 280 | `AllExist` | constant | csharp | name+resolver | `tests/Miller.Tests/Freshness/WatchEventRouterTests.cs:18` | confirmed-live (same-file) | `tests/Miller.Tests/Freshness/WatchEventRouterTests.cs:44` |
+| 281 | `NoneExist` | constant | csharp | name+resolver | `tests/Miller.Tests/Freshness/WatchEventRouterTests.cs:19` | confirmed-live (same-file) | `tests/Miller.Tests/Freshness/WatchEventRouterTests.cs:58` |
+| 282 | `FailedJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:101` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:176` |
+| 283 | `ChangedJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:15` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:81` |
+| 284 | `NoChangeJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:32` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:131` |
+| 285 | `DeletedJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:48` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:141` |
+| 286 | `NotFoundJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:64` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:151` |
+| 287 | `PartialJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:81` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:161` |
+| 288 | `NoSymbols` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/FreshnessReaderTests.cs:19` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/FreshnessReaderTests.cs:25` |
+| 289 | `SqliteReadOnlyAccessTestSeam` | class | csharp | name+resolver | `tests/Miller.Tests/Indexing/FullRebuildScanScaleTests.cs:108` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/FullRebuildScanScaleTests.cs:91` |
+| 290 | `FilesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1065` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:456` |
+| 291 | `SymbolsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1080` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:457` |
+| 292 | `IdentifiersDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1106` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:458` |
+| 293 | `RelationshipsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1124` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:460` |
+| 294 | `SourceRegionsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1139` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:461` |
+| 295 | `SourceRegionsIndexesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1157` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:462` |
+| 296 | `PatternCatalogDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1163` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:464` |
+| 297 | `StructuralFactsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1173` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:463` |
+| 298 | `ComplexityMetricsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1194` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:465` |
+| 299 | `TypeArgumentUsagesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1224` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:471` |
+| 300 | `TypeArgumentsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1235` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:472` |
+| 301 | `LiteralsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1245` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:473` |
+| 302 | `SymbolAnnotationsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1267` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:474` |
+| 303 | `ParserInventoryDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1281` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:476` |
+| 304 | `ParseDiagnosticsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1293` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:477` |
+| 305 | `LanguageCapabilitiesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1311` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:478` |
+| 306 | `LanguageCapabilityFixturesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1331` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:479` |
+| 307 | `LanguageCapabilityGapsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1341` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:480` |
+| 308 | `PendingRelationshipsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1356` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:481` |
+| 309 | `PendingRelationshipsIndexesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1383` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:482` |
+| 310 | `IdentifierResolutionsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1392` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:485` |
+| 311 | `IdentifierResolutionsIndexDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1406` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:486` |
+| 312 | `PendingResolutionsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1411` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:487` |
+| 313 | `PendingResolutionsIndexDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1423` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:488` |
+| 314 | `TypeFactsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1426` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:489` |
+| 315 | `MetadataDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1439` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:490` |
+| 316 | `ExtractionRevisionsDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1450` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:467` |
+| 317 | `RevisionFileChangesDdl` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:1466` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieDbFixture.cs:468` |
+| 318 | `ScanSuccessJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:115` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:135` |
+| 319 | `InfoJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:146` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:165` |
+| 320 | `AbsDb` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:16` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:16` |
+| 321 | `AbsRoot` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:17` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:17` |
+| 322 | `FailedJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:176` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:101` |
+| 323 | `AbsFile` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:18` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:18` |
+| 324 | `LanguagesJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:70` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:83` |
+| 325 | `FailedUpdateJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:106` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:125` |
+| 326 | `AbsDb` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:16` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:16` |
+| 327 | `AbsRoot` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:17` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:17` |
+| 328 | `AbsFile` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:18` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/JulieExtractRunnerTests.cs:18` |
+| 329 | `ChangedJson` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieExtractRunnerUpdateDeleteTests.cs:81` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/ExtractReportParsingTests.cs:15` |
+| 330 | `NoRows` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:21` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:41` |
+| 331 | `PinSchema` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:23` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:41` |
+| 332 | `PinContract` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:24` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:25` |
+| 333 | `PinContractStr` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:25` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/JulieSchemaGateTests.cs:41` |
+| 334 | `RequiredClientLanguages` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:1121` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:1093` |
+| 335 | `TableDisplays` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:2385` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:2377` |
+| 336 | `RouteDisplays` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:2387` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/LiveBridgeTraceTests.cs:2379` |
+| 337 | `ValidateId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/MillerRepositoryIndexTests.cs:127` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs:16` |
+| 338 | `HandleId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/MillerRepositoryIndexTests.cs:128` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:28` |
+| 339 | `ValidateId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs:16` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/MillerRepositoryIndexTests.cs:127` |
+| 340 | `DefaultArtifactId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/RevisionDeltaReaderTests.cs:16` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/Cli/ImpactRevisionDeltaCliTests.cs:19` |
+| 341 | `SqliteFixtureMutator` | class | csharp | name+resolver | `tests/Miller.Tests/Indexing/SqliteFixtureMutator.cs:5` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/WorkspaceToolTests.cs:568` |
+| 342 | `ValidateId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:27` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs:16` |
+| 343 | `HandleId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:28` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:32` |
+| 344 | `LogAId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:30` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:44` |
+| 345 | `LogBId` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:31` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:44` |
+| 346 | `NameMap` | constant | csharp | name+resolver | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:38` | confirmed-live (same-file) | `tests/Miller.Tests/Indexing/SymbolGraphReaderTests.cs:48` |
+| 347 | `ReadToolRoutingTestSupport` | class | csharp | name+resolver | `tests/Miller.Tests/ReadToolRoutingTestSupport.cs:165` | confirmed-live (cross-file) | `tests/Miller.Tests/Tools/TraceToolTests.cs:319` |
+| 348 | `SearchEvalQueries` | class | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:227` | confirmed-live (cross-file) | `tests/Miller.Tests/Search/SearchRecallEvalTests.cs:37` |
+| 349 | `MinComponentLength` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:229` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:317` |
+| 350 | `InteriorMin` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:230` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:276` |
+| 351 | `InteriorMax` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:231` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:283` |
+| 352 | `RecallMetrics` | class | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:337` | confirmed-live (cross-file) | `tests/Miller.Tests/Search/SearchRecallEvalTests.cs:98` |
+| 353 | `RecallK` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:63` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:124` |
+| 354 | `FetchLimit` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:64` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:120` |
+| 355 | `PopularityOf` | function | csharp | name+resolver | `tests/Miller.Tests/Search/SearchRecallEval.cs:89` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SearchRecallEval.cs:112` |
+| 356 | `ArtifactRevision` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SymbolSearchEvalScaleTests.cs:29` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SymbolSearchEvalScaleTests.cs:74` |
+| 357 | `InteriorRecallFloor_x100` | constant | csharp | name+resolver | `tests/Miller.Tests/Search/SymbolSearchEvalScaleTests.cs:30` | confirmed-live (same-file) | `tests/Miller.Tests/Search/SymbolSearchEvalScaleTests.cs:129` |
+| 358 | `DefaultToolDescriptionChars` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:31` | confirmed-live (same-file) | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:40` |
+| 359 | `ToolDescriptionBudgets` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:32` | confirmed-live (same-file) | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:40` |
+| 360 | `ToolsThatMustRedirectInNotForClause` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:50` | confirmed-live (same-file) | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:203` |
+| 361 | `AllToolNames` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:62` | confirmed-live (same-file) | `tests/Miller.Tests/Server/AgentInstructionsTests.cs:206` |
+| 362 | `NullLoggerFactory` | class | csharp | name+resolver | `tests/Miller.Tests/Server/CallToolFilterTelemetryTests.cs:476` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/IndexerWatcherExtensionGateTests.cs:91` |
+| 363 | `DefaultArtifactId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/Cli/ImpactRevisionDeltaCliTests.cs:19` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/RevisionDeltaReaderTests.cs:16` |
+| 364 | `ControllerId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ContextToolTests.cs:23` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:38` |
+| 365 | `ServiceId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ContextToolTests.cs:24` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:40` |
+| 366 | `RepoId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ContextToolTests.cs:25` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:42` |
+| 367 | `UnrelatedId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ContextToolTests.cs:26` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:44` |
+| 368 | `TestId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ContextToolTests.cs:27` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ContextToolTests.cs:46` |
+| 369 | `LogLoggerGate` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/CorrelationFilterTests.cs:49` | confirmed-live (same-file) | `tests/Miller.Tests/Server/CorrelationFilterTests.cs:93` |
+| 370 | `EditFixtureFiles` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/EditToolTests.cs:46` | confirmed-live (same-file) | `tests/Miller.Tests/Server/EditToolTests.cs:170` |
+| 371 | `ValidateId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:30` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/RepositoryIndexLoaderTests.cs:16` |
+| 372 | `HandleId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:32` | confirmed-live (cross-file) | `tests/Miller.Tests/Indexing/MillerRepositoryIndexTests.cs:128` |
+| 373 | `ProcessWorksId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:33` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:52` |
+| 374 | `LonelyId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:34` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:54` |
+| 375 | `HelperId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:35` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:93` |
+| 376 | `ImportId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:36` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:94` |
+| 377 | `ModuleId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:37` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:95` |
+| 378 | `RustParseConfigId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:829` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:839` |
+| 379 | `RustTestId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:830` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:841` |
+| 380 | `RustHelperId` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/ImpactToolTests.cs:831` | confirmed-live (same-file) | `tests/Miller.Tests/Server/ImpactToolTests.cs:844` |
+| 381 | `BeginScope` | method | csharp | name+resolver | `tests/Miller.Tests/Server/IndexerServiceLeadershipTests.cs:91` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/WorkspaceRegistryScanPublisherTests.cs:102` |
+| 382 | `BeginScope` | method | csharp | name+resolver | `tests/Miller.Tests/Server/IndexerServiceScanTests.cs:116` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/SoftBudgetFilterTests.cs:47` |
+| 383 | `ThrowIfSearchBuiltCalled` | method | csharp | name+resolver | `tests/Miller.Tests/Server/IndexerSidecarConvergerTests.cs:164` | confirmed-live (same-file) | `tests/Miller.Tests/Server/IndexerSidecarConvergerTests.cs:46` |
+| 384 | `ThrowIfSearchCurrentCalled` | method | csharp | name+resolver | `tests/Miller.Tests/Server/IndexerSidecarConvergerTests.cs:174` | confirmed-live (same-file) | `tests/Miller.Tests/Server/IndexerSidecarConvergerTests.cs:25` |
+| 385 | `CsOnly` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/IndexerWatcherExtensionGateTests.cs:19` | confirmed-live (same-file) | `tests/Miller.Tests/Server/IndexerWatcherExtensionGateTests.cs:103` |
+| 386 | `DocCommentBodyContent` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/InspectToolTests.cs:413` | confirmed-live (same-file) | `tests/Miller.Tests/Server/InspectToolTests.cs:438` |
+| 387 | `LargeDbWriter` | class | csharp | name+resolver | `tests/Miller.Tests/Server/LargeDbWriter.cs:20` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/RebuildLatencyTests.cs:90` |
+| 388 | `ScopedEnvironment` | class | csharp | name+resolver | `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs:447` | confirmed-live (same-file) | `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs:120` |
+| 389 | `BeginScope` | method | csharp | name+resolver | `tests/Miller.Tests/Server/WorkspaceRegistryScanPublisherTests.cs:102` | confirmed-live (cross-file) | `tests/Miller.Tests/Server/SoftBudgetFilterTests.cs:47` |
+| 390 | `Forbidden` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/WorkspaceRootSafetyTests.cs:17` | confirmed-live (same-file) | `tests/Miller.Tests/Server/WorkspaceRootSafetyTests.cs:30` |
+| 391 | `OtherWs` | constant | csharp | name+resolver | `tests/Miller.Tests/Server/WorkspaceToolTests.cs:32` | confirmed-live (same-file) | `tests/Miller.Tests/Server/WorkspaceToolTests.cs:430` |
+| 392 | `JsonOptions` | constant | csharp | name+resolver | `tools/Miller.SearchQuality/SearchQuality.cs:460` | confirmed-live (same-file) | `tools/Miller.SearchQuality/SearchQuality.cs:497` |
+
+## Appendix B — julie-extractors "maybe-dead" candidates (26 of 653)
+
+The other 627 candidates are confirmed live by cross-reference (194 cross-file, 433 same-file).
+These 26 survived the automated sweep; all are QML runtime-invoked handlers/actions or Rust test
+debug helpers — live, not dead. No genuine dead code was found in julie-extractors.
+
+| name | kind | lang | path:line |
+|------|------|------|-----------|
+| `debug_r_ast` | function | rust | `crates/julie-extractors/src/tests/r/basics.rs:13` |
+| `debug_data_structures_ast` | function | rust | `crates/julie-extractors/src/tests/r/data_structures.rs:13` |
+| `onXChanged` | function | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:33` |
+| `onYChanged` | function | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:34` |
+| `onHeightChanged` | function | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:36` |
+| `onFullscreenChanged` | function | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:54` |
+| `globalMenuLoader` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:65` |
+| `showMenubarAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:77` |
+| `fullscreenAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:86` |
+| `quitAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:95` |
+| `showsettingsAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:101` |
+| `copyAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:110` |
+| `pasteAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:115` |
+| `zoomIn` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:120` |
+| `zoomOut` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:126` |
+| `showAboutAction` | property | qml | `fixtures/qml/real-world/cool-retro-term-main.qml:132` |
+| `onExternalData` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:134` |
+| `highlightItemSvg` | property | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:153` |
+| `listItemSvg` | property | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:162` |
+| `toolBoxSvg` | property | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:171` |
+| `onDragEnter` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:208` |
+| `onDragMove` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:225` |
+| `onDragLeave` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:243` |
+| `onDrop` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:254` |
+| `onAppletChanged` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:329` |
+| `onUserDrag` | function | qml | `fixtures/qml/real-world/kde-plasma-desktop-main.qml:353` |

--- a/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
+++ b/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
@@ -27,6 +27,48 @@ lead owns any corrective dispatch against Core/Indexing/CLI. Task 5 edits no cod
 
 ---
 
+## LEAD ADDENDUM (2026-07-07, post-gate investigation) — the failure is a FIXABLE incomplete-signal defect, NOT a design dead-end
+
+The Task 5 analysis is correct about what it tested: name-death computed from `identifiers.name` **alone**
+is broken, because C# emits the reference identifier keyed by the terminal token, never the receiver. But
+that is not the only reference signal in the v4 artifact. Direct DB investigation (fresh `src/`-only v4
+scan) found two signals the **as-built Task 2 reader never consulted**:
+
+1. **`pending_relationships` carries the receiver.** For `GraphTraversal.Reach(...)` there are 4 rows with
+   `kind=calls, target_terminal_name=Reach, target_receiver=GraphTraversal, target_display_name=GraphTraversal.Reach`.
+   The receiver/qualifier — the exact thing name-death is blind to — is a first-class column. Matching a
+   symbol's name against `pending_relationships.target_receiver`/`target_terminal_name` (plus resolved
+   `relationships.to_symbol_id`) marks static-access helpers alive.
+2. **A same-file code-occurrence check** (a whole-word appearance of the symbol's name in CODE within its own
+   file, outside its definition span — reusing the existing freshness-guarded file scan) marks same-file bare
+   `const`/field reads alive. These reads emit **no** identifier/relationship in C# at all, so a scoped
+   lexical liveness *save* is the pragmatic signal; it only ever suppresses (conservative, aligned with
+   "facts to check, not deletions").
+
+**Measured on the `src/`-only artifact (328 candidates from the as-built reader):**
+
+| Corrected liveness signal | Candidates rescued |
+|---|---:|
+| reference graph (`pending_relationships` receiver/terminal + resolved `relationships` inbound) | 65 |
+| same-file code occurrence | 235 |
+| **residual (would-be candidates after the fix)** | **28 (8%)** |
+
+16 of the 28 residual are `*ForTest` methods referenced only from `tests/` (excluded from a `src/`-only
+scan — rescued on a full-repo scan); the rest are genuine finds the Task 5 hand-verification already
+confirmed dead (`RegionBackendMetadata`, `TextContentBackendMetadata`, `SearchBackendMetadata`,
+`UnknownWorkspaceIdNote`) plus framework-override blind spots (`ExecuteAsync` overrides of
+`BackgroundService`) that a small override/entry-point suppression clears.
+
+**Corrected verdict:** the as-built reader fails the gate, but the fix is entirely Miller-side and reuses
+data already in the artifact + existing scan plumbing — NOT an extraction rewrite. A cleaner long-term
+option is for julie-extractors to emit `variable_ref` identifiers for C# bare reads (the kind exists in the
+enum but C# does not emit it), giving a structured signal instead of the same-file lexical scan; that is an
+all-languages extractor enhancement, not a blocker for the Miller-side fix. **Corrective dispatch: revise
+the Task 1 evaluator contract + Task 2 reader to add graph-receiver liveness and same-file code occurrence,
+then re-run this gate on a full-repo scan.**
+
+---
+
 ## Headline numbers
 
 | Repo | Examined | Candidates | Confirmed live (false positive) | Plausibly dead (correct) | Precision | CLI wall-clock (compact / --json) |

--- a/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
+++ b/docs/findings/2026-07-07-dead-code-candidates-dogfood.md
@@ -1,6 +1,6 @@
 # Dead-code candidates dogfood — evidence gate (Task 5)
 
-**Date:** 2026-07-07 · **Status:** ❌ **GATE FAILED — do not surface `references candidates`** ·
+**Date:** 2026-07-07 · **Status:** ✅ **GATE PASSED (final re-run; see FINAL VERDICT below) — original first-run verdict preserved beneath** ·
 **Feature under test:** `miller references candidates [--json]` (design
 `docs/plans/2026-07-07-dead-code-candidates-design.md` rev 2) ·
 **Binary:** `1.4.5+1fe27ca2f833` (Release) · **Extractor:** `julie-extract 2.9.0` (schema v4,
@@ -24,6 +24,47 @@ receiver has **zero** `identifiers` rows carrying its name and is falsely flagge
 Per the Task 5 brief this is a **stop-and-report gate**, not a fix lane. The findings below are recorded;
 no "success" commit is made; the false positives are reported to the lead as a design/data mismatch. The
 lead owns any corrective dispatch against Core/Indexing/CLI. Task 5 edits no code.
+
+---
+
+## FINAL VERDICT (2026-07-07 evening) — ✅ GATE PASSED: 392 → 5, zero confirmed-live
+
+The corrective work the first-run addendum called for is complete, and the gate now
+passes literally. Re-run on a full-repo scan with julie-extract **v2.10.0**
+(variable_ref emission across 30 languages — receivers, bare reads, initializer
+members — plus two adversarial-review predicate fixes and two grammar-level fixes)
+and two new Miller evaluator rules:
+
+| Stage | Binary / evaluator | Candidates | Confirmed live |
+|---|---|---:|---:|
+| First run (this doc's original verdict) | 2.9.0 / 9 rules | 392 | ≈388 (99%) |
+| variable_ref emission | 2.10.0 @ adc4d4b / 9 rules | 15 | ≈10 |
+| + override_member + test-path rules | 2.10.0 / 10 rules | 10 | 5 |
+| + live_member_container rule | 2.10.0 / 11 rules | 9 | 4 |
+| + razor grammar fix + C# A*B recovery | 2.10.0 final / 11 rules | **5** | **0** |
+
+The final five, each hand-verified:
+
+1. `RegionBackendMetadata` (SearchTool.cs, constant) — dead, first-run-verified.
+2. `TextContentBackendMetadata` (SearchTool.cs, constant) — dead, first-run-verified.
+3. `SearchBackendMetadata` (SearchTool.cs, method) — dead, first-run-verified.
+4. `UnknownWorkspaceIdNote` (WorkspaceTool.cs, method) — dead, first-run-verified.
+5. `IFS` (scripts/release-promote.sh, constant) — write-only (`while IFS= read`);
+   a TRUE find under the pre-agreed write-only rule. Nuance: setting `IFS` is
+   consumed by the shell runtime, so it is idiomatic rather than deletable — the
+   surface's "fact to check, not a verdict" framing covers exactly this case.
+
+Precision: **100% by the pre-agreed classification** (5/5 true finds; ≈1% on the
+first run). The design's hard gate — zero confirmed-live symbols among Miller-repo
+candidates — is met. `references candidates` is cleared to surface.
+
+What it took (cross-repo ledger): julie-extractors variable_ref emission (30
+languages, locked complement-arm contract), the v2.9.0 savepoint-quadratic scan fix
+(425.9 s → ~7.6 s), java FQ-static-receiver + python match-binding predicate fixes
+(Codex adversarial review), a tree-sitter-razor grammar fix for attribute values
+(anortham fork, upstream PR tris203/tree-sitter-razor#27), a C# `A * B`
+pointer-mis-parse recovery heuristic, and Miller-side rules `override_member` and
+`live_member_container` plus a test-path fallback for `test_symbol`.
 
 ---
 

--- a/docs/plans/2026-07-06-background-bootstrap-design.md
+++ b/docs/plans/2026-07-06-background-bootstrap-design.md
@@ -1,7 +1,8 @@
 # Background Bootstrap + Fast Not-Ready Tool Responses — Design
 
 Date: 2026-07-06
-Status: design for user review (lightweight path — same-session implementation intended)
+Status: design for user review, rev 2 — Codex design review findings folded in (see "Review
+record" at the end); same-session implementation intended
 Driver: 2026-07-06 incident follow-up. The sensitive-root bind fix (`d225dc5`) removed the
 *trigger*, but the underlying UX defect remains: the first MCP tool call runs the entire initial
 julie-extract scan synchronously, and every other call waits behind it with no timeout — 30
@@ -36,8 +37,18 @@ Bound ──BootstrapForRoot (new root)──▶ Running   (existing rebind sema
 ```
 
 State transitions happen under the existing `_gate`. Exposed as
-`BootstrapSnapshot { Phase, CanonicalRoot?, StartedAtUtc?, FailureMessage? }` — a read-only
-snapshot property, safe to render from any thread.
+`BootstrapSnapshot { Phase, CanonicalRoot?, StartedAtUtc?, FailureMessage?, RunGeneration }` — a
+read-only snapshot property, safe to render from any thread.
+
+**Atomic publication (review blocker 1):** today `RunBootstrap` writes `_holder` first and
+`IsBound` is just `_holder is not null` — safe only because everything runs under `_gate` on the
+caller's thread. On a background task that ordering is a torn-state hazard. The background run
+builds a complete immutable `BoundWorkspace { Holder, Resolver, Workspace, Ledger }` in locals,
+then publishes it in ONE step under `_gate` — registry ready-marking and
+`ledger.RebindWorkspace` happen at that same publish point (review should-fix: today they run
+mid-scan, so telemetry attribution and registry state could reflect a bind that then fails), and
+only then does `SignalBound` fire. `IsBound` reads the published record. On background failure:
+state → `Failed`, registry row marked error best-effort, nothing published.
 
 ### `BootstrapForRoot` splits into synchronous gate + background work
 
@@ -54,10 +65,14 @@ snapshot property, safe to render from any thread.
 - On exception: state → `Failed(message)`, error logged; the binding gate is NOT signaled.
   A later `BootstrapForRoot` for the same root retries from `Failed` (self-healing after a
   transient failure — e.g. julie-extract binary restored).
-- A `BootstrapForRoot` for a DIFFERENT root while `Running` is ignored with a warning log
-  (callers see not-ready for the in-flight root; the rebind happens naturally on the next
-  `EnsurePrimaryBound` after the current run completes). Rebind-while-running is rare
-  (roots/list_changed mid-scan) and serializing it is simpler than a preemption protocol.
+- `BootstrapForRoot` returns a `BindOutcome` (`Started | AlreadyBound | JoinedRunning |
+  RebindDeferred`). A DIFFERENT root while `Running` returns `RebindDeferred` with a warning log
+  — and critically, `WorkspaceBindingService` clears `_rootsDirty` ONLY for `Started` /
+  `AlreadyBound` / `JoinedRunning` outcomes (review blocker 2: the current unconditional clear
+  at `WorkspaceBindingService.cs:93-98` would otherwise strand the session on the old root
+  forever — once the old-root run bound, `IsBound && !NeedsRefresh` early-returns and the new
+  root is never bound). With the dirty flag preserved, the first call after the in-flight run
+  completes re-resolves roots and starts the rebind. No preemption protocol needed.
 - Internal test seam `TestRunBootstrapOverride: Action<string>?` — replaces `RunBootstrap` in
   the background task so tests can simulate slow (block on a gate) and failing (throw)
   bootstraps deterministically.
@@ -68,26 +83,49 @@ After `EnsurePrimaryBoundAsync` returns (now fast — it only triggers/joins the
 consults the snapshot:
 
 - `Bound` → call the tool handler (today's happy path).
-- `Running` → await the binding gate with a **grace timeout** (default 5s; env knob
-  `MILLER_BOOTSTRAP_GRACE_SECONDS`, `0` = julie-style immediate fail-fast). If the gate opens in
-  time → proceed to the handler. If not → return
+- `Running` → await a **run-generation-keyed gate** with a **grace timeout** (default 5s; env
+  knob `MILLER_BOOTSTRAP_GRACE_SECONDS`, `0` = julie-style immediate fail-fast). Generation-keyed
+  because `WaitUntilBoundAsync` returns immediately whenever ANY holder exists (review blocker
+  4): during a rebind — `Bound(A) → Running(B)` — the old gate reads "bound" and tools would
+  silently answer from workspace A while B indexes. The filter waits on THIS run's completion;
+  if it opens in time → proceed. If not → return
   `CallToolResult { IsError = true }` with:
   `"Miller is indexing this workspace for the first time: <root> (started <N>s ago). Tool calls
   will work once indexing completes — retry shortly, or run 'workspace status' for progress."`
   A tool-result error (not a protocol error) so agents read the text and retry naturally.
-- `Failed` → return `CallToolResult { IsError = true }` with the stored failure message plus
-  `"The next tool call retries bootstrap automatically."` (and it does — `Failed → Running`).
+- `Failed` → one exact contract (review should-fix: "return stored error, next call retries"
+  was ambiguous because `EnsurePrimaryBoundCoreAsync` re-triggers `BootstrapForRoot` BEFORE the
+  filter inspects state, so the filter would observe `Running`, not `Failed`): the call that
+  finds `Failed` STARTS the retry (`Failed → Running`) and returns
+  `CallToolResult { IsError = true }` with `"bootstrap failed: <stored message>; retry started —
+  call again shortly."` The snapshot keeps `LastFailureMessage` through the retry so the text is
+  available while `Running`.
 - `Idle` with no resolvable root → existing `CreateBindingFailureException` behavior unchanged.
 
 `EnsurePrimaryBoundCoreAsync` no longer holds `_bindLock` for the scan duration (BootstrapForRoot
 returns after dispatch), so queued calls fall through to the grace-wait immediately.
 
-**Workspace-tool exemption:** the `workspace` tool bypasses the not-ready gate so
-`workspace status`/`health` are usable DURING indexing (julie parity: `manage_workspace` worked
-while indexing). When unbound, `workspace status` renders the bootstrap snapshot only —
-`"bootstrap: running <root>, started <N>s ago"` or `"bootstrap: failed — <message>"` — without
-touching index getters (which throw pre-bound). Other workspace operations that need the index
-report the same not-ready line instead of throwing.
+**Workspace-tool exemption — rendered by the FILTER, not the tool (review blocker 3):**
+`WorkspaceTool`'s constructor requires `IndexHolder`, `WorkspaceContext`, `TelemetryLedger`,
+`JulieExtractRunner`, … — all resolved through bootstrap getters that THROW before binding
+(`MillerServiceRegistration.cs:45-48`), so an unbound `workspace` call cannot even construct the
+tool. Instead: when the snapshot is not `Bound` and the tool name is `workspace`
+(`request.Params?.Name`, same pattern telemetry uses), the filter itself returns a SUCCESSFUL
+`CallToolResult` rendering the bootstrap snapshot — `"bootstrap: running <root>, started <N>s
+ago"` / `"bootstrap: failed — <message>"` — for every operation, without invoking the tool.
+Once bound, `workspace` flows normally (and its status render gains a one-line rebind notice
+when a new run is in flight, via an injected `IndexBootstrapService` snapshot — constructible
+because the tool only resolves when bound). julie parity: `manage_workspace` worked while
+indexing.
+
+### Filter ordering and telemetry (review should-fix)
+
+`Program.cs` composes the binding filter OUTSIDE the telemetry filter. That order is now
+load-bearing twice over: telemetry's filter resolves `TelemetryLedger` (a bound-only getter)
+before calling `next`, so it must never run for unbound calls — and consequently not-ready
+responses are NOT telemetered (they are logged by the binding filter instead; acceptable and now
+documented). An integration test pins the composition order so a refactor cannot silently flip
+it.
 
 ### Eager startup path
 
@@ -113,8 +151,9 @@ on failure (same as today's deferred-never-bound case).
   `src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs` (grace wait + not-ready/failed
   results + workspace-tool exemption), `src/Miller.Server/Tools/WorkspaceTool.cs` +
   `WorkspaceRender` (unbound status rendering).
-- Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs` (state transitions, retry
-  from Failed, different-root-while-running ignored),
+- Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs` (state transitions,
+  atomic-publication visibility, `BindOutcome` contract, retry-from-Failed contract,
+  rebind-deferred keeps `_rootsDirty` and rebinds after the in-flight run),
   `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs` (new: grace path, not-ready
   result, failed result, workspace exemption, `MILLER_BOOTSTRAP_GRACE_SECONDS=0`),
   `tests/Miller.Tests/Server/WorkspaceToolTests.cs` (unbound status render).
@@ -130,7 +169,44 @@ on failure (same as today's deferred-never-bound case).
 - [ ] Tool calls after a bootstrap failure return the stored error and the next call retries.
 - [ ] `workspace status`/`health` work during indexing and render the bootstrap snapshot when
       unbound.
+- [ ] `BoundWorkspace` publishes atomically under `_gate`; registry-ready + ledger rebind occur
+      only at the publish point; failed rebind keeps the previous workspace serving (existing
+      `HostStartupRegistrationTests` behavior preserved).
+- [ ] Grace wait is run-generation-keyed; during a rebind, tools return not-ready for the new
+      run rather than silently answering from the old root.
+- [ ] `RebindDeferred` preserves `_rootsDirty`; the deferred rebind starts on the first call
+      after the in-flight run completes (regression test for the stranded-root sequence).
+- [ ] Filter composition order (binding outside telemetry) pinned by an integration test;
+      not-ready responses documented as logged-not-telemetered.
+- [ ] CLAUDE.md host-lifecycle section updated ("getters throw until BOUND", not "until
+      StartAsync"); AGENTS.md regenerated in sync.
 - [ ] Existing binding/bootstrap tests pass unchanged (synchronous `TestBootstrapInterceptor`
       seam preserved).
 - [ ] Fast suite green within budget; no new Scale-tagged tests needed (all simulation via the
       test seams, no real julie-extract spawn).
+
+## Review record (Codex, read-only, 2026-07-06)
+
+Verdict on rev 1: not implement-ready — 4 blockers, 3 should-fix, 1 nit. All verified against
+code before acceptance; all folded into rev 2:
+
+1. **Confirmed — background publication unsafe as drafted** (`_holder` first, `IsBound` =
+   holder-null check). → Atomic `BoundWorkspace` publish under `_gate`, then signal.
+2. **Confirmed — ignore-rebind-while-Running strands the session on the old root** (unconditional
+   `_rootsDirty` clear). → `BindOutcome` return; dirty cleared only on accepting outcomes.
+3. **Confirmed — workspace-tool exemption impossible with current DI** (ctor needs bound-only
+   getters). → Snapshot rendered by the filter itself; tool untouched when unbound.
+4. **Confirmed — `WaitUntilBoundAsync` breaks the grace wait for rebinds** (returns immediately
+   when any holder exists). → Run-generation-keyed gate.
+5. **Accepted — Failed-retry contract was ambiguous.** → Retry-starts-and-reports contract.
+6. **Accepted — filter/telemetry ordering unspecified.** → Binding outside telemetry, pinned by
+   test; not-ready responses logged, not telemetered.
+7. **Accepted — registry/ledger writes mid-scan corrupt attribution on failed rebinds.** →
+   Moved to the atomic publish point; failure marks registry error best-effort.
+8. **Accepted (nit) — CLAUDE.md lifecycle wording.** → "until bound" language + AGENTS regen in
+   the implementation slice.
+
+Dropped by the reviewer after verification: `CallToolResult{IsError}` expressibility and
+tool-name access in filters (both already used by `TelemetryCallToolFilter`), and M3
+hosted-service lifecycle concerns (constructors already take bootstrap lazily; guard test
+covers it).

--- a/docs/plans/2026-07-06-background-bootstrap-design.md
+++ b/docs/plans/2026-07-06-background-bootstrap-design.md
@@ -1,0 +1,136 @@
+# Background Bootstrap + Fast Not-Ready Tool Responses — Design
+
+Date: 2026-07-06
+Status: design for user review (lightweight path — same-session implementation intended)
+Driver: 2026-07-06 incident follow-up. The sensitive-root bind fix (`d225dc5`) removed the
+*trigger*, but the underlying UX defect remains: the first MCP tool call runs the entire initial
+julie-extract scan synchronously, and every other call waits behind it with no timeout — 30
+silent minutes against a huge tree. julie (the product-family predecessor) ran indexing in
+`spawn_blocking` off the request path and answered tools immediately with an actionable
+not-ready message (`julie/src/tools/workspace/indexing/index.rs:104`,
+`julie/src/handler/workspace_resolution.rs:91`). Miller regressed that; this restores it.
+
+## Verified current behavior (the defect)
+
+- `WorkspaceBindingCallToolFilter` awaits `EnsurePrimaryBoundAsync` before EVERY tool handler.
+- Deferred path: `EnsurePrimaryBoundCoreAsync` takes `_bindLock`, then
+  `IndexBootstrapService.BootstrapForRoot` → `RunBootstrap` runs `runner.Scan(...)`
+  **synchronously inside the tool call** (`IndexBootstrapService.cs:227`), holding `_bindLock`
+  for the scan's whole duration. Queued calls wait on `_bindLock.WaitAsync(ct)` — cancellation
+  is the only exit.
+- Eager path: `StartAsync` calls `BootstrapForRoot` inline, blocking host startup on the scan.
+- Other waiters use `WaitUntilBoundAsync` → `_bindingReady.Task.WaitAsync(ct)` — no timeout.
+- No progress signal, no not-ready response, no failure surface: a failed background rebind or a
+  wedged julie-extract is indistinguishable from a slow scan.
+
+## Design
+
+### Bootstrap state machine (`IndexBootstrapService`)
+
+```
+Idle ──BootstrapForRoot──▶ Running { canonicalRoot, source, startedAtUtc }
+Running ──scan+load ok──▶ Bound        (existing SignalBound gate fires)
+Running ──exception─────▶ Failed { canonicalRoot, message, failedAtUtc }
+Failed ──BootstrapForRoot (retry)──▶ Running
+Bound ──BootstrapForRoot (new root)──▶ Running   (existing rebind semantics)
+```
+
+State transitions happen under the existing `_gate`. Exposed as
+`BootstrapSnapshot { Phase, CanonicalRoot?, StartedAtUtc?, FailureMessage? }` — a read-only
+snapshot property, safe to render from any thread.
+
+### `BootstrapForRoot` splits into synchronous gate + background work
+
+**Stays synchronous on the caller's thread (unchanged semantics):**
+- `CanonicalizeAndRejectSensitiveRoot` for every source — the `d225dc5` guard still throws
+  immediately at bind time, BEFORE any state transition or background dispatch.
+- Same-canonical-root idempotence check (already-bound → return; already-Running for the same
+  root → return).
+- `TestBootstrapInterceptor` — invoked synchronously exactly as today; returning true skips the
+  background dispatch entirely. Existing tests keep passing unmodified.
+
+**Moves to a background task (`Task.Run`):**
+- `RunBootstrap` (julie-extract scan, index load, registry write) + `SignalBound`.
+- On exception: state → `Failed(message)`, error logged; the binding gate is NOT signaled.
+  A later `BootstrapForRoot` for the same root retries from `Failed` (self-healing after a
+  transient failure — e.g. julie-extract binary restored).
+- A `BootstrapForRoot` for a DIFFERENT root while `Running` is ignored with a warning log
+  (callers see not-ready for the in-flight root; the rebind happens naturally on the next
+  `EnsurePrimaryBound` after the current run completes). Rebind-while-running is rare
+  (roots/list_changed mid-scan) and serializing it is simpler than a preemption protocol.
+- Internal test seam `TestRunBootstrapOverride: Action<string>?` — replaces `RunBootstrap` in
+  the background task so tests can simulate slow (block on a gate) and failing (throw)
+  bootstraps deterministically.
+
+### Fast not-ready tool responses (`WorkspaceBindingCallToolFilter`)
+
+After `EnsurePrimaryBoundAsync` returns (now fast — it only triggers/joins the bind), the filter
+consults the snapshot:
+
+- `Bound` → call the tool handler (today's happy path).
+- `Running` → await the binding gate with a **grace timeout** (default 5s; env knob
+  `MILLER_BOOTSTRAP_GRACE_SECONDS`, `0` = julie-style immediate fail-fast). If the gate opens in
+  time → proceed to the handler. If not → return
+  `CallToolResult { IsError = true }` with:
+  `"Miller is indexing this workspace for the first time: <root> (started <N>s ago). Tool calls
+  will work once indexing completes — retry shortly, or run 'workspace status' for progress."`
+  A tool-result error (not a protocol error) so agents read the text and retry naturally.
+- `Failed` → return `CallToolResult { IsError = true }` with the stored failure message plus
+  `"The next tool call retries bootstrap automatically."` (and it does — `Failed → Running`).
+- `Idle` with no resolvable root → existing `CreateBindingFailureException` behavior unchanged.
+
+`EnsurePrimaryBoundCoreAsync` no longer holds `_bindLock` for the scan duration (BootstrapForRoot
+returns after dispatch), so queued calls fall through to the grace-wait immediately.
+
+**Workspace-tool exemption:** the `workspace` tool bypasses the not-ready gate so
+`workspace status`/`health` are usable DURING indexing (julie parity: `manage_workspace` worked
+while indexing). When unbound, `workspace status` renders the bootstrap snapshot only —
+`"bootstrap: running <root>, started <N>s ago"` or `"bootstrap: failed — <message>"` — without
+touching index getters (which throw pre-bound). Other workspace operations that need the index
+report the same not-ready line instead of throwing.
+
+### Eager startup path
+
+`StartAsync` uses the same split: guard synchronously, dispatch the scan to background, return.
+Host startup and MCP initialize no longer block on the initial scan; for small repos the scan
+typically wins the race with the first tool call anyway, and the grace period absorbs the rest.
+The M3 hosted services are unaffected — they already read bootstrap getters lazily inside
+`ExecuteAsync` and wait on the binding gate, which still signals on success and stays unsignaled
+on failure (same as today's deferred-never-bound case).
+
+### What this does NOT do (YAGNI)
+
+- No mid-scan progress percentages: julie-extract reports at scan end; the status line reports
+  root + elapsed, which is what an operator needs to distinguish "working" from "wedged".
+- No preemptive cancel of an in-flight scan on rebind, no scan queue.
+- No MCP progress notifications (revisit if agent harnesses start rendering them).
+
+## Files
+
+- Modify: `src/Miller.Server/Hosting/IndexBootstrapService.cs` (state machine, background
+  dispatch, test seam), `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (fast return,
+  snapshot passthrough on `IWorkspaceBindingService`),
+  `src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs` (grace wait + not-ready/failed
+  results + workspace-tool exemption), `src/Miller.Server/Tools/WorkspaceTool.cs` +
+  `WorkspaceRender` (unbound status rendering).
+- Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs` (state transitions, retry
+  from Failed, different-root-while-running ignored),
+  `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs` (new: grace path, not-ready
+  result, failed result, workspace exemption, `MILLER_BOOTSTRAP_GRACE_SECONDS=0`),
+  `tests/Miller.Tests/Server/WorkspaceToolTests.cs` (unbound status render).
+
+## Acceptance criteria
+
+- [ ] Sensitive-root rejection still throws synchronously at bind time for every source
+      (existing `d225dc5` regression tests pass unchanged).
+- [ ] The initial scan runs on a background task in BOTH eager and deferred paths; no tool call
+      and no host startup ever blocks for the scan's duration.
+- [ ] Tool calls during `Running` return an is-error result with root + elapsed after the grace
+      timeout; `MILLER_BOOTSTRAP_GRACE_SECONDS` honored, `0` = immediate.
+- [ ] Tool calls after a bootstrap failure return the stored error and the next call retries.
+- [ ] `workspace status`/`health` work during indexing and render the bootstrap snapshot when
+      unbound.
+- [ ] Existing binding/bootstrap tests pass unchanged (synchronous `TestBootstrapInterceptor`
+      seam preserved).
+- [ ] Fast suite green within budget; no new Scale-tagged tests needed (all simulation via the
+      test seams, no real julie-extract spawn).

--- a/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
@@ -222,10 +222,10 @@ failed text + retry started, unbound `workspace` → successful snapshot render,
 `workspace` → passthrough.
 
 **Acceptance criteria:**
-- [ ] All eight filter behaviors above tested and green; texts match Global Constraints verbatim
-- [ ] Ordering pin test locks binding-outside-telemetry (or documents + pins reality per plan
+- [x] All eight filter behaviors above tested and green; texts match Global Constraints verbatim
+- [x] Ordering pin test locks binding-outside-telemetry (or documents + pins reality per plan
       mismatch note)
-- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+- [x] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
 
 ### Task 4: Status surfaces, CLAUDE.md, branch gate
 

--- a/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
@@ -260,10 +260,10 @@ invariant and the new env knob (do not restructure other sections); finish with 
 `dotnet build Miller.slnx -c Release` (0 warnings), recording both in the ledger.
 
 **Acceptance criteria:**
-- [ ] Rebind notice rendered only when Running-while-bound; absent otherwise
-- [ ] CLAUDE.md updated, AGENTS.md regenerated, `cmp -s` clean
-- [ ] Branch gate green: fast + scale suites, Release build 0 warnings
-- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+- [x] Rebind notice rendered only when Running-while-bound; absent otherwise
+- [x] CLAUDE.md updated, AGENTS.md regenerated, `cmp -s` clean
+- [x] Branch gate green: fast + scale suites, Release build 0 warnings
+- [x] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
 
 ---
 

--- a/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
@@ -133,15 +133,15 @@ A keeps serving. Concurrency test: two threads call `BootstrapForRoot` for the s
 `Started`, one `JoinedRunning`, single background run.
 
 **Acceptance criteria:**
-- [ ] `d225dc5` guard tests and all existing bootstrap/host tests pass unchanged
-- [ ] Slow-run simulation: `IsBound` false, snapshot `Running` with root+start time, host
+- [x] `d225dc5` guard tests and all existing bootstrap/host tests pass unchanged
+- [x] Slow-run simulation: `IsBound` false, snapshot `Running` with root+start time, host
       `StartAsync` returns immediately in BOTH eager and deferred paths
-- [ ] Failed-run simulation: snapshot `Failed`+message, gate unsignaled, registry error-marked,
+- [x] Failed-run simulation: snapshot `Failed`+message, gate unsignaled, registry error-marked,
       same-root retry transitions to `Running`
-- [ ] Atomic publication proven: no observer sees `IsBound==true` before the full
+- [x] Atomic publication proven: no observer sees `IsBound==true` before the full
       `BoundWorkspace` (test polls getters from another thread during a gated publish)
-- [ ] `WaitForRunAsync` completes on that run's bind AND on its failure
-- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+- [x] `WaitForRunAsync` completes on that run's bind AND on its failure
+- [x] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
 
 ### Task 2: BindOutcome / rootsDirty contract in WorkspaceBindingService
 
@@ -232,13 +232,15 @@ failed text + retry started, unbound `workspace` → successful snapshot render,
 **Files:**
 - Modify: `src/Miller.Server/Tools/WorkspaceTool.cs` (status op), `src/Miller.Server/Tools/WorkspaceRender.cs:193` (status render — one-line rebind notice when a new run is in flight while bound)
 - Modify: `CLAUDE.md` "Host lifecycle gotcha" + "Server host & startup" sections ("getters throw until BOUND", background bootstrap, `MILLER_BOOTSTRAP_GRACE_SECONDS`), then `scripts/sync-agents.sh`, then `cmp -s CLAUDE.md AGENTS.md`
-- Test: `tests/Miller.Tests/Server/WorkspaceToolTests.cs`
+- Test: `tests/Miller.Tests/Server/WorkspaceToolTests.cs` (bound-side rebind notice only; unbound
+  `workspace` snapshot rendering belongs to Task 3's filter tests because the tool cannot
+  construct before binding)
 
 **Interfaces:**
 - Consumes: Task 1's snapshot (inject `IndexBootstrapService` into `WorkspaceTool` — safe, the
   tool only constructs when bound; the UNBOUND case is fully handled by Task 3's filter render
   and needs nothing here).
-- Produces: `workspace status` shows `rebinding: <new root> (started <N>s ago)` when
+- Produces: bound `workspace status` shows `rebinding: <new root> (started <N>s ago)` when
   `Snapshot.Phase == Running` while bound; docs match shipped behavior.
 
 **Contract inputs:** design rev 2 §"Workspace-tool exemption" (bound-side notice only) and the

--- a/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
@@ -175,9 +175,9 @@ starts on the next ensure call (snapshot root == B). Keep `EnsurePrimaryBoundFro
 test seam behavior intact.
 
 **Acceptance criteria:**
-- [ ] Stranded-root regression sequence passes (fails on pre-task code)
-- [ ] Dirty cleared on accepting outcomes only; existing binding tests pass
-- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+- [x] Stranded-root regression sequence passes (fails on pre-task code)
+- [x] Dirty cleared on accepting outcomes only; existing binding tests pass
+- [x] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
 
 ### Task 3: Filter — grace wait, not-ready/failed results, workspace snapshot render, ordering pin
 

--- a/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-07-06-background-bootstrap-implementation-plan.md
@@ -1,0 +1,271 @@
+# Background Bootstrap + Fast Not-Ready Responses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use razorback:subagent-driven-development when
+> subagent delegation is available. Fall back to razorback:executing-plans for single-task,
+> tightly-sequential, or no-delegation runs.
+
+**Goal:** Move Miller's initial index scan off the MCP tool-call path onto a background task and
+give tool calls fast, actionable not-ready/failed responses, per
+[`2026-07-06-background-bootstrap-design.md`](2026-07-06-background-bootstrap-design.md) (rev 2 —
+the authoritative spec; implementers MUST read the cited sections before coding).
+
+**Architecture:** A bootstrap state machine (`Idle/Running/Bound/Failed`) in
+`IndexBootstrapService` with atomic `BoundWorkspace` publication under `_gate`; `BootstrapForRoot`
+returns a `BindOutcome` and dispatches `RunBootstrap` to `Task.Run`; the binding filter waits a
+run-generation-keyed grace gate and returns `CallToolResult{IsError=true}` status text on
+timeout/failure, rendering the `workspace` tool's snapshot itself while unbound.
+
+**Tech Stack:** .NET 10, existing MCP SDK filter chain, xUnit fast suite.
+
+**Architecture Quality:** Approved shape per design rev 2: state machine + publication in
+`IndexBootstrapService`; outcome/dirty contract in `WorkspaceBindingService`; grace/not-ready/
+snapshot-render in `WorkspaceBindingCallToolFilter`; no new services, no DI changes to
+`WorkspaceTool` construction. Architecture risk: medium (concurrency + filter contract). If code
+reality contradicts this shape, report a plan mismatch — do not redesign locally.
+
+## Global Constraints
+
+- Design rev 2 is the spec. Exact contracts: `BindOutcome = Started | AlreadyBound |
+  JoinedRunning | RebindDeferred`; snapshot
+  `BootstrapSnapshot { Phase, CanonicalRoot?, StartedAtUtc?, FailureMessage?, RunGeneration }`;
+  grace env knob `MILLER_BOOTSTRAP_GRACE_SECONDS` (default 5, `0` = immediate fail-fast).
+- Exact response texts (agent-facing contract, keep verbatim): not-ready →
+  `"Miller is indexing this workspace for the first time: <root> (started <N>s ago). Tool calls
+  will work once indexing completes — retry shortly, or run 'workspace status' for progress."`;
+  failed → `"bootstrap failed: <stored message>; retry started — call again shortly."`
+- The `d225dc5` sensitive-root guard stays synchronous at bind time for every source; its
+  regression tests must pass unchanged.
+- `TestBootstrapInterceptor` stays synchronous and short-circuits background dispatch (existing
+  tests pass unmodified).
+- Every task ends with `scripts/test.sh` green (fast suite, warnings-as-errors build). No new
+  test may spawn julie-extract (all simulation via seams; anything else would need
+  `[Trait("Category","Scale")]` — this plan should not need it).
+- CLAUDE.md is edited first, then `scripts/sync-agents.sh`, then `cmp -s CLAUDE.md AGENTS.md`
+  (repo rule) — Task 4 only.
+
+## Verification Strategy
+
+**Project source of truth:** `CLAUDE.md` "Testing" section; `scripts/test.sh`.
+
+**Worker red/green scope:** `dotnet test tests/Miller.Tests/Miller.Tests.csproj --filter
+"FullyQualifiedName~<TestClassOrMethod>"` for the task's named tests.
+
+**Worker ceiling:** `scripts/test.sh` (fast suite). Workers never run the scale suite.
+
+**Worker gate invariant:** each task's acceptance criteria name the behaviors its tests prove;
+red-first is required where a behavior changes.
+
+**Lead affected-change scope:** `scripts/test.sh` after each task's commit.
+
+**Branch gate:** `scripts/test.sh all` — the scale suite is REQUIRED here because this plan
+touches the indexing/bootstrap path (CLAUDE.md rule), plus `dotnet build Miller.slnx -c Release`
+(0 warnings) so running servers pick up the fix on next launch.
+
+**Replay/metric evidence:** none — behavior gates only.
+
+**Escalation triggers:** any change touching `JulieExtractRunner`, `FullRebuildPromotion`, or
+leadership files escalates to the scale suite immediately (not expected in this plan).
+
+**Assigned verification failure:** Workers stop and report when assigned verification fails.
+
+**Verification ledger:** Record invariant, command, scope label, commit SHA, result, timestamp
+per task. Reuse same-HEAD passing evidence.
+
+## Parallel Execution Contract
+
+| Task | Parallel batch | File ownership | Serialization required | Dependency reason |
+|---|---|---|---|---|
+| Task 1: State machine + atomic publication + background dispatch | None - serial | Modify: `src/Miller.Server/Hosting/IndexBootstrapService.cs`, `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (minimal compile adaptation only); Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs` | Yes | Foundation — every later task consumes its types; same files as Task 2. |
+| Task 2: BindOutcome / rootsDirty contract | None - serial | Modify: `src/Miller.Server/Hosting/WorkspaceBindingService.cs`; Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs` | Yes | Consumes Task 1's `BindOutcome`; same test file as Task 1. |
+| Task 3: Filter grace/not-ready/failed/snapshot render | None - serial | Modify: `src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs`, `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (snapshot passthrough on `IWorkspaceBindingService`); Test: `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs` | Yes | Consumes Task 1's snapshot + run-generation gate and Task 2's outcome semantics. |
+| Task 4: Status surfaces, docs, branch gate | None - serial | Modify: `src/Miller.Server/Tools/WorkspaceTool.cs`, `src/Miller.Server/Tools/WorkspaceRender.cs`, `CLAUDE.md` (+ regenerated `AGENTS.md`); Test: `tests/Miller.Tests/Server/WorkspaceToolTests.cs` | Yes | Consumes the full stack; runs the branch gate. |
+
+Commit mode: `serial-worker-commit` for all tasks.
+
+---
+
+### Task 1: State machine, atomic publication, background dispatch (both paths)
+
+**Files:**
+- Modify: `src/Miller.Server/Hosting/IndexBootstrapService.cs` (`StartAsync` :100, `BootstrapForRoot` :127, `SignalBound` :158, `RunBootstrap` :174, publication block :328-340, `IsBound`/`WaitUntilBoundAsync` :64-86)
+- Modify: `src/Miller.Server/Hosting/WorkspaceBindingService.cs` — ONLY the minimal adaptation to the new `BootstrapForRoot` return type (ignore the outcome for now; Task 2 owns the contract)
+- Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs`
+
+**Interfaces:**
+- Consumes: design rev 2 §"Bootstrap state machine" and §"`BootstrapForRoot` splits".
+- Produces (Tasks 2–4 rely on):
+  - `enum BindOutcome { Started, AlreadyBound, JoinedRunning, RebindDeferred }`;
+    `BootstrapForRoot(...) -> BindOutcome`.
+  - `BootstrapSnapshot Snapshot { get; }` with
+    `{ Phase (Idle|Running|Bound|Failed), CanonicalRoot?, StartedAtUtc?, FailureMessage?,
+    LastFailureMessage?, RunGeneration }`.
+  - `Task WaitForRunAsync(int runGeneration, CancellationToken ct)` — completes when THAT run
+    binds or fails (both outcomes complete the wait; caller re-reads the snapshot).
+  - `internal Action<string>? TestRunBootstrapOverride` — replaces `RunBootstrap` inside the
+    background task (throw = Failed path; block on a gate = slow-scan simulation).
+  - Semantics: guard + idempotence + interceptor synchronous; `RunBootstrap` + publication on
+    `Task.Run`; `BoundWorkspace` built in locals and published in ONE step under `_gate`
+    (registry ready-mark + `ledger.RebindWorkspace` at the publish point, error-mark on failure);
+    `SignalBound` only after publish; `Failed → Running` allowed on same-root retry.
+
+**Contract inputs:** existing `_gate`, `_bindingReady` gate + `BindingGeneration` counter,
+`TestBootstrapInterceptor` (must stay synchronous), `d225dc5` guard tests
+(`BootstrapForRoot_RejectsSensitiveRoot*`), `HostStartupRegistrationTests` failed-rebind-keeps-
+previous-workspace behavior (:88).
+
+**File ownership:** Modify: `src/Miller.Server/Hosting/IndexBootstrapService.cs`, `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (minimal compile adaptation only); Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Foundation — every later task consumes its types; same files as Task 2.
+
+**What to build:** The state machine and the thread-safety core: split `BootstrapForRoot`,
+background both the eager (`StartAsync`) and deferred paths, publish atomically, key the wait
+gate by run generation, keep failed rebinds serving the previous workspace.
+
+**Approach:** Restructure `RunBootstrap`'s tail so holder/resolver/workspace/ledger land in a
+`BoundWorkspace` record; move the registry `MarkReady`/scan-stamp and `ledger.RebindWorkspace`
+calls to the publish step (verify current call order at :299-340 while editing). TDD via the
+seams: slow-run test (override blocks) proves `IsBound` stays false and the snapshot reads
+`Running`; failing-run test proves `Failed` + `FailureMessage` + gate NOT signaled + registry
+error-marked; retry test proves `Failed → Running → Bound`; rebind-failure test proves workspace
+A keeps serving. Concurrency test: two threads call `BootstrapForRoot` for the same root — one
+`Started`, one `JoinedRunning`, single background run.
+
+**Acceptance criteria:**
+- [ ] `d225dc5` guard tests and all existing bootstrap/host tests pass unchanged
+- [ ] Slow-run simulation: `IsBound` false, snapshot `Running` with root+start time, host
+      `StartAsync` returns immediately in BOTH eager and deferred paths
+- [ ] Failed-run simulation: snapshot `Failed`+message, gate unsignaled, registry error-marked,
+      same-root retry transitions to `Running`
+- [ ] Atomic publication proven: no observer sees `IsBound==true` before the full
+      `BoundWorkspace` (test polls getters from another thread during a gated publish)
+- [ ] `WaitForRunAsync` completes on that run's bind AND on its failure
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 2: BindOutcome / rootsDirty contract in WorkspaceBindingService
+
+**Files:**
+- Modify: `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (`EnsurePrimaryBoundCoreAsync` :73-104, `NeedsRefresh` :106)
+- Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's `BindOutcome`.
+- Produces: `_rootsDirty` cleared ONLY on `Started | AlreadyBound | JoinedRunning`;
+  `RebindDeferred` preserves dirty + cached roots stay uncleared so the first call after the
+  in-flight run completes re-resolves and starts the rebind (design rev 2 review blocker 2).
+  `_bindLock` held only for the resolve+dispatch (never scan duration).
+
+**Contract inputs:** design rev 2 §"`BootstrapForRoot` splits" (the stranded-root sequence);
+existing roots caching in `GetRootUrisAsync`.
+
+**File ownership:** Modify: `src/Miller.Server/Hosting/WorkspaceBindingService.cs`; Test: `tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Consumes Task 1's `BindOutcome`; same test file as Task 1.
+
+**What to build:** The outcome-conditional dirty clear plus the stranded-root regression test:
+bind A (slow, running) → roots change to B (`MarkRootsDirty`) → `EnsurePrimaryBound` returns
+`RebindDeferred` (dirty stays true) → A completes → next `EnsurePrimaryBound` starts B →
+B binds. Without the fix this sequence leaves the session on A forever.
+
+**Approach:** Use Task 1's seams: gate-blocked override for A's run, release, assert B's run
+starts on the next ensure call (snapshot root == B). Keep `EnsurePrimaryBoundFromRootsAsync`
+test seam behavior intact.
+
+**Acceptance criteria:**
+- [ ] Stranded-root regression sequence passes (fails on pre-task code)
+- [ ] Dirty cleared on accepting outcomes only; existing binding tests pass
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 3: Filter — grace wait, not-ready/failed results, workspace snapshot render, ordering pin
+
+**Files:**
+- Modify: `src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs`
+- Modify: `src/Miller.Server/Hosting/WorkspaceBindingService.cs` — add `BootstrapSnapshot Snapshot { get; }` + `Task WaitForRunAsync(int, CancellationToken)` passthroughs to `IWorkspaceBindingService`
+- Test: `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 1's snapshot + `WaitForRunAsync`; Task 2's fast-return semantics; the exact
+  response texts from Global Constraints; tool name via `request.Params?.Name` (pattern:
+  `TelemetryCallToolFilter.cs:52`); is-error result shape (pattern: `TelemetryCallToolFilter.cs:117`).
+- Produces: the full agent-facing not-ready contract — `Bound` → next(); `Running` →
+  `WaitForRunAsync(snapshot.RunGeneration)` with grace timeout from
+  `MILLER_BOOTSTRAP_GRACE_SECONDS` (default 5, `0` = skip wait) → re-read snapshot → proceed if
+  `Bound`, else is-error not-ready text; `Failed` → is-error failed text (the ensure call
+  already started the retry — assert snapshot went `Running` with `LastFailureMessage`
+  preserved); unbound `workspace` tool → SUCCESSFUL result rendering the snapshot without
+  invoking the tool.
+
+**Contract inputs:** design rev 2 §"Fast not-ready tool responses", §"Workspace-tool exemption",
+§"Filter ordering and telemetry"; filter registration order at `src/Miller.Server/Program.cs:111-115`
+(binding added before telemetry — the ordering-pin test asserts binding runs OUTSIDE, i.e. an
+unbound call never reaches the telemetry filter; verify actual composition direction in the MCP
+SDK while writing the test and pin whichever direction reality has, reporting a plan mismatch if
+telemetry turns out to be outer).
+
+**File ownership:** Modify: `src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs`, `src/Miller.Server/Hosting/WorkspaceBindingService.cs` (snapshot passthrough on `IWorkspaceBindingService`); Test: `tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Consumes Task 1's snapshot + run-generation gate and Task 2's outcome semantics.
+
+**What to build:** The user-visible half: grace wait, the two is-error texts, the workspace
+snapshot render, env knob, and the composition-order pin test.
+
+**Approach:** Drive the filter directly in tests (compose a fake `next`, fake binding service
+with scripted snapshots) — no MCP transport needed; follow the existing test file's pattern.
+Cover: bound passthrough, running + gate opens within grace → proceeds, running + timeout →
+not-ready text, grace `0` → immediate, cancellation during grace honors the token, failed →
+failed text + retry started, unbound `workspace` → successful snapshot render, bound
+`workspace` → passthrough.
+
+**Acceptance criteria:**
+- [ ] All eight filter behaviors above tested and green; texts match Global Constraints verbatim
+- [ ] Ordering pin test locks binding-outside-telemetry (or documents + pins reality per plan
+      mismatch note)
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 4: Status surfaces, CLAUDE.md, branch gate
+
+**Files:**
+- Modify: `src/Miller.Server/Tools/WorkspaceTool.cs` (status op), `src/Miller.Server/Tools/WorkspaceRender.cs:193` (status render — one-line rebind notice when a new run is in flight while bound)
+- Modify: `CLAUDE.md` "Host lifecycle gotcha" + "Server host & startup" sections ("getters throw until BOUND", background bootstrap, `MILLER_BOOTSTRAP_GRACE_SECONDS`), then `scripts/sync-agents.sh`, then `cmp -s CLAUDE.md AGENTS.md`
+- Test: `tests/Miller.Tests/Server/WorkspaceToolTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's snapshot (inject `IndexBootstrapService` into `WorkspaceTool` — safe, the
+  tool only constructs when bound; the UNBOUND case is fully handled by Task 3's filter render
+  and needs nothing here).
+- Produces: `workspace status` shows `rebinding: <new root> (started <N>s ago)` when
+  `Snapshot.Phase == Running` while bound; docs match shipped behavior.
+
+**Contract inputs:** design rev 2 §"Workspace-tool exemption" (bound-side notice only) and the
+review-record nit; CLAUDE.md edit-then-sync rule.
+
+**File ownership:** Modify: `src/Miller.Server/Tools/WorkspaceTool.cs`, `src/Miller.Server/Tools/WorkspaceRender.cs`, `CLAUDE.md` (+ regenerated `AGENTS.md`); Test: `tests/Miller.Tests/Server/WorkspaceToolTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Consumes the full stack; runs the branch gate.
+
+**What to build:** The bound-side rebind notice, the doc truth-up, and the branch gate.
+
+**Approach:** Render test for the rebind line; CLAUDE.md wording change scoped to the lifecycle
+invariant and the new env knob (do not restructure other sections); finish with the branch gate:
+`scripts/test.sh all` (scale suite required — indexing path touched) and
+`dotnet build Miller.slnx -c Release` (0 warnings), recording both in the ledger.
+
+**Acceptance criteria:**
+- [ ] Rebind notice rendered only when Running-while-bound; absent otherwise
+- [ ] CLAUDE.md updated, AGENTS.md regenerated, `cmp -s` clean
+- [ ] Branch gate green: fast + scale suites, Release build 0 warnings
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+---
+
+## Out of scope
+
+Mid-scan progress percentages, scan preemption on rebind, MCP progress notifications (design
+§YAGNI). Pushing the commits and any release remain user-approval items.

--- a/docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md
+++ b/docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md
@@ -1,0 +1,101 @@
+# Miller Standalone Bolstering Assessment
+
+Date: 2026-07-06
+Status: assessment for user review — no direction approved yet, nothing implemented.
+
+## Context
+
+Eros is not shipping and may never ship. The user wants Miller to be a complete standalone tool,
+not one that leaves visible holes labeled "Eros owns this." This assessment inventories what the
+dashboard and CLI already deliver, which Eros-deferred capabilities are worth absorbing, and a
+prioritized order. The constraint that survives: Miller stays deterministic and local — absorbing
+Eros *workflows* does not mean absorbing embeddings or semantic ranking.
+
+## Current state (verified 2026-07-06 against live dashboard + CLI)
+
+Dashboard (index page): all registered workspaces (166 on this machine), aggregate file/symbol
+counts, filterable table, JSON feeds (`workspaces.json`, `activity.json`, `telemetry.json`,
+`diagnostics.json`).
+
+Dashboard (workspace detail): index transparency (files, symbols, languages, symbol kinds,
+freshness, revision, extractor version, sidecar status), health panel with warnings and
+recommended actions, pattern inventory, telemetry-derived onboarding (hot targets, misses,
+starters), local metrics panel (complexity hotspots + clone groups), context savings, activity
+feed, refresh action.
+
+CLI already ships the raw facts Eros was meant to consume:
+
+- `metrics churn|clones|complexity --json` (contract: `docs/contracts/metrics-json-v1.md`);
+  churn maps git hunks to current-index symbols.
+- `references export --jsonl` (contract: `docs/contracts/references-export-v1.md`); raw usage
+  facts, explicitly *not* a dead-code verdict.
+- `todos` (marker audit), `patterns`, `impact --json`, `trace --json`, `telemetry export`,
+  `content export`, `capabilities --json`.
+
+## Gap inventory — what is deferred to Eros today
+
+| Capability | Facts already in Miller? | Deterministic? | Verdict |
+|---|---|---|---|
+| Hotspots (churn × complexity) | Yes — both metrics exist separately | Yes | Absorb — cheap join |
+| Dead-code candidates | Yes — `references export` raw facts | Yes, with explicit heuristics | Absorb — needs careful suppression design |
+| Signals rollup (one repo report) | Yes — all inputs exist | Yes — composition only | Absorb |
+| History / trends | No — everything is point-in-time | Yes — needs a snapshot sidecar | Absorb later — real design work |
+| Semantic/vector retrieval, embeddings | No | No | Keep out (or revisit as an explicit opt-in later) |
+| Confidence/evidence views, commercial orchestration | No | Partially | Keep out — onboarding panel covers the useful subset |
+
+## Proposed roadmap (priority order)
+
+### P1 — Hotspots: `metrics hotspots`
+
+Join churn rows with complexity rows on current-index symbol id; rank by a stated deterministic
+formula (e.g. normalized churn rank × complexity rank). Surface as `miller metrics hotspots
+[--json]` and a dashboard panel row in the local metrics panel. Smallest slice, immediate "where
+is the risky code" value. Additive to metrics-json-v1.
+
+### P2 — Dead-code candidates: `references candidates`
+
+Deterministic candidate list from the `identifiers`/references facts: symbols with zero inbound
+references, minus explicit suppression classes (entry points, exported/public API surface flagged
+as such, test symbols, generated paths, framework-bound symbols discoverable via structural facts
+like routes/handlers). Every suppression is a named, listed rule — output states what was
+suppressed and why, so it reads as facts, not a verdict. CLI (`--json`) + dashboard panel.
+This is the highest-value absorb but needs the most design care to avoid false-positive noise.
+
+### P3 — Signals rollup: `miller report`
+
+One command composing existing facts into a single repo quality report: health warnings, marker
+counts, top complexity hotspots, top clone groups, top churn/hotspot rows, dead-code candidate
+count. Markdown (human) + JSON (agent/CI) output, plus a dashboard summary section. Pure
+composition — no new extraction.
+
+### P4 — Metric history and trends
+
+A revision-keyed snapshot sidecar (same derived-index pattern as `telemetry.db`/`search.db`)
+recording per-revision metric aggregates; dashboard trend sparklines (symbol count, complexity
+distribution, clone count, marker count over time). Needs design: when snapshots are taken
+(leader convergence vs explicit), retention, and schema. Do after P1–P3 prove out.
+
+### Explicitly out (for now)
+
+- Embeddings/semantic retrieval — changes Miller's deterministic character, heavy deps
+  (model + vector store). Revisit only as a deliberate, separate decision.
+- Fleet/cross-workspace ranking, suppression persistence, task orchestration — no demonstrated
+  standalone need yet.
+
+## Boundary housekeeping (required alongside any absorb)
+
+- CLAUDE.md "1.0 replacement boundary" section, README replacement-story section, public site
+  copy, and the Eros-boundary paragraphs in `docs/contracts/*.md` all say Eros owns these
+  workflows. Update them in the same slice that ships each capability, or the docs will
+  contradict the product.
+- MCP surface stays stingy: all of the above land as CLI verbs + dashboard surfaces (the
+  established `metrics` pattern), **no new MCP tools** — `search`/`inspect`/`context` remain the
+  agent-facing surface, and agents can shell out to the CLI for reports.
+
+## Acceptance criteria for this assessment
+
+- [x] Dashboard functionality inventoried from live instance + code
+- [x] CLI fact surfaces verified against actual binary and contracts
+- [x] Eros-deferred capabilities enumerated with absorb/keep-out verdicts
+- [x] Prioritized roadmap with rationale
+- [ ] User picks direction (which priorities to green-light) — pending

--- a/docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md
+++ b/docs/plans/2026-07-06-miller-standalone-bolstering-assessment.md
@@ -1,7 +1,41 @@
 # Miller Standalone Bolstering Assessment
 
 Date: 2026-07-06
-Status: assessment for user review — no direction approved yet, nothing implemented.
+Status: consensus reached (Claude + Codex adversarial review, user-directed); implementation started
+on the amended priorities below. The original roadmap section is retained below for history.
+
+## Consensus amendments (Codex adversarial review, 2026-07-06)
+
+Codex verdict on the original roadmap: rework. Verified findings that changed the plan:
+
+1. **`metrics hotspots` name is taken.** `hotspots` is an existing CLI alias normalized to
+   `complexity` (`MetricsTool.NormalizeOperation`, `CliDispatch`). Reusing it would silently change
+   an existing alias. The churn×complexity feature is renamed **`metrics risk`**.
+2. **Dead-code cannot be reference-graph-based today.** The live Miller artifact has 90,742
+   `identifiers` rows and **0 resolved `target_symbol_id`** rows; the references contract itself
+   says null targets must not be read as absence of usage. Dead-code candidates are demoted to P3
+   as an evidence-gated, name-based-liveness prototype (a symbol is a candidate only when its name
+   never appears as an identifier outside its own definition — conservative: collisions hide dead
+   code rather than flagging live code), scoped to non-public symbols in high-evidence languages,
+   with per-language confidence labels. Blocked-on: extractor reference resolution quality.
+3. **Signals rollup moves ahead of dead-code.** `miller report` composes only reliable facts
+   (health, markers, complexity, clones, churn, risk); dead-code is omitted until P3 earns
+   confidence.
+4. **Not just a cheap join.** `metrics risk` must join churn and complexity *before* limiting
+   (top-N∩top-N misses real hotspots), define file-only/null-symbol tiers, align test filtering,
+   and carry a performance budget on git range size.
+5. **Contract discipline.** Each new operation is a documented additive update to
+   `metrics-json-v1` (or a new contract doc for `report`), advertised in `capabilities --json`,
+   with tests.
+6. **P4 history must be keyed by `(workspace_id, artifact_id, revision)`** plus extractor version
+   — never revision alone, because full rebuilds restart the revision counter.
+7. **Dashboard consumes cached/snapshotted facts, CLI first.** No git subprocess on dashboard
+   page load; churn/risk reach the dashboard via cached facts or an explicit refresh action.
+8. **MCP stance holds by default.** No new MCP tools; if MCP-only clients later need `report`,
+   that is an explicit user-approval discussion, not a default.
+
+**Amended priority order: P1 `metrics risk` → P2 `miller report` (no dead-code) → P3 dead-code
+candidates prototype (evidence-gated) → P4 history/trends.**
 
 ## Context
 
@@ -43,7 +77,7 @@ CLI already ships the raw facts Eros was meant to consume:
 | Semantic/vector retrieval, embeddings | No | No | Keep out (or revisit as an explicit opt-in later) |
 | Confidence/evidence views, commercial orchestration | No | Partially | Keep out — onboarding panel covers the useful subset |
 
-## Proposed roadmap (priority order)
+## Original proposed roadmap (superseded by the consensus amendments above)
 
 ### P1 — Hotspots: `metrics hotspots`
 
@@ -98,4 +132,5 @@ distribution, clone count, marker count over time). Needs design: when snapshots
 - [x] CLI fact surfaces verified against actual binary and contracts
 - [x] Eros-deferred capabilities enumerated with absorb/keep-out verdicts
 - [x] Prioritized roadmap with rationale
-- [ ] User picks direction (which priorities to green-light) — pending
+- [x] User picks direction — Codex adversarial review requested, consensus amendments folded in,
+      implementation green-lit on the amended P1→P2 order (2026-07-06)

--- a/docs/plans/2026-07-07-dead-code-candidates-design.md
+++ b/docs/plans/2026-07-07-dead-code-candidates-design.md
@@ -41,7 +41,13 @@ A symbol S (from `symbols`) is a candidate iff ALL of:
 1. **Definition kind.** `S.kind ∈ {function, method, class, struct, interface, enum, delegate,
    property, constant}` — the definition kinds worth reporting. Excluded: `variable`, `field`,
    `import`, `export`, `module`, `namespace`, `enum_member`, `constructor` (constructors follow
-   their type; fields/variables are too noisy for a prototype).
+   their type; fields/variables are too noisy for a prototype). **Also excluded: syntax-invoked
+   member shapes** that are never referenced by an identifier bearing their own name — names
+   starting `~` (finalizers/destructors), names containing `this[` (indexers), names starting
+   `operator` or `op_` (operator overloads), and `Finalize`. (Doubt-pass finding 1: a live
+   private C# finalizer `~Resource` and indexer `this[int index]` pass every evidence check;
+   they are invoked by syntax, not by name.) The exclusion list is a named table in
+   `Miller.Core`, extensible per language.
 2. **Name-based liveness fails.** No row in `identifiers` has `name = S.name` outside S's own
    definition (an identifier is "inside" when `containing_symbol_id = S.symbol_id` OR it lies
    within S's `[start_byte, end_byte]` span in S's file). Same-name matches anywhere else in the
@@ -49,8 +55,12 @@ A symbol S (from `symbols`) is a candidate iff ALL of:
 3. **No resolved inbound evidence.** Zero `identifier_resolutions` rows with
    `target_symbol_id = S.symbol_id` originating outside S (per the same inside-test on the
    resolved identifier), AND zero `relationships` rows with `to_symbol_id = S.symbol_id` from
-   outside S. This is where v4 earns its keep: a resolved edge from an *aliased* usage (identifier
-   name ≠ symbol name) rescues a symbol that name-matching alone would falsely flag.
+   outside S, AND zero `pending_resolutions` rows with `target_symbol_id = S.symbol_id` whose
+   joined `pending_relationships` row originates outside S. (Doubt-pass finding 2:
+   `pending_resolutions` is independent inbound evidence — on the live Miller artifact at least
+   one resolved pending target has no `identifier_resolutions` row at all.) Resolution is where
+   v4 earns its keep: a resolved edge from an *aliased* usage (identifier name ≠ symbol name)
+   rescues a symbol that name-matching alone would falsely flag.
 4. **No named suppression applies** (see below).
 
 ### Suppression rules (each named, each counted in output)
@@ -65,48 +75,71 @@ A symbol S (from `symbols`) is a candidate iff ALL of:
 | `annotated` | symbol carries any `symbol_annotations` row (attributes/decorators frequently mean reflection/framework discovery — `[Fact]`, `[JsonProperty]`, `@app.route`, …) | `symbol_annotations` |
 | `generated_path` | path matches conservative generated-code globs (`*.g.cs`, `*.generated.*`, `obj/`, `bin/`, `node_modules/`, `*.designer.cs`, `wwwroot/lib/`) | `symbols.path` |
 | `low_evidence_language` | the symbol's language has zero identifier rows in this artifact (nothing to test liveness against — e.g. css/html) | computed |
+| `string_literal_match` | the symbol's name appears in workspace string-literal text — reflection/config/DI-by-name usage (`GetMethod("Foo")`, route strings, serialized member names). Implemented by scanning the artifact's `string_literal` `source_regions` spans (75,818 on the live Miller scan) and re-reading only those spans from source with the established `files.content_hash` freshness guard. The scan runs on the *surviving candidate set only* (small), so it reads each literal-bearing file at most once. Files whose content hash is stale are counted and reported as unscanned. | `source_regions` + source re-read |
 
 `visibility_unknown` is the honesty rule the live data forces: 26,925 of 38,670 symbols carry
 NULL visibility. A prototype that flagged them would be guessing about public exposure. The
 output's suppression counts make the cost visible per repo, which is exactly the evidence needed
 to decide whether per-language visibility inference is worth extractor work later.
 
-### Confidence labels (per candidate)
+### Evidence provenance (per candidate) — not certainty grades
 
-- `strong` — the candidate's language has resolution coverage ≥ 10% in *this artifact*
-  (measured: resolved identifiers / identifiers for that language) AND the symbol's file had at
-  least one resolution attempt. Both name evidence and resolution evidence agree it is unused.
-- `moderate` — everything else that survives the rule (name evidence alone; resolver largely
-  blind in this language).
+(Doubt-pass finding 3: a `strong` label over a 15%-coverage resolver reads as deletion-grade
+certainty it cannot deliver. Labels therefore state what evidence was consulted, never how sure
+we are.)
 
-Thresholds are computed from the artifact at query time — never hardcoded per language — so the
-labels stay honest as the resolver improves.
+- `evidence=name` — name-based liveness plus literal-scan found nothing; the resolver was
+  effectively blind for this language (below 10% measured coverage in this artifact).
+- `evidence=name+resolver` — the above AND the language has ≥ 10% measured resolution coverage
+  in this artifact, so resolver silence carries some additional weight.
+
+Coverage is computed from the artifact at query time (resolved identifiers / identifiers per
+language) — never hardcoded. Every output (compact header and JSON) carries the artifact's
+`reference_resolution_status` (`partial` on all current real scans) and
+`reference_resolution_version` verbatim, so no consumer can mistake a candidate list built on a
+partial resolver for a verdict. The compact header states it plainly:
+`resolver: partial — candidates are facts to check, not deletions to make.`
 
 ## Output
 
-**Compact:** header (`candidates: N of M symbols examined`), one line per candidate —
-`name kind language path:line visibility confidence [name_matches=0 resolved_in=0 calls_in=0]` —
-then a footer: suppression counts by rule id and a per-language coverage table
-(`csharp: 15.6% resolved; razor: 2.1% — name-evidence only`). Bounded (default top 50 by
-file path; `--limit`).
+**Compact:** header (`candidates: N of M symbols examined · resolver: partial — candidates are
+facts to check, not deletions to make`), one line per candidate —
+`name kind language path:line visibility evidence=… [name_matches=0 resolved_in=0 pending_in=0 calls_in=0]` —
+then a footer: suppression counts by rule id, literal-scan coverage (files scanned / skipped
+stale), and a per-language coverage table (`csharp: 15.6% resolved; razor: 2.1% — name-evidence
+only`). Bounded (default top 50 by file path; `--limit`).
 
 **`--json`:** new contract doc `docs/contracts/references-candidates-v1.md` (additive, versioned
 per the contract discipline): `schema_version: 1`, `candidates[]` (symbol_id, name, kind,
-language, path, start_line, visibility, confidence, evidence{name_matches, resolved_inbound,
-calls_inbound}), `suppressions{rule_id: count}`, `language_coverage[]` (language, identifiers,
-resolved_pct), `examined`, `artifact{artifact_id, revision, reference_resolution_version}`.
-Advertised in `capabilities --json` under `optional_features.references_candidates`.
+language, path, start_line, visibility, evidence_label, evidence{name_matches, resolved_inbound,
+pending_resolved_inbound, calls_inbound}), `suppressions{rule_id: count}`,
+`literal_scan{files_scanned, files_skipped_stale}`, `language_coverage[]` (language, identifiers,
+resolved_pct), `examined`, `artifact{artifact_id, revision, reference_resolution_status,
+reference_resolution_version}`.
+
+**Capabilities** (doubt-pass finding 4 — follow the existing shape, all three surfaces):
+`optional_features.references_candidates: true` (boolean feature flag, same pattern as
+`reference_aware_context`), a `json_commands` entry for `references candidates --json`, and a
+`json_contracts` entry naming `references-candidates-v1`. **In the same slice**, amend the stale
+boundary sentences: `docs/contracts/references-export-v1.md` ("Eros owns candidate ranking …")
+and the corresponding `docs/contracts/cli-eros-v1.md` line must reflect the 2026-07-06 consensus
+— deterministic candidate listing with named suppressions is Miller-owned; ranking beyond the
+deterministic rule, suppression *persistence*, history, and fleet workflows stay out.
 
 ## Architecture
 
 Follows the `ReferenceExportReader` seam exactly — no new architecture:
 
-- `Miller.Core`: pure candidate/suppression/confidence logic over plain row records
-  (`DeadCodeCandidates.Evaluate(...)`) — unit-testable in milliseconds, zero I/O.
+- `Miller.Core`: pure candidate/suppression/evidence-label logic over plain row records
+  (`DeadCodeCandidates.Evaluate(...)`), including the syntax-invoked name-shape exclusion table
+  — unit-testable in milliseconds, zero I/O.
 - `Miller.Indexing`: `DeadCodeCandidateReader` — SQL that pages the needed rows (symbols of
-  candidate kinds; identifier name-match counts via indexed lookups; resolved-inbound counts;
-  structural-fact/annotation suppression sets) and feeds `Miller.Core`. One pass, no full-table
-  materialization of identifiers.
+  candidate kinds; identifier name-match counts via indexed lookups; resolved/pending/calls
+  inbound counts; structural-fact/annotation suppression sets) and feeds `Miller.Core`. One
+  pass, no full-table materialization of identifiers. The `string_literal_match` scan runs
+  LAST, over the surviving candidate set only: collect `string_literal` `source_regions` spans,
+  group by file, re-read each literal-bearing file once under the `files.content_hash` guard,
+  and search the (small) candidate-name set within literal spans.
 - `Miller.Server`: `CliDispatch` wiring (`references candidates`), compact render, JSON
   serializer context entries, `CliCapabilities` advertisement.
 
@@ -115,8 +148,11 @@ Follows the `ReferenceExportReader` seam exactly — no new architecture:
 - Fast suite: contract-faithful v4 fixtures (real column shapes incl. `identifier_resolutions`
   with the `outcome='resolved' ⇔ target NOT NULL` CHECK — per the fixture-fidelity rule).
   Cover: candidate found; saved-by-name-match; saved-by-resolved-alias-edge (identifier name ≠
-  symbol name); each suppression rule fires and is counted; confidence split; visibility NULL
-  path; JSON shape.
+  symbol name); saved-by-pending-resolution-only (no identifier_resolutions row — doubt-pass
+  finding 2); finalizer/indexer/operator names excluded by rule 1 (doubt-pass finding 1);
+  reflection-string suppression via `string_literal_match` incl. the stale-file-skipped counter;
+  each suppression rule fires and is counted; evidence-label split; visibility NULL path; JSON
+  shape incl. `reference_resolution_status`.
 - Scale suite: one test scanning a small multi-language fixture with the real binary, asserting
   the command runs end-to-end and per-language coverage renders.
 - CLI contract tests extend `CliDispatchTests` (existing seams: `SetIdentifierTarget`,
@@ -143,15 +179,33 @@ Before this feature is mentioned in `miller report`, the dashboard, README, or a
 ## Acceptance criteria
 
 - [ ] `miller references candidates` and `--json` run against a v4 artifact; compact and JSON
-      shapes match this doc; `--limit` honored.
+      shapes match this doc; `--limit` honored; `reference_resolution_status` present in both
+      outputs.
 - [ ] Rule fidelity proven by fast tests: alive-by-name, alive-by-resolved-alias-edge,
-      alive-by-calls-edge each prevent candidacy; all eight suppression rules fire, are counted,
-      and are named in output.
-- [ ] Confidence labels derive from artifact-measured per-language coverage (no hardcoded
-      language lists).
-- [ ] `references-candidates-v1.md` contract committed; `capabilities --json` advertises it;
-      contract test added.
+      alive-by-pending-resolution-only, and alive-by-calls-edge each prevent candidacy;
+      finalizer/indexer/operator name shapes are excluded by rule 1; all nine suppression rules
+      fire, are counted, and are named in output.
+- [ ] Evidence labels state provenance (`name` / `name+resolver`), derive from
+      artifact-measured per-language coverage (no hardcoded language lists), and never use
+      certainty words.
+- [ ] `references-candidates-v1.md` contract committed; `capabilities --json` advertises it via
+      `optional_features` + `json_commands` + `json_contracts`; contract test added;
+      `references-export-v1.md` and `cli-eros-v1.md` boundary language amended in the same
+      slice.
 - [ ] Fast suite stays fast; the one real-binary test is `Category=Scale` via
       `ScaleTestSupport`.
 - [ ] Dogfood evidence recorded in `docs/findings/` with hand-verified precision on the Miller
       repo (evidence gate for any further surfacing).
+
+## Review log
+
+- **Rev 2 (2026-07-07):** Codex adversarial doubt pass (verdict: needs-attention, 4 findings —
+  all verified against the live v4 artifact and folded in): (1) syntax-invoked members
+  (finalizers, indexers, operators) excluded by name shape in rule 1; (2) `pending_resolutions`
+  added as inbound evidence in rule 3; (3) `strong`/`moderate` certainty labels replaced with
+  evidence-provenance labels plus mandatory `reference_resolution_status` in all output; (4)
+  capabilities advertisement widened to `json_commands`/`json_contracts` and the stale
+  Eros-ownership sentences in `references-export-v1.md`/`cli-eros-v1.md` amended in-slice. Also
+  added the `string_literal_match` suppression (reflection/config-string usage) via
+  `source_regions` span re-reads — the artifact's `literals` table holds only classified
+  sql/url rows (6 on the live scan) and cannot serve this purpose.

--- a/docs/plans/2026-07-07-dead-code-candidates-design.md
+++ b/docs/plans/2026-07-07-dead-code-candidates-design.md
@@ -1,0 +1,157 @@
+# Dead-code candidates: `miller references candidates` (P3, evidence-gated)
+
+**Status:** design for review · **Date:** 2026-07-07 · **Depends on:** julie-extract 2.9.0 pin
+(schema v4, merged locally at `e1b7b9a`)
+
+## Context
+
+The 2026-07-06 standalone-bolstering consensus demoted dead-code candidates to P3, blocked on
+extractor reference resolution. julie-extractors v2.9.0 shipped that resolution (schema v4:
+`pending_resolutions` + `identifier_resolutions` overlay tables, FK-consistent
+`identifiers.target_symbol_id`, tiered confidence). Miller's pin is bumped and gated
+(`MillerExtractContract` expects schema 4).
+
+**The load-bearing measurement** (live 2.9.0 scan of the Miller repo, 2026-07-07):
+
+- 92,952 identifiers → 14,183 resolved (15.3%). Outcomes: `no_context` 25,759, `missing` 13,889,
+  `ambiguous` 214. Tiers seen: `tier1_local` 0.95 (7,469), `tier4_global` 0.55 (6,555),
+  `tier3_receiver` 0.65 (159).
+- Per-language resolved %: C# 15.6, Python 14.1, JavaScript 10.1, bash 5.5, razor 2.1, css/html 0.
+- `symbols.visibility`: 26,925 NULL, 8,209 public, 3,534 private, 2 protected on the same scan.
+
+Consequence: **absence of a resolved inbound edge is weak evidence of death** (≈85% of usage
+sites are unresolved), while **presence of one is strong evidence of life**. The candidate rule
+below treats resolution accordingly: it can only save symbols from being flagged, never add
+flags. This preserves the locked-in conservative stance ("collisions hide dead code rather than
+flagging live code").
+
+## Product shape
+
+- **Surface:** `miller references candidates [--json]` — a new operation on the existing
+  `references` CLI verb. **No new MCP tool** (standing rule). **Not** added to `miller report`
+  or the dashboard yet: the consensus keeps dead-code out of the rollup until this prototype
+  earns confidence on real dogfood.
+- **Posture:** facts, not a verdict. Output is a candidate list plus named-rule suppression
+  counts and per-language coverage disclaimers. No suppression persistence, no state.
+
+## Candidate rule
+
+A symbol S (from `symbols`) is a candidate iff ALL of:
+
+1. **Definition kind.** `S.kind ∈ {function, method, class, struct, interface, enum, delegate,
+   property, constant}` — the definition kinds worth reporting. Excluded: `variable`, `field`,
+   `import`, `export`, `module`, `namespace`, `enum_member`, `constructor` (constructors follow
+   their type; fields/variables are too noisy for a prototype).
+2. **Name-based liveness fails.** No row in `identifiers` has `name = S.name` outside S's own
+   definition (an identifier is "inside" when `containing_symbol_id = S.symbol_id` OR it lies
+   within S's `[start_byte, end_byte]` span in S's file). Same-name matches anywhere else in the
+   workspace — any file, any language — count as alive. Conservative by construction.
+3. **No resolved inbound evidence.** Zero `identifier_resolutions` rows with
+   `target_symbol_id = S.symbol_id` originating outside S (per the same inside-test on the
+   resolved identifier), AND zero `relationships` rows with `to_symbol_id = S.symbol_id` from
+   outside S. This is where v4 earns its keep: a resolved edge from an *aliased* usage (identifier
+   name ≠ symbol name) rescues a symbol that name-matching alone would falsely flag.
+4. **No named suppression applies** (see below).
+
+### Suppression rules (each named, each counted in output)
+
+| Rule id | Suppresses | Source |
+|---|---|---|
+| `public_api` | `visibility = 'public'` or language-equivalent exported forms | `symbols.visibility` |
+| `visibility_unknown` | `visibility IS NULL` — the extractor did not record visibility for this symbol/language, so public exposure cannot be ruled out | `symbols.visibility` |
+| `test_symbol` | `is_test = 1`, or any ancestor via `parent_symbol_id` has `is_test = 1` | `symbols.is_test` |
+| `entry_point` | well-known entry names per language (e.g. `Main`/`main`, `Program`), plus symbols under a `Program.cs`-style startup file heuristic per language | `symbols.name`/`path` |
+| `framework_bound` | symbol (or an ancestor) is `containing_symbol_id` of any `structural_facts` row — routes, handlers, bindings, DI registrations, etc. Broad on purpose | `structural_facts` |
+| `annotated` | symbol carries any `symbol_annotations` row (attributes/decorators frequently mean reflection/framework discovery — `[Fact]`, `[JsonProperty]`, `@app.route`, …) | `symbol_annotations` |
+| `generated_path` | path matches conservative generated-code globs (`*.g.cs`, `*.generated.*`, `obj/`, `bin/`, `node_modules/`, `*.designer.cs`, `wwwroot/lib/`) | `symbols.path` |
+| `low_evidence_language` | the symbol's language has zero identifier rows in this artifact (nothing to test liveness against — e.g. css/html) | computed |
+
+`visibility_unknown` is the honesty rule the live data forces: 26,925 of 38,670 symbols carry
+NULL visibility. A prototype that flagged them would be guessing about public exposure. The
+output's suppression counts make the cost visible per repo, which is exactly the evidence needed
+to decide whether per-language visibility inference is worth extractor work later.
+
+### Confidence labels (per candidate)
+
+- `strong` — the candidate's language has resolution coverage ≥ 10% in *this artifact*
+  (measured: resolved identifiers / identifiers for that language) AND the symbol's file had at
+  least one resolution attempt. Both name evidence and resolution evidence agree it is unused.
+- `moderate` — everything else that survives the rule (name evidence alone; resolver largely
+  blind in this language).
+
+Thresholds are computed from the artifact at query time — never hardcoded per language — so the
+labels stay honest as the resolver improves.
+
+## Output
+
+**Compact:** header (`candidates: N of M symbols examined`), one line per candidate —
+`name kind language path:line visibility confidence [name_matches=0 resolved_in=0 calls_in=0]` —
+then a footer: suppression counts by rule id and a per-language coverage table
+(`csharp: 15.6% resolved; razor: 2.1% — name-evidence only`). Bounded (default top 50 by
+file path; `--limit`).
+
+**`--json`:** new contract doc `docs/contracts/references-candidates-v1.md` (additive, versioned
+per the contract discipline): `schema_version: 1`, `candidates[]` (symbol_id, name, kind,
+language, path, start_line, visibility, confidence, evidence{name_matches, resolved_inbound,
+calls_inbound}), `suppressions{rule_id: count}`, `language_coverage[]` (language, identifiers,
+resolved_pct), `examined`, `artifact{artifact_id, revision, reference_resolution_version}`.
+Advertised in `capabilities --json` under `optional_features.references_candidates`.
+
+## Architecture
+
+Follows the `ReferenceExportReader` seam exactly — no new architecture:
+
+- `Miller.Core`: pure candidate/suppression/confidence logic over plain row records
+  (`DeadCodeCandidates.Evaluate(...)`) — unit-testable in milliseconds, zero I/O.
+- `Miller.Indexing`: `DeadCodeCandidateReader` — SQL that pages the needed rows (symbols of
+  candidate kinds; identifier name-match counts via indexed lookups; resolved-inbound counts;
+  structural-fact/annotation suppression sets) and feeds `Miller.Core`. One pass, no full-table
+  materialization of identifiers.
+- `Miller.Server`: `CliDispatch` wiring (`references candidates`), compact render, JSON
+  serializer context entries, `CliCapabilities` advertisement.
+
+## Testing
+
+- Fast suite: contract-faithful v4 fixtures (real column shapes incl. `identifier_resolutions`
+  with the `outcome='resolved' ⇔ target NOT NULL` CHECK — per the fixture-fidelity rule).
+  Cover: candidate found; saved-by-name-match; saved-by-resolved-alias-edge (identifier name ≠
+  symbol name); each suppression rule fires and is counted; confidence split; visibility NULL
+  path; JSON shape.
+- Scale suite: one test scanning a small multi-language fixture with the real binary, asserting
+  the command runs end-to-end and per-language coverage renders.
+- CLI contract tests extend `CliDispatchTests` (existing seams: `SetIdentifierTarget`,
+  `MarkSymbolAsTest`).
+
+## Evidence gate (definition of "earned confidence")
+
+Before this feature is mentioned in `miller report`, the dashboard, README, or agent guidance:
+
+1. Dogfood on the Miller repo and the julie-extractors repo (registered workspace).
+2. Hand-verify every candidate on the Miller repo (expected: a short list; non-public C# symbols
+   with zero name matches are rare in a heavily-tested codebase).
+3. Record precision in a findings doc (`docs/findings/`). If the list is noisy, the rule
+   tightens or the feature stays CLI-only and undocumented — it does not ship noisy.
+
+## Out of scope (YAGNI)
+
+- Collision refinement (flagging symbols whose every name-match resolves elsewhere) — needs
+  trust in tier-4 (0.55) global resolutions; revisit with resolver improvements.
+- Suppression persistence, ignore-lists, or per-repo config.
+- Dashboard panel, `miller report` section, MCP tool — gated on the evidence above.
+- Cross-workspace candidates.
+
+## Acceptance criteria
+
+- [ ] `miller references candidates` and `--json` run against a v4 artifact; compact and JSON
+      shapes match this doc; `--limit` honored.
+- [ ] Rule fidelity proven by fast tests: alive-by-name, alive-by-resolved-alias-edge,
+      alive-by-calls-edge each prevent candidacy; all eight suppression rules fire, are counted,
+      and are named in output.
+- [ ] Confidence labels derive from artifact-measured per-language coverage (no hardcoded
+      language lists).
+- [ ] `references-candidates-v1.md` contract committed; `capabilities --json` advertises it;
+      contract test added.
+- [ ] Fast suite stays fast; the one real-binary test is `Category=Scale` via
+      `ScaleTestSupport`.
+- [ ] Dogfood evidence recorded in `docs/findings/` with hand-verified precision on the Miller
+      repo (evidence gate for any further surfacing).

--- a/docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md
+++ b/docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md
@@ -1,0 +1,204 @@
+# Dead-Code Candidates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use razorback:subagent-driven-development when subagent delegation is available. Fall back to razorback:executing-plans for single-task, tightly-sequential, or no-delegation runs.
+
+**Goal:** Ship `miller references candidates [--json]` — a deterministic, conservatively-suppressed dead-code candidate list built on julie-extract schema v4 reference resolution, per the approved design `docs/plans/2026-07-07-dead-code-candidates-design.md` (rev 2, Codex doubt-pass folded in).
+
+**Architecture:** Pure candidate/suppression/evidence logic in `Miller.Core/DeadCode` (zero I/O); a `DeadCodeCandidateReader` in `Miller.Indexing` that pages symbols/identifiers/resolutions and runs the string-literal span scan last over survivors only; CLI wiring in `CliDispatch` under the existing `references` verb. Follows the `ReferenceExportReader` seam — no new architecture.
+
+**Tech Stack:** .NET 10, Microsoft.Data.Sqlite, xUnit. No new dependencies.
+
+**Architecture Quality:** Follows the established artifact-reader seam (`ReferenceExportReader` / `SqliteSourceRegionReader`). Approved shape: Core evaluator consumes plain row records and returns a typed result; Indexing owns all SQL and source re-reads; Server owns rendering/JSON/capabilities. Risk: low (read-only surface). If code reality contradicts this shape, report a plan mismatch rather than redesigning locally.
+
+## Global Constraints
+
+- **The design doc is the spec.** `docs/plans/2026-07-07-dead-code-candidates-design.md` rev 2 governs; where this plan and the design conflict, report the mismatch.
+- **False positives are the failure mode.** Every rule ambiguity resolves toward NOT flagging.
+- Candidate kinds: `function, method, class, struct, interface, enum, delegate, property, constant`. Syntax-invoked name-shape exclusions: names starting `~`, containing `this[`, starting `operator`, starting `op_`, or equal to `Finalize`.
+- Nine named suppression rule ids, exactly: `public_api`, `visibility_unknown`, `test_symbol`, `entry_point`, `framework_bound`, `annotated`, `generated_path`, `low_evidence_language`, `string_literal_match`.
+- Evidence labels are provenance, never certainty: `name` and `name+resolver` (resolver label requires ≥ 10% measured per-language resolution coverage in the artifact, computed at query time — no hardcoded language lists).
+- Compact header must include verbatim: `resolver: <status> — candidates are facts to check, not deletions to make.` where `<status>` is the artifact's `reference_resolution_status` metadata value (fallback `unknown` when the key is absent).
+- JSON envelope: `schema_version: 1`, `candidates[]` (symbol_id, name, kind, language, path, start_line, visibility, evidence_label, evidence{name_matches, resolved_inbound, pending_resolved_inbound, calls_inbound}), `suppressions{rule_id: count}`, `literal_scan{files_scanned, files_skipped_stale}`, `language_coverage[]` (language, identifiers, resolved_pct), `examined`, `artifact{artifact_id, revision, reference_resolution_status, reference_resolution_version}`.
+- Generated-path globs (conservative): `*.g.cs`, `*.generated.*`, `obj/`, `bin/`, `node_modules/`, `*.designer.cs`, `wwwroot/lib/`.
+- No new MCP tool. No dashboard/`miller report`/README/agent-instructions surfacing (evidence-gated). `MILLER_AGENT_INSTRUCTIONS.md` untouched.
+- Build: 0 warnings / 0 errors (warnings are errors). `Miller.Core` stays zero-I/O.
+- Test split: julie-spawning tests are `[Trait("Category","Scale")]` via `ScaleTestSupport.RequireJulieServer()`; fast suite stays fast/pure.
+- CLAUDE.md edits go through `scripts/sync-agents.sh` then `cmp -s CLAUDE.md AGENTS.md`.
+
+## Verification Strategy
+
+**Project source of truth:** `CLAUDE.md` (Testing + Build sections), `scripts/test.sh`.
+
+**Worker red/green scope:** focused filters, e.g. `dotnet test tests/Miller.Tests -c Release --filter "FullyQualifiedName~DeadCodeCandidates"` (Task 1), `~DeadCodeCandidateReader` (Task 2), `~CliDispatchTests` (Task 3). Fast-suite category rules apply automatically.
+
+**Worker ceiling:** `scripts/test.sh` (fast suite). Workers do not run the scale suite on their own except the Task 3 worker's single new Scale test via `scripts/test.sh scale`.
+
+**Worker gate invariant:** each task's acceptance criteria are proven by tests the worker runs red→green in their own scope.
+
+**Lead affected-change scope:** `scripts/test.sh` after each task lands.
+
+**Branch gate:** `dotnet build Miller.slnx -c Release` (0 warnings) + `scripts/test.sh` + `scripts/test.sh scale` before the final report. `.tools/julie-extract` 2.9.0 is present at repo root (restored this session) — scale tests must NOT silently skip; verify `Skipped: 0`.
+
+**Replay/metric evidence:** Task 5's dogfood counts are report-only evidence recorded in the findings doc; the hard gate is hand-verified precision (no confirmed-live symbol may appear as a candidate).
+
+**Escalation triggers:** any change under `src/Miller.Indexing/` or to fixtures ⇒ run `scripts/test.sh scale` at branch gate (already required).
+
+**Assigned verification failure:** workers stop and report; do not weaken guards or fixtures to pass.
+
+**Verification ledger:** record invariant, command, scope label, commit SHA, result, timestamp per task. Reuse passing same-HEAD entries rather than rerunning expensive gates.
+
+## Parallel Execution Contract
+
+| Task | Parallel batch | File ownership | Serialization required | Dependency reason |
+|---|---|---|---|---|
+| Task 1: Core evaluator | None - serial | Create: `src/Miller.Core/DeadCode/*.cs`; Test: `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs` | Yes | Produces the row-record and result contracts Tasks 2–3 consume. |
+| Task 2: Indexing reader + v4 fixture | None - serial | Create: `src/Miller.Indexing/DeadCodeCandidateReader.cs`; Modify: `tests/Miller.Tests/Indexing/JulieDbFixture.cs`, `tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs`; Test: `tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs` | Yes | Consumes Task 1's contracts; produces the reader API Task 3 wires. |
+| Task 3: CLI + capabilities + Scale test | None - serial | Modify: `src/Miller.Server/Cli/CliDispatch.cs`, `src/Miller.Server/Cli/CliCapabilities.cs`; Test: `tests/Miller.Tests/Server/Cli/CliDispatchTests.cs`, `tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs` (new) | Yes | Consumes Task 2's reader API. |
+| Task 4: Contracts + boundary docs | None - serial | Create: `docs/contracts/references-candidates-v1.md`; Modify: `docs/contracts/references-export-v1.md`, `docs/contracts/cli-eros-v1.md`, `docs/README.md`, `CLAUDE.md`, `AGENTS.md` (generated) | Yes | Documents Task 3's shipped shapes verbatim (JSON field names, capabilities keys). |
+| Task 5: Dogfood evidence | None - serial | Create: `docs/findings/2026-07-07-dead-code-candidates-dogfood.md` | Yes | Runs the Task 3 binary against real artifacts; is the design's evidence gate. |
+
+Commit mode: `serial-worker-commit` for every task.
+
+---
+
+### Task 1: Core evaluator (`Miller.Core/DeadCode`)
+
+**Files:**
+- Create: `src/Miller.Core/DeadCode/DeadCodeCandidates.cs` (evaluator + result types)
+- Create: `src/Miller.Core/DeadCode/DeadCodeRows.cs` (input row records)
+- Test: `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs`
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces: `DeadCodeSymbolRow` (SymbolId, Name, Kind, Language, Path, StartLine, StartByte, EndByte, Visibility (string?), IsTest (bool), ParentSymbolId (string?), HasAnnotation (bool), HasStructuralFact (bool), NameMatchesOutside (int), ResolvedInbound (int), PendingResolvedInbound (int), CallsInbound (int), LiteralMatch (bool?) — null = not yet scanned); `LanguageCoverageRow` (Language, IdentifierCount, ResolvedCount); `DeadCodeCandidates.Evaluate(IReadOnlyList<DeadCodeSymbolRow>, IReadOnlyList<LanguageCoverageRow>) -> DeadCodeResult` where `DeadCodeResult` carries `Candidates` (list with `EvidenceLabel`), `Suppressions` (rule_id -> count, all nine ids always present), `Examined` (int). Also `DeadCodeCandidates.IsSyntaxInvokedName(string name, string kind) -> bool` and `DeadCodeCandidates.CandidateKinds` (the set), both public for the reader's SQL prefilter and tests.
+- Produces: two-phase contract — `Evaluate` treats `LiteralMatch == true` as the `string_literal_match` suppression; `LiteralMatch == null` rows are returned in `DeadCodeResult.NeedsLiteralScan` so the reader can scan survivors only and call `Evaluate` semantics again via `DeadCodeCandidates.ApplyLiteralScan(result, matchedSymbolIds)`.
+
+**Contract inputs:** Global Constraints (kinds, exclusions, nine rule ids, evidence-label rules, ≥10% coverage threshold). Entry-point names: `Main`, `main`, plus path-tail heuristic `Program.cs` per the design.
+
+**File ownership:** Create: `src/Miller.Core/DeadCode/*.cs`; Test: `tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Produces the row-record and result contracts Tasks 2–3 consume.
+
+**What to build:** The entire candidate/suppression/evidence decision as pure functions over plain records, per design §Candidate rule + §Suppression rules + §Evidence provenance. Suppression precedence: kind/name-shape exclusion removes a symbol from `Examined` candidates entirely (not a suppression count); the nine rules apply in table order, first match wins for the count, and any match suppresses.
+
+**Approach:** TDD. Follow `Miller.Core` conventions (records, no I/O, no Sqlite references). Keep evidence-label logic reading only `LanguageCoverageRow` data. Cover in tests: candidate found; alive-by-name / alive-by-resolved / alive-by-pending / alive-by-calls each prevent candidacy; each of the nine rules fires and counts; finalizer `~Resource`, indexer `this[int index]`, `operator +`, `op_Addition`, `Finalize` excluded; evidence-label split at the 10% boundary (9.9% → `name`, 10% → `name+resolver`); NULL visibility → `visibility_unknown`; two-phase literal-scan contract (`NeedsLiteralScan` then `ApplyLiteralScan` suppresses matched ids under `string_literal_match`).
+
+**Acceptance criteria:**
+- [ ] All rule-fidelity behaviors above proven red→green in `DeadCodeCandidatesTests`
+- [ ] `Miller.Core` has no new I/O dependency (no Sqlite/file APIs)
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 2: Indexing reader + v4 fixture extension
+
+**Files:**
+- Create: `src/Miller.Indexing/DeadCodeCandidateReader.cs`
+- Modify: `tests/Miller.Tests/Indexing/JulieDbFixture.cs` (add v4 resolution tables + builder helpers)
+- Modify: `tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs` (guard the new tables)
+- Test: `tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's `DeadCodeCandidates` API (rows, `Evaluate`, `ApplyLiteralScan`, `IsSyntaxInvokedName`, `CandidateKinds`).
+- Produces: `DeadCodeCandidateReader.Read(string symbolsDbPath, string workspaceRoot) -> DeadCodeCandidateReport` where the report carries `DeadCodeResult` plus `LanguageCoverage`, `LiteralScan` (FilesScanned, FilesSkippedStale), and `Artifact` (ArtifactId, Revision, ReferenceResolutionStatus (fallback `"unknown"`), ReferenceResolutionVersion (nullable)). Task 3 renders exactly this report.
+
+**Contract inputs:** Real v4 DDL verified live this session — `identifier_resolutions` (identifier_id PK REFERENCES identifiers CASCADE, target_symbol_id REFERENCES symbols CASCADE, tier, confidence REAL, method TEXT, outcome TEXT NOT NULL, candidates INTEGER, resolved_at_revision INTEGER NOT NULL, CHECK ((outcome = 'resolved') = (target_symbol_id IS NOT NULL))); `pending_resolutions` (pending_relationship_id PK REFERENCES pending_relationships CASCADE, target_symbol_id TEXT NOT NULL REFERENCES symbols CASCADE, tier INTEGER NOT NULL, confidence REAL NOT NULL, method TEXT NOT NULL, resolved_at_revision INTEGER NOT NULL) with index `idx_pending_resolutions_target`; artifact_metadata keys `reference_resolution_status` / `reference_resolution_version`. Copy DDL into the fixture verbatim (fixture-fidelity rule). Existing span-read pattern: `src/Miller.Indexing/SqliteSourceRegionReader.cs` + `SourceRegionRow.cs`; freshness guard via `files.content_hash` (blake3, normalized) as used by existing source re-readers.
+
+**File ownership:** Create: `src/Miller.Indexing/DeadCodeCandidateReader.cs`; Modify: `tests/Miller.Tests/Indexing/JulieDbFixture.cs`, `tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs`; Test: `tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Consumes Task 1's contracts; produces the reader API Task 3 wires.
+
+**What to build:** The SQL + literal-scan half per design §Architecture. One pass, no full identifiers materialization: per-symbol counts via indexed subqueries/CTEs (`identifiers` name-match outside the symbol's `[start_byte,end_byte]`+file OR `containing_symbol_id`; `identifier_resolutions` inbound from outside; `pending_resolutions JOIN pending_relationships` inbound from outside using the pending row's file/`caller_scope_symbol_id`/span context; `relationships` inbound from outside). Then `Evaluate`, then the literal scan LAST over `NeedsLiteralScan` survivors only: collect `string_literal` rows from `source_regions` grouped by file, re-read each file once, verify `files.content_hash` (skip + count stale files as `FilesSkippedStale`), substring-search surviving candidate names within literal spans, `ApplyLiteralScan`. Missing v4 tables (v3 artifact) must fail with the schema-gate error, not silently return zero — the D5 gate runs before the read, same as `ReferenceExportReader`.
+
+**Approach:** TDD against the extended `JulieDbFixture`. Extend the fixture with the three v4 tables (also `pending_relationships` if absent — copy real columns from a live probe: run `.tools/julie-extract scan` on a temp dir and `.schema pending_relationships`, do not invent) and builder methods (`AddIdentifierResolution`, `AddPendingResolution`, …). Extend `JulieDbFixtureCurrentSchemaTests` to require the new tables/columns/CHECK. Reader tests cover: candidate emitted with all evidence counts zero; saved-by-pending-resolution-only (no `identifier_resolutions` row — doubt-pass finding 2); literal match found in a real temp file under the workspace root suppresses (`string_literal_match`); stale content hash counts as skipped and does NOT suppress; artifact block populated incl. `reference_resolution_status` fallback `unknown` when key absent; coverage rows computed per language.
+
+**Acceptance criteria:**
+- [ ] Fixture carries the real v4 resolution DDL incl. the CHECK constraint; schema-guard test extended
+- [ ] Reader behaviors above proven red→green in `DeadCodeCandidateReaderTests`
+- [ ] Literal scan reads each literal-bearing file at most once and only runs when survivors exist
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 3: CLI surface, capabilities, Scale test
+
+**Files:**
+- Modify: `src/Miller.Server/Cli/CliDispatch.cs` (the `case "references":` arm at `src/Miller.Server/Cli/CliDispatch.cs:114` currently hardwires `export`; route ops `export` | `candidates`, add `--json` + `--limit` for candidates, update the help text at the `references <op>` line)
+- Modify: `src/Miller.Server/Cli/CliCapabilities.cs` (`optional_features.references_candidates: true`; `json_commands` entry `references candidates --json`; `json_contracts` entry `references-candidates-v1`)
+- Test: `tests/Miller.Tests/Server/Cli/CliDispatchTests.cs` (extend; existing seams `SetIdentifierTarget`, `MarkSymbolAsTest`)
+- Test: `tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs` (new, `[Trait("Category","Scale")]`, binary via `ScaleTestSupport.RequireJulieServer()`)
+
+**Interfaces:**
+- Consumes: Task 2's `DeadCodeCandidateReader.Read(symbolsDbPath, workspaceRoot) -> DeadCodeCandidateReport`.
+- Produces: the user-facing contract — compact render and the exact JSON envelope from Global Constraints; `--limit N` (default 50, ordered by path then start_line); workspace selection flags identical to `references export` (`--workspace-id`, `--workspace`).
+
+**Contract inputs:** Global Constraints (header string verbatim, JSON field names verbatim). Compact line shape from design §Output. Follow the existing compact/JSON render conventions in `CliDispatch` (see `metrics`/`report` renders for footer-table precedent).
+
+**File ownership:** Modify: `src/Miller.Server/Cli/CliDispatch.cs`, `src/Miller.Server/Cli/CliCapabilities.cs`; Test: `tests/Miller.Tests/Server/Cli/CliDispatchTests.cs`, `tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Consumes Task 2's reader API.
+
+**What to build:** `miller references candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]`. Compact: header with examined count + verbatim resolver line; candidate lines; footer with suppression counts (all nine ids), literal-scan coverage, per-language coverage table. JSON: the exact envelope. AOT note: add any new serialized types to the existing JSON serializer context (`CliDispatch` JSON output follows the source-generated context pattern — match it, reflection-based serialization breaks the AOT publish).
+
+**Approach:** TDD via `CliDispatchTests` against the extended fixture: compact candidate + suppressed counts + header string; `--json` envelope field-complete (assert every Global-Constraints field name); `--limit` honored; v3-artifact fixture (schema gate) exits 3 with the rebuild message like other artifact commands; capabilities assertions extended (boolean + json_commands + json_contracts). Scale test: scan a small temp fixture workspace containing a deliberately-dead private helper plus a reflection-string case with the REAL binary, run the CLI end-to-end, assert the dead helper appears and the reflection-named symbol is suppressed `string_literal_match`, and per-language coverage renders.
+
+**Acceptance criteria:**
+- [ ] Compact and JSON outputs match Global Constraints exactly; `--limit` honored; resolver status line present
+- [ ] Capabilities advertises all three surfaces; capabilities test extended
+- [ ] Scale test green against the real 2.9.0 binary (`scripts/test.sh scale`, `Skipped: 0` for the new test)
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+### Task 4: Contract docs + boundary amendments
+
+**Files:**
+- Create: `docs/contracts/references-candidates-v1.md`
+- Modify: `docs/contracts/references-export-v1.md` (lines 3–7: replace the "Eros owns candidate ranking, generated/framework suppression …" sentence per the 2026-07-06 consensus)
+- Modify: `docs/contracts/cli-eros-v1.md` (add `references candidates --json` to the documented surfaces; fix any Eros-ownership sentence about dead-code)
+- Modify: `docs/README.md` (contracts map entry)
+- Modify: `CLAUDE.md` (the "Dead-code candidates stay out until extractor reference resolution earns them" sentence in the 1.0-replacement-boundary section → now: shipped as an evidence-gated CLI prototype consuming schema v4 resolution; still absent from report/dashboard/MCP until the evidence gate passes), then `scripts/sync-agents.sh`, then `cmp -s CLAUDE.md AGENTS.md`
+
+**Interfaces:**
+- Consumes: Task 3's shipped shapes — copy JSON field names, capabilities keys, and the resolver header string verbatim from the code/tests, not from memory.
+- Produces: `references-candidates-v1` contract doc (status: experimental/evidence-gated; full envelope; the nine suppression rule-id semantics; evidence-label semantics incl. the explicit "provenance, not certainty" statement and the partial-resolver caveat).
+
+**Contract inputs:** Design §Output + §Evidence provenance; existing contract-doc format (`docs/contracts/references-export-v1.md` as the template).
+
+**File ownership:** Create: `docs/contracts/references-candidates-v1.md`; Modify: `docs/contracts/references-export-v1.md`, `docs/contracts/cli-eros-v1.md`, `docs/README.md`, `CLAUDE.md`, `AGENTS.md` (generated)
+
+**Serialization required:** Yes
+
+**Dependency reason:** Documents Task 3's shipped shapes verbatim (JSON field names, capabilities keys).
+
+**What to build:** The contract + boundary truth-up per doubt-pass finding 4. Keep amendments surgical: ranking-beyond-the-deterministic-rule, suppression *persistence*, history, and fleet workflows remain out of Miller.
+
+**Acceptance criteria:**
+- [ ] New contract doc complete (no TBDs), listed in `docs/README.md`
+- [ ] Stale Eros-ownership sentences amended in both existing contracts
+- [ ] `CLAUDE.md` boundary sentence updated; `cmp -s CLAUDE.md AGENTS.md` clean
+- [ ] Worker-scope verification passes (fast suite — `AgentInstructionsTests`/doc gates); `serial-worker-commit` with recorded SHA
+
+### Task 5: Dogfood evidence (the design's evidence gate)
+
+**Files:**
+- Create: `docs/findings/2026-07-07-dead-code-candidates-dogfood.md`
+
+**Interfaces:**
+- Consumes: the built Release CLI (`src/Miller.Server/bin/Release/net10.0/miller`) and v4 artifacts produced by `.tools/julie-extract` 2.9.0.
+- Produces: the findings doc gating any future surfacing (report/dashboard/README/agent guidance).
+
+**Contract inputs:** Design §Evidence gate. v4 scratch artifacts: build fresh ones with `.tools/julie-extract scan --root <repo> --db <scratch>/x.db` for `/Users/murphy/source/miller` and `/Users/murphy/source/julie-extractors` (do NOT rebuild the live `.miller/symbols.db` artifacts — the user-scope installed Miller still expects schema 3; run the CLI against the scratch DBs via `--workspace`-style selection or the reader's direct db path as `CliDispatchTests` does with `Context(...)` — if the CLI cannot target a scratch artifact cleanly, run `references candidates` through a temporary registered workspace copy and say so in the findings doc).
+
+**File ownership:** Create: `docs/findings/2026-07-07-dead-code-candidates-dogfood.md`
+
+**Serialization required:** Yes
+
+**Dependency reason:** Runs the Task 3 binary against real artifacts; is the design's evidence gate.
+
+**What to build:** Run candidates against both repos. Record: examined/candidate/suppression counts, per-language coverage, literal-scan coverage, full candidate lists. **Hand-verify every Miller-repo candidate** (read each symbol and its references; classify true-dead / false-positive / uncertain with file:line notes). Hard gate: zero confirmed-live symbols in the list. If any false positive is found: record it, tighten per design intent (report a plan mismatch if the fix needs a rule change beyond the design), re-run.
+
+**Acceptance criteria:**
+- [ ] Findings doc records both repos' runs with the full evidence and the hand-verification table
+- [ ] Hard gate met: no confirmed-live symbol among Miller-repo candidates (or the mismatch is reported and resolved)
+- [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA

--- a/docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md
+++ b/docs/plans/2026-07-07-dead-code-candidates-implementation-plan.md
@@ -19,6 +19,9 @@
 - Evidence labels are provenance, never certainty: `name` and `name+resolver` (resolver label requires ≥ 10% measured per-language resolution coverage in the artifact, computed at query time — no hardcoded language lists).
 - Compact header must include verbatim: `resolver: <status> — candidates are facts to check, not deletions to make.` where `<status>` is the artifact's `reference_resolution_status` metadata value (fallback `unknown` when the key is absent).
 - JSON envelope: `schema_version: 1`, `candidates[]` (symbol_id, name, kind, language, path, start_line, visibility, evidence_label, evidence{name_matches, resolved_inbound, pending_resolved_inbound, calls_inbound}), `suppressions{rule_id: count}`, `literal_scan{files_scanned, files_skipped_stale}`, `language_coverage[]` (language, identifiers, resolved_pct), `examined`, `artifact{artifact_id, revision, reference_resolution_status, reference_resolution_version}`.
+- `resolved_pct` is a 0–100 number rounded to one decimal (e.g. `15.6`, `10.0` for 1-of-10) — NOT a 0–1 ratio. The plan-review doubt pass flagged this as a cross-task drift risk; every task uses this convention.
+- CLI JSON is rendered with `Utf8JsonWriter` + manual snake_case field writes, the existing CLI convention (`CliCapabilities`, `ReferenceExportReader`). There is NO CLI source-generated serializer context — do not invent one or use reflection-based `JsonSerializer` (AOT).
+- Suppression booleans are ancestor-closed where the design says so: `test_symbol` and `framework_bound` suppress on the symbol OR any `parent_symbol_id` ancestor; `annotated` is self-only. Row-record field names carry the closure explicitly (see Task 1 Produces).
 - Generated-path globs (conservative): `*.g.cs`, `*.generated.*`, `obj/`, `bin/`, `node_modules/`, `*.designer.cs`, `wwwroot/lib/`.
 - No new MCP tool. No dashboard/`miller report`/README/agent-instructions surfacing (evidence-gated). `MILLER_AGENT_INSTRUCTIONS.md` untouched.
 - Build: 0 warnings / 0 errors (warnings are errors). `Miller.Core` stays zero-I/O.
@@ -70,7 +73,7 @@ Commit mode: `serial-worker-commit` for every task.
 
 **Interfaces:**
 - Consumes: nothing (pure).
-- Produces: `DeadCodeSymbolRow` (SymbolId, Name, Kind, Language, Path, StartLine, StartByte, EndByte, Visibility (string?), IsTest (bool), ParentSymbolId (string?), HasAnnotation (bool), HasStructuralFact (bool), NameMatchesOutside (int), ResolvedInbound (int), PendingResolvedInbound (int), CallsInbound (int), LiteralMatch (bool?) — null = not yet scanned); `LanguageCoverageRow` (Language, IdentifierCount, ResolvedCount); `DeadCodeCandidates.Evaluate(IReadOnlyList<DeadCodeSymbolRow>, IReadOnlyList<LanguageCoverageRow>) -> DeadCodeResult` where `DeadCodeResult` carries `Candidates` (list with `EvidenceLabel`), `Suppressions` (rule_id -> count, all nine ids always present), `Examined` (int). Also `DeadCodeCandidates.IsSyntaxInvokedName(string name, string kind) -> bool` and `DeadCodeCandidates.CandidateKinds` (the set), both public for the reader's SQL prefilter and tests.
+- Produces: `DeadCodeSymbolRow` (SymbolId, Name, Kind, Language, Path, StartLine, StartByte, EndByte, Visibility (string?), IsTestSelfOrAncestor (bool — ancestor-closed via `parent_symbol_id`, computed by the caller), ParentSymbolId (string?), HasAnnotation (bool — SELF only), HasStructuralFactSelfOrAncestor (bool — ancestor-closed, computed by the caller), NameMatchesOutside (int), ResolvedInbound (int), PendingResolvedInbound (int), CallsInbound (int), LiteralMatch (bool?) — null = not yet scanned); `LanguageCoverageRow` (Language, IdentifierCount, ResolvedCount); `DeadCodeCandidates.Evaluate(IReadOnlyList<DeadCodeSymbolRow>, IReadOnlyList<LanguageCoverageRow>) -> DeadCodeResult` where `DeadCodeResult` carries `Candidates` (list with `EvidenceLabel`), `Suppressions` (rule_id -> count, all nine ids always present), `Examined` (int). Core trusts the closure booleans as given — the ancestor walk is the reader's job (Task 2); Core tests still cover a parent-only-test and parent-only-structural-fact row proving the closed booleans suppress. Also `DeadCodeCandidates.IsSyntaxInvokedName(string name, string kind) -> bool` and `DeadCodeCandidates.CandidateKinds` (the set), both public for the reader's SQL prefilter and tests.
 - Produces: two-phase contract — `Evaluate` treats `LiteralMatch == true` as the `string_literal_match` suppression; `LiteralMatch == null` rows are returned in `DeadCodeResult.NeedsLiteralScan` so the reader can scan survivors only and call `Evaluate` semantics again via `DeadCodeCandidates.ApplyLiteralScan(result, matchedSymbolIds)`.
 
 **Contract inputs:** Global Constraints (kinds, exclusions, nine rule ids, evidence-label rules, ≥10% coverage threshold). Entry-point names: `Main`, `main`, plus path-tail heuristic `Program.cs` per the design.
@@ -83,7 +86,7 @@ Commit mode: `serial-worker-commit` for every task.
 
 **What to build:** The entire candidate/suppression/evidence decision as pure functions over plain records, per design §Candidate rule + §Suppression rules + §Evidence provenance. Suppression precedence: kind/name-shape exclusion removes a symbol from `Examined` candidates entirely (not a suppression count); the nine rules apply in table order, first match wins for the count, and any match suppresses.
 
-**Approach:** TDD. Follow `Miller.Core` conventions (records, no I/O, no Sqlite references). Keep evidence-label logic reading only `LanguageCoverageRow` data. Cover in tests: candidate found; alive-by-name / alive-by-resolved / alive-by-pending / alive-by-calls each prevent candidacy; each of the nine rules fires and counts; finalizer `~Resource`, indexer `this[int index]`, `operator +`, `op_Addition`, `Finalize` excluded; evidence-label split at the 10% boundary (9.9% → `name`, 10% → `name+resolver`); NULL visibility → `visibility_unknown`; two-phase literal-scan contract (`NeedsLiteralScan` then `ApplyLiteralScan` suppresses matched ids under `string_literal_match`).
+**Approach:** TDD. Follow `Miller.Core` conventions (records, no I/O, no Sqlite references). Keep evidence-label logic reading only `LanguageCoverageRow` data. Cover in tests: candidate found; alive-by-name / alive-by-resolved / alive-by-pending / alive-by-calls each prevent candidacy; each of the nine rules fires and counts; finalizer `~Resource`, indexer `this[int index]`, `operator +`, `op_Addition`, `Finalize` excluded; evidence-label split at the 10% boundary (9.9% → `name`, 10% → `name+resolver`); NULL visibility → `visibility_unknown`; rows with `IsTestSelfOrAncestor`/`HasStructuralFactSelfOrAncestor` set (ancestor-only case) suppress under `test_symbol`/`framework_bound`; two-phase literal-scan contract (`NeedsLiteralScan` then `ApplyLiteralScan` suppresses matched ids under `string_literal_match`).
 
 **Acceptance criteria:**
 - [ ] All rule-fidelity behaviors above proven red→green in `DeadCodeCandidatesTests`
@@ -102,7 +105,45 @@ Commit mode: `serial-worker-commit` for every task.
 - Consumes: Task 1's `DeadCodeCandidates` API (rows, `Evaluate`, `ApplyLiteralScan`, `IsSyntaxInvokedName`, `CandidateKinds`).
 - Produces: `DeadCodeCandidateReader.Read(string symbolsDbPath, string workspaceRoot) -> DeadCodeCandidateReport` where the report carries `DeadCodeResult` plus `LanguageCoverage`, `LiteralScan` (FilesScanned, FilesSkippedStale), and `Artifact` (ArtifactId, Revision, ReferenceResolutionStatus (fallback `"unknown"`), ReferenceResolutionVersion (nullable)). Task 3 renders exactly this report.
 
-**Contract inputs:** Real v4 DDL verified live this session — `identifier_resolutions` (identifier_id PK REFERENCES identifiers CASCADE, target_symbol_id REFERENCES symbols CASCADE, tier, confidence REAL, method TEXT, outcome TEXT NOT NULL, candidates INTEGER, resolved_at_revision INTEGER NOT NULL, CHECK ((outcome = 'resolved') = (target_symbol_id IS NOT NULL))); `pending_resolutions` (pending_relationship_id PK REFERENCES pending_relationships CASCADE, target_symbol_id TEXT NOT NULL REFERENCES symbols CASCADE, tier INTEGER NOT NULL, confidence REAL NOT NULL, method TEXT NOT NULL, resolved_at_revision INTEGER NOT NULL) with index `idx_pending_resolutions_target`; artifact_metadata keys `reference_resolution_status` / `reference_resolution_version`. Copy DDL into the fixture verbatim (fixture-fidelity rule). Existing span-read pattern: `src/Miller.Indexing/SqliteSourceRegionReader.cs` + `SourceRegionRow.cs`; freshness guard via `files.content_hash` (blake3, normalized) as used by existing source re-readers.
+**Contract inputs:** Real v4 DDL verified live this session — copy into the fixture VERBATIM including FKs, CHECK, and indexes (fixture-fidelity rule; the plan-review doubt pass flagged delegated DDL discovery as a drift risk):
+
+```sql
+CREATE TABLE identifier_resolutions (
+  identifier_id TEXT PRIMARY KEY REFERENCES identifiers(identifier_id) ON DELETE CASCADE,
+  target_symbol_id TEXT REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+  tier INTEGER, confidence REAL, method TEXT, outcome TEXT NOT NULL, candidates INTEGER,
+  resolved_at_revision INTEGER NOT NULL,
+  CHECK ((outcome = 'resolved') = (target_symbol_id IS NOT NULL))
+);
+CREATE INDEX idx_identifier_resolutions_target ON identifier_resolutions(target_symbol_id);
+CREATE TABLE pending_relationships (
+  pending_relationship_id TEXT PRIMARY KEY, from_symbol_id TEXT NOT NULL,
+  caller_scope_symbol_id TEXT, file_id TEXT NOT NULL, path TEXT NOT NULL, kind TEXT NOT NULL,
+  target_display_name TEXT NOT NULL, target_terminal_name TEXT NOT NULL, target_receiver TEXT,
+  target_namespace_json TEXT NOT NULL, target_import_context TEXT,
+  start_line INTEGER NOT NULL, start_column INTEGER, end_line INTEGER, end_column INTEGER,
+  start_byte INTEGER, end_byte INTEGER, confidence REAL NOT NULL, metadata_json TEXT,
+  FOREIGN KEY (from_symbol_id) REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+  FOREIGN KEY (caller_scope_symbol_id) REFERENCES symbols(symbol_id) ON DELETE SET NULL,
+  FOREIGN KEY (file_id) REFERENCES files(file_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_pending_terminal ON pending_relationships(target_terminal_name);
+CREATE INDEX idx_pending_file ON pending_relationships(file_id);
+CREATE INDEX idx_pending_from ON pending_relationships(from_symbol_id);
+CREATE INDEX idx_pending_caller_scope ON pending_relationships(caller_scope_symbol_id);
+CREATE TABLE pending_resolutions (
+  pending_relationship_id TEXT PRIMARY KEY
+    REFERENCES pending_relationships(pending_relationship_id) ON DELETE CASCADE,
+  target_symbol_id TEXT NOT NULL REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+  tier INTEGER NOT NULL, confidence REAL NOT NULL, method TEXT NOT NULL,
+  resolved_at_revision INTEGER NOT NULL
+);
+CREATE INDEX idx_pending_resolutions_target ON pending_resolutions(target_symbol_id);
+```
+
+(If the fixture already has a `pending_relationships` table with fewer columns/keys, upgrade it to this shape.) artifact_metadata keys: `reference_resolution_status` / `reference_resolution_version`. Existing span-read pattern: `src/Miller.Indexing/SqliteSourceRegionReader.cs` + `SourceRegionRow.cs`; freshness guard via `files.content_hash` (blake3, normalized) as used by existing source re-readers.
+
+**Schema-gate reality (plan-review finding, verified):** `JulieSchemaGate` validates only `artifact_metadata` values — it does NOT check table presence. A v4-stamped artifact missing the resolution tables passes the gate and would surface as a raw `SqliteException` (CLI exit 1, not the rebuild-oriented exit 3). The reader must therefore validate its required tables (`identifier_resolutions`, `pending_resolutions`, `pending_relationships`) via `sqlite_master` up front and throw the same incompatible-artifact exception type the gate uses (see `JulieSchemaGate`/`IncompatibleExtract` handling in `ReferenceExportReader`'s call path) so the CLI maps it to exit 3 with the rebuild message. Tests: one per missing required table against a v4-stamped DB.
 
 **File ownership:** Create: `src/Miller.Indexing/DeadCodeCandidateReader.cs`; Modify: `tests/Miller.Tests/Indexing/JulieDbFixture.cs`, `tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs`; Test: `tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs`
 
@@ -110,13 +151,13 @@ Commit mode: `serial-worker-commit` for every task.
 
 **Dependency reason:** Consumes Task 1's contracts; produces the reader API Task 3 wires.
 
-**What to build:** The SQL + literal-scan half per design §Architecture. One pass, no full identifiers materialization: per-symbol counts via indexed subqueries/CTEs (`identifiers` name-match outside the symbol's `[start_byte,end_byte]`+file OR `containing_symbol_id`; `identifier_resolutions` inbound from outside; `pending_resolutions JOIN pending_relationships` inbound from outside using the pending row's file/`caller_scope_symbol_id`/span context; `relationships` inbound from outside). Then `Evaluate`, then the literal scan LAST over `NeedsLiteralScan` survivors only: collect `string_literal` rows from `source_regions` grouped by file, re-read each file once, verify `files.content_hash` (skip + count stale files as `FilesSkippedStale`), substring-search surviving candidate names within literal spans, `ApplyLiteralScan`. Missing v4 tables (v3 artifact) must fail with the schema-gate error, not silently return zero — the D5 gate runs before the read, same as `ReferenceExportReader`.
+**What to build:** The SQL + literal-scan half per design §Architecture. One pass, no full identifiers materialization: per-symbol counts via indexed subqueries/CTEs (`identifiers` name-match outside the symbol's `[start_byte,end_byte]`+file OR `containing_symbol_id` — `idx_identifiers_name_kind` serves the name lookup; `identifier_resolutions` inbound from outside via `idx_identifier_resolutions_target`; `pending_resolutions JOIN pending_relationships` inbound from outside using the pending row's file/`caller_scope_symbol_id`/span context; `relationships` inbound from outside). The reader also computes the ancestor closures for `IsTestSelfOrAncestor` and `HasStructuralFactSelfOrAncestor` by walking `parent_symbol_id` (recursive CTE or in-memory parent map — parent maps are small). Then `Evaluate`, then the literal scan LAST over `NeedsLiteralScan` survivors only: collect `string_literal` rows from `source_regions` grouped by file, re-read each file once, verify `files.content_hash` (skip + count stale files as `FilesSkippedStale`), substring-search surviving candidate names within literal spans, `ApplyLiteralScan`. The D5 gate runs before the read (same as `ReferenceExportReader`) AND the reader validates required-table presence per the Schema-gate reality note above — a v4-stamped artifact missing resolution tables must exit 3 with the rebuild message, never a raw SqliteException or a silent zero.
 
-**Approach:** TDD against the extended `JulieDbFixture`. Extend the fixture with the three v4 tables (also `pending_relationships` if absent — copy real columns from a live probe: run `.tools/julie-extract scan` on a temp dir and `.schema pending_relationships`, do not invent) and builder methods (`AddIdentifierResolution`, `AddPendingResolution`, …). Extend `JulieDbFixtureCurrentSchemaTests` to require the new tables/columns/CHECK. Reader tests cover: candidate emitted with all evidence counts zero; saved-by-pending-resolution-only (no `identifier_resolutions` row — doubt-pass finding 2); literal match found in a real temp file under the workspace root suppresses (`string_literal_match`); stale content hash counts as skipped and does NOT suppress; artifact block populated incl. `reference_resolution_status` fallback `unknown` when key absent; coverage rows computed per language.
+**Approach:** TDD against the extended `JulieDbFixture`. Extend the fixture with the pinned DDL above and builder methods (`AddIdentifierResolution`, `AddPendingRelationship`, `AddPendingResolution`, …). Extend `JulieDbFixtureCurrentSchemaTests` to assert the new tables, columns, the `identifier_resolutions` CHECK constraint, and ALL pinned indexes — not table presence alone. Reader tests cover: candidate emitted with all evidence counts zero; saved-by-pending-resolution-only (no `identifier_resolutions` row — doubt-pass finding 2); parent-only `is_test` ancestor suppresses (`test_symbol`); parent-only structural fact suppresses (`framework_bound`); literal match found in a real temp file under the workspace root suppresses (`string_literal_match`); stale content hash counts as skipped and does NOT suppress; v4-stamped DB missing each required resolution table throws the incompatible-artifact exception (one test per table); artifact block populated incl. `reference_resolution_status` fallback `unknown` when key absent; coverage rows computed per language.
 
 **Acceptance criteria:**
-- [ ] Fixture carries the real v4 resolution DDL incl. the CHECK constraint; schema-guard test extended
-- [ ] Reader behaviors above proven red→green in `DeadCodeCandidateReaderTests`
+- [ ] Fixture carries the pinned v4 DDL verbatim (FKs, CHECK, all indexes); schema-guard test asserts indexes + CHECK, not just tables/columns
+- [ ] Reader behaviors above proven red→green in `DeadCodeCandidateReaderTests`, incl. ancestor-closure suppressions and one incompatible-artifact test per missing required table
 - [ ] Literal scan reads each literal-bearing file at most once and only runs when survivors exist
 - [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
 
@@ -140,9 +181,9 @@ Commit mode: `serial-worker-commit` for every task.
 
 **Dependency reason:** Consumes Task 2's reader API.
 
-**What to build:** `miller references candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]`. Compact: header with examined count + verbatim resolver line; candidate lines; footer with suppression counts (all nine ids), literal-scan coverage, per-language coverage table. JSON: the exact envelope. AOT note: add any new serialized types to the existing JSON serializer context (`CliDispatch` JSON output follows the source-generated context pattern — match it, reflection-based serialization breaks the AOT publish).
+**What to build:** `miller references candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]`. Compact: header with examined count + verbatim resolver line; candidate lines; footer with suppression counts (all nine ids), literal-scan coverage, per-language coverage table. JSON: the exact envelope, rendered with `Utf8JsonWriter` + manual snake_case field writes per Global Constraints — the existing CLI convention (`CliCapabilities.Render`, `ReferenceExportReader.WriteJsonLines`). There is no CLI source-generated serializer context; do not create one or use reflection `JsonSerializer` (AOT). Routing note: `ArtifactExport` (`CliDispatch.cs:692`) hardwires `operation == "export"`; branch on the op inside `case "references":` before delegating (candidates gets its own handler, export keeps `ArtifactExport`).
 
-**Approach:** TDD via `CliDispatchTests` against the extended fixture: compact candidate + suppressed counts + header string; `--json` envelope field-complete (assert every Global-Constraints field name); `--limit` honored; v3-artifact fixture (schema gate) exits 3 with the rebuild message like other artifact commands; capabilities assertions extended (boolean + json_commands + json_contracts). Scale test: scan a small temp fixture workspace containing a deliberately-dead private helper plus a reflection-string case with the REAL binary, run the CLI end-to-end, assert the dead helper appears and the reflection-named symbol is suppressed `string_literal_match`, and per-language coverage renders.
+**Approach:** TDD via `CliDispatchTests` against the extended fixture: compact candidate + suppressed counts + header string; `--json` envelope field-complete (assert every Global-Constraints field name) PLUS one exact-value assertion for `resolved_pct` with a 1-of-10 language fixture (`10.0`, not `0.1` — pins the 0–100 one-decimal convention); `--limit` honored; v3-artifact fixture (schema gate) exits 3 with the rebuild message like other artifact commands; v4-stamped fixture missing a resolution table also exits 3 (Task 2's reader validation surfacing through the CLI); capabilities assertions extended (boolean + json_commands + json_contracts). Scale test: scan a small temp fixture workspace containing a deliberately-dead private helper plus a reflection-string case with the REAL binary, run the CLI end-to-end, assert the dead helper appears and the reflection-named symbol is suppressed `string_literal_match`, and per-language coverage renders.
 
 **Acceptance criteria:**
 - [ ] Compact and JSON outputs match Global Constraints exactly; `--limit` honored; resolver status line present
@@ -188,7 +229,12 @@ Commit mode: `serial-worker-commit` for every task.
 - Consumes: the built Release CLI (`src/Miller.Server/bin/Release/net10.0/miller`) and v4 artifacts produced by `.tools/julie-extract` 2.9.0.
 - Produces: the findings doc gating any future surfacing (report/dashboard/README/agent guidance).
 
-**Contract inputs:** Design §Evidence gate. v4 scratch artifacts: build fresh ones with `.tools/julie-extract scan --root <repo> --db <scratch>/x.db` for `/Users/murphy/source/miller` and `/Users/murphy/source/julie-extractors` (do NOT rebuild the live `.miller/symbols.db` artifacts — the user-scope installed Miller still expects schema 3; run the CLI against the scratch DBs via `--workspace`-style selection or the reader's direct db path as `CliDispatchTests` does with `Context(...)` — if the CLI cannot target a scratch artifact cleanly, run `references candidates` through a temporary registered workspace copy and say so in the findings doc).
+**Contract inputs:** Design §Evidence gate. **Pinned dogfood recipe** (plan-review finding: the built CLI has no direct-DB flag, `--workspace`/`--workspace-id` resolve through the registry, and `CliDispatchTests.Context(...)` is a test seam, not a CLI path — do NOT touch the live `.miller/symbols.db` artifacts; the user-scope installed Miller still expects schema 3):
+
+1. For each repo (`/Users/murphy/source/miller`, `/Users/murphy/source/julie-extractors`): `git clone --local <repo> <scratch>/<name>` (temp source copy in the session scratchpad).
+2. `.tools/julie-extract scan --root <scratch>/<name> --db <scratch>/<name>/.miller/symbols.db` (v4 artifact inside the COPY's `.miller`).
+3. Run the freshly built Release binary with the copy as cwd: `cd <scratch>/<name> && <repo-root>/src/Miller.Server/bin/Release/net10.0/miller references candidates --json` (cwd-based `WorkspaceContext` resolution finds `<cwd>/.miller/symbols.db`; no registry entry, no live-state contact).
+4. Delete the copies afterwards.
 
 **File ownership:** Create: `docs/findings/2026-07-07-dead-code-candidates-dogfood.md`
 
@@ -196,9 +242,28 @@ Commit mode: `serial-worker-commit` for every task.
 
 **Dependency reason:** Runs the Task 3 binary against real artifacts; is the design's evidence gate.
 
-**What to build:** Run candidates against both repos. Record: examined/candidate/suppression counts, per-language coverage, literal-scan coverage, full candidate lists. **Hand-verify every Miller-repo candidate** (read each symbol and its references; classify true-dead / false-positive / uncertain with file:line notes). Hard gate: zero confirmed-live symbols in the list. If any false positive is found: record it, tighten per design intent (report a plan mismatch if the fix needs a rule change beyond the design), re-run.
+**What to build:** Run candidates against both repos per the pinned recipe. Record: examined/candidate/suppression counts, per-language coverage, literal-scan coverage, full candidate lists. **Hand-verify every Miller-repo candidate** (read each symbol and its references; classify true-dead / false-positive / uncertain with file:line notes). Hard gate: zero confirmed-live symbols in the list.
+
+**This task is a verification GATE, not a fix lane** (plan-review finding: Task 5 owns only the findings doc). If any confirmed-live candidate is found: record it in the findings doc with the evidence, do NOT commit a success result, STOP and report the false positive to the lead as a plan/design mismatch. The lead dispatches the corrective work against the owning tasks' files and re-runs this gate. Task 5 never edits Core/Indexing/CLI code.
 
 **Acceptance criteria:**
 - [ ] Findings doc records both repos' runs with the full evidence and the hand-verification table
-- [ ] Hard gate met: no confirmed-live symbol among Miller-repo candidates (or the mismatch is reported and resolved)
+- [ ] Hard gate met: no confirmed-live symbol among Miller-repo candidates — or the gate STOPPED and reported the false positive to the lead (no success commit)
+- [ ] Live workspace artifacts and registry untouched (scratch copies only)
 - [ ] Worker-scope verification passes; `serial-worker-commit` with recorded SHA
+
+## Review log
+
+- **Rev 2 (2026-07-07):** Codex adversarial plan review (verdict: needs-attention, 7 findings — all
+  verified against live code/artifact and folded in): (1) `JulieSchemaGate` validates metadata only,
+  so Task 2 gained explicit required-table validation → incompatible-artifact exception → CLI exit 3,
+  with per-missing-table tests; (2) Task 5's dogfood recipe pinned to temp source copies scanned into
+  `<copy>/.miller/symbols.db` and run with cwd-based resolution — no direct-DB flag exists and the
+  test `Context(...)` seam is not a CLI path; (3) ancestor-closure made explicit in the row contract
+  (`IsTestSelfOrAncestor`, `HasStructuralFactSelfOrAncestor`, reader computes the walk) with
+  parent-only tests in both Core and Reader; (4) full v4 DDL (FKs, CHECK, all indexes, incl.
+  `pending_relationships`) pinned in Task 2 verbatim and the schema-guard test extended to assert
+  indexes; (5) Task 5 converted to a stop-and-report verification gate (owns only the findings doc,
+  never edits code); (6) the invented "CLI serializer context" replaced with the real convention —
+  `Utf8JsonWriter` manual snake_case (no CLI source-generated context exists); (7) `resolved_pct`
+  pinned as 0–100 one-decimal with an exact-value 1-of-10 CLI test.

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -64,8 +64,9 @@
         </p>
         <p>
           Miller is one piece of the Julie replacement story: <code>julie-extractors</code> owns parser-backed
-          extraction, Miller owns the local deterministic agent-tool core, and Eros owns semantic retrieval,
-          guidance, signals reports, confidence views, and commercial workflow orchestration.
+          extraction, Miller owns the local deterministic agent-tool core — including deterministic repo-quality
+          reports like <code>metrics risk</code> and <code>miller report</code> — and Eros owns semantic retrieval,
+          guidance, confidence views, and commercial workflow orchestration.
         </p>
       </div>
       <div class="feature-strip" aria-label="Miller product pillars">

--- a/scripts/julie-pins.json
+++ b/scripts/julie-pins.json
@@ -1,12 +1,12 @@
 {
-  "version": "2.8.1",
+  "version": "2.9.0",
   "binary": "julie-extract",
   "archiveInnerPathTemplate": "dist/{triple}/julie-extract{exe}",
   "urlTemplate": "https://github.com/anortham/julie-extractors/releases/download/v{VER}/{asset}",
   "assets": {
-    "aarch64-apple-darwin":     { "name": "julie-extract-v{VER}-aarch64-apple-darwin.tar.gz",     "sha256": "d147b62367153b38c08399ddc8d11873b0f21268222a2dc9523428c5e5a78fcb" },
-    "x86_64-apple-darwin":      { "name": "julie-extract-v{VER}-x86_64-apple-darwin.tar.gz",      "sha256": "431a6b9205dc5c259cea710d60d48e7440276a8fb2434e39dc31458093fd1e09" },
-    "x86_64-unknown-linux-gnu": { "name": "julie-extract-v{VER}-x86_64-unknown-linux-gnu.tar.gz", "sha256": "b8217e019b3cd4d1f3f930bab0507a2d3d3f313ed773a8110bdf45212bc32e9d" },
-    "x86_64-pc-windows-msvc":   { "name": "julie-extract-v{VER}-x86_64-pc-windows-msvc.zip",      "sha256": "e3e1afb80fa168d6437a3fc886a969bf8dcb39c230b9fb5762d6bd22f45953dc" }
+    "aarch64-apple-darwin":     { "name": "julie-extract-v{VER}-aarch64-apple-darwin.tar.gz",     "sha256": "ab6ccea3278c7d4b9e765c09384078d6537376d7be96c451899eadd16f2ef95f" },
+    "x86_64-apple-darwin":      { "name": "julie-extract-v{VER}-x86_64-apple-darwin.tar.gz",      "sha256": "7dae42c454fa4f9bd14fcbbf55020012a483ff3439de6d5670378312063af7c0" },
+    "x86_64-unknown-linux-gnu": { "name": "julie-extract-v{VER}-x86_64-unknown-linux-gnu.tar.gz", "sha256": "df6a21ecc9eff09d9375b11a979b5ee5cc12a0d63c5c2e1fbf082494c552ef6f" },
+    "x86_64-pc-windows-msvc":   { "name": "julie-extract-v{VER}-x86_64-pc-windows-msvc.zip",      "sha256": "54519cc322952b0df6002e8c5f91851345d7453d534b1d9d61fe83a804969739" }
   }
 }

--- a/scripts/julie-pins.json
+++ b/scripts/julie-pins.json
@@ -4,9 +4,9 @@
   "archiveInnerPathTemplate": "dist/{triple}/julie-extract{exe}",
   "urlTemplate": "https://github.com/anortham/julie-extractors/releases/download/v{VER}/{asset}",
   "assets": {
-    "aarch64-apple-darwin":     { "name": "julie-extract-v{VER}-aarch64-apple-darwin.tar.gz",     "sha256": "ab6ccea3278c7d4b9e765c09384078d6537376d7be96c451899eadd16f2ef95f" },
-    "x86_64-apple-darwin":      { "name": "julie-extract-v{VER}-x86_64-apple-darwin.tar.gz",      "sha256": "7dae42c454fa4f9bd14fcbbf55020012a483ff3439de6d5670378312063af7c0" },
-    "x86_64-unknown-linux-gnu": { "name": "julie-extract-v{VER}-x86_64-unknown-linux-gnu.tar.gz", "sha256": "df6a21ecc9eff09d9375b11a979b5ee5cc12a0d63c5c2e1fbf082494c552ef6f" },
-    "x86_64-pc-windows-msvc":   { "name": "julie-extract-v{VER}-x86_64-pc-windows-msvc.zip",      "sha256": "54519cc322952b0df6002e8c5f91851345d7453d534b1d9d61fe83a804969739" }
+    "aarch64-apple-darwin":     { "name": "julie-extract-v{VER}-aarch64-apple-darwin.tar.gz",     "sha256": "dcdd59b24ad5724bbc2edf5c9bef1a87500cfc7ed2f8aaf25d2f61ce019b6fe7" },
+    "x86_64-apple-darwin":      { "name": "julie-extract-v{VER}-x86_64-apple-darwin.tar.gz",      "sha256": "8cabfa2ab4d617bb301a790494d8b3c5382450faaceadc55b4cfd44970fb3119" },
+    "x86_64-unknown-linux-gnu": { "name": "julie-extract-v{VER}-x86_64-unknown-linux-gnu.tar.gz", "sha256": "32e9d57d45c72e4807dbb88e1c5832105d6cd4faf62eaeada40997e762ef4e01" },
+    "x86_64-pc-windows-msvc":   { "name": "julie-extract-v{VER}-x86_64-pc-windows-msvc.zip",      "sha256": "2380935f7fa2b940bd0927c422543f30b0ce4c52d1979d2941faafd7a48603df" }
   }
 }

--- a/scripts/julie-pins.json
+++ b/scripts/julie-pins.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.9.0",
+  "version": "2.10.0",
   "binary": "julie-extract",
   "archiveInnerPathTemplate": "dist/{triple}/julie-extract{exe}",
   "urlTemplate": "https://github.com/anortham/julie-extractors/releases/download/v{VER}/{asset}",

--- a/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
+++ b/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
@@ -34,6 +34,7 @@ public static class DeadCodeCandidates
     private const string VisibilityUnknown = "visibility_unknown";
     private const string TestSymbol = "test_symbol";
     private const string EntryPoint = "entry_point";
+    private const string OverrideMember = "override_member";
     private const string FrameworkBound = "framework_bound";
     private const string Annotated = "annotated";
     private const string GeneratedPath = "generated_path";
@@ -51,12 +52,12 @@ public static class DeadCodeCandidates
     };
 
     /// <summary>
-    /// The nine suppression rule ids in TABLE ORDER — the single source of the ids and their output order, so the
+    /// The ten suppression rule ids in TABLE ORDER — the single source of the ids and their output order, so the
     /// Indexing / Server layers cannot drift the set or its ordering.
     /// </summary>
     public static IReadOnlyList<string> SuppressionRuleIds { get; } =
     [
-        PublicApi, VisibilityUnknown, TestSymbol, EntryPoint, FrameworkBound,
+        PublicApi, VisibilityUnknown, TestSymbol, EntryPoint, OverrideMember, FrameworkBound,
         Annotated, GeneratedPath, LowEvidenceLanguage, StringLiteralMatch,
     ];
 
@@ -204,11 +205,14 @@ public static class DeadCodeCandidates
         if (string.IsNullOrWhiteSpace(row.Visibility))
             return VisibilityUnknown;
 
-        if (row.IsTestSelfOrAncestor)
+        if (row.IsTestSelfOrAncestor || IsTestPath(row.Path))
             return TestSymbol;
 
         if (IsEntryPoint(row))
             return EntryPoint;
+
+        if (row.IsOverrideMember)
+            return OverrideMember;
 
         if (row.HasStructuralFactSelfOrAncestor)
             return FrameworkBound;
@@ -228,6 +232,41 @@ public static class DeadCodeCandidates
             return StringLiteralMatch;
 
         return null;
+    }
+
+    // Whole path segments that mark test trees. The extractor's is_test flag misses helper types declared inside
+    // test files (a fake logger has no test attribute), so the test_symbol rule also fires on path evidence.
+    // Whole-segment match only — "src/protest/" or "LatestReport.cs" must not fire.
+    private static readonly string[] TestPathSegments = ["test", "tests", "__tests__"];
+
+    private static bool IsTestPath(string path)
+    {
+        foreach (var segment in Normalize(path).Split('/'))
+        {
+            foreach (var testSegment in TestPathSegments)
+            {
+                if (string.Equals(segment, testSegment, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when a symbol's signature carries an <c>override</c>-family modifier (C#/Kotlin/Swift/Scala
+    /// <c>override</c>, VB <c>Overrides</c>): the member is invoked through its base contract, so zero inbound
+    /// name/graph evidence is expected and it must not be flagged. Whole-word match — identifiers that merely
+    /// contain the word (<c>override_config</c>, <c>OverrideCount</c>) do not fire. Java's <c>@Override</c> is an
+    /// annotation, covered by the <c>annotated</c> rule.
+    /// </summary>
+    public static bool IsOverrideSignature(string? signature)
+    {
+        if (string.IsNullOrEmpty(signature))
+            return false;
+
+        return System.Text.RegularExpressions.Regex.IsMatch(
+            signature, @"\boverrides?\b", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
 
     private static bool IsEntryPoint(DeadCodeSymbolRow row)

--- a/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
+++ b/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
@@ -12,7 +12,7 @@ public sealed record DeadCodeCandidate(
 
 /// <summary>
 /// The result of <see cref="DeadCodeCandidates.Evaluate"/>: the surviving candidates, the per-rule suppression
-/// counts (ALL nine rule ids always present, even when 0), the examined count (symbols that survived exclusion),
+/// counts (ALL eleven rule ids always present, even when 0), the examined count (symbols that survived exclusion),
 /// and the provisional candidates still awaiting the reader's literal scan (<see cref="NeedsLiteralScan"/>).
 /// </summary>
 public sealed record DeadCodeResult(
@@ -35,6 +35,7 @@ public static class DeadCodeCandidates
     private const string TestSymbol = "test_symbol";
     private const string EntryPoint = "entry_point";
     private const string OverrideMember = "override_member";
+    private const string LiveMemberContainer = "live_member_container";
     private const string FrameworkBound = "framework_bound";
     private const string Annotated = "annotated";
     private const string GeneratedPath = "generated_path";
@@ -52,14 +53,20 @@ public static class DeadCodeCandidates
     };
 
     /// <summary>
-    /// The ten suppression rule ids in TABLE ORDER — the single source of the ids and their output order, so the
+    /// The eleven suppression rule ids in TABLE ORDER — the single source of the ids and their output order, so the
     /// Indexing / Server layers cannot drift the set or its ordering.
     /// </summary>
     public static IReadOnlyList<string> SuppressionRuleIds { get; } =
     [
-        PublicApi, VisibilityUnknown, TestSymbol, EntryPoint, OverrideMember, FrameworkBound,
-        Annotated, GeneratedPath, LowEvidenceLanguage, StringLiteralMatch,
+        PublicApi, VisibilityUnknown, TestSymbol, EntryPoint, OverrideMember, LiveMemberContainer,
+        FrameworkBound, Annotated, GeneratedPath, LowEvidenceLanguage, StringLiteralMatch,
     ];
+
+    // Type kinds that CONTAIN members — a static extension class, a partial container, an interface with a
+    // referenced member. Delegates and other candidate kinds have no members and are deliberately excluded, so
+    // the live_member_container rule only rescues genuine containers.
+    private static readonly IReadOnlySet<string> TypeContainerKinds =
+        new HashSet<string>(StringComparer.Ordinal) { "class", "struct", "interface", "enum" };
 
     // Visibility values treated as exported / public (conservative — suppressing more avoids false positives).
     private static readonly IReadOnlySet<string> ExportedVisibilities =
@@ -103,7 +110,7 @@ public static class DeadCodeCandidates
     /// <summary>
     /// Evaluate the candidate + suppression rules over the reader's rows. See the design doc for the full decision
     /// logic; the short version: exclude non-candidate kinds and syntax-invoked names, drop alive-by-evidence
-    /// symbols silently, then apply the nine suppression rules in table order (first match wins the count). What
+    /// symbols silently, then apply the eleven suppression rules in table order (first match wins the count). What
     /// remains is a candidate; a candidate whose <see cref="DeadCodeSymbolRow.LiteralMatch"/> is <c>null</c> is
     /// provisional and also listed in <see cref="DeadCodeResult.NeedsLiteralScan"/>.
     /// </summary>
@@ -123,6 +130,20 @@ public static class DeadCodeCandidates
         foreach (var id in SuppressionRuleIds)
             suppressions[id] = 0;
 
+        // Parent ids of candidate-kind members that show inbound evidence — the input to the live_member_container
+        // rule. Built once over the LOADED rows (candidate kinds only, per DeadCodeSymbolRow's contract): a
+        // container whose only members are non-candidate kinds (fields, constructors) never appears here, so it
+        // stays a candidate (conservative direction). O(n) over the rows already passed to Evaluate.
+        var parentsWithLiveMember = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            if (row.ParentSymbolId is not null
+                && CandidateKinds.Contains(row.Kind)
+                && (row.NameMatchesOutside > 0 || row.ResolvedInbound > 0
+                    || row.PendingResolvedInbound > 0 || row.CallsInbound > 0))
+                parentsWithLiveMember.Add(row.ParentSymbolId);
+        }
+
         var candidates = new List<DeadCodeCandidate>();
         var needsLiteralScan = new List<DeadCodeSymbolRow>();
         int examined = 0;
@@ -140,7 +161,7 @@ public static class DeadCodeCandidates
                 || row.PendingResolvedInbound > 0 || row.CallsInbound > 0)
                 continue;
 
-            var suppressingRule = FirstSuppressionRule(row, coverageByLanguage);
+            var suppressingRule = FirstSuppressionRule(row, coverageByLanguage, parentsWithLiveMember);
             if (suppressingRule is not null)
             {
                 suppressions[suppressingRule]++;
@@ -197,7 +218,8 @@ public static class DeadCodeCandidates
     /// </summary>
     private static string? FirstSuppressionRule(
         DeadCodeSymbolRow row,
-        IReadOnlyDictionary<string, LanguageCoverageRow> coverageByLanguage)
+        IReadOnlyDictionary<string, LanguageCoverageRow> coverageByLanguage,
+        IReadOnlySet<string> parentsWithLiveMember)
     {
         if (!string.IsNullOrWhiteSpace(row.Visibility) && ExportedVisibilities.Contains(row.Visibility))
             return PublicApi;
@@ -213,6 +235,13 @@ public static class DeadCodeCandidates
 
         if (row.IsOverrideMember)
             return OverrideMember;
+
+        // A TYPE-kind row (class/struct/interface/enum) whose name shows no inbound evidence but at least one of its
+        // loaded members does — the classic C# static extension class shape (the class name appears nowhere;
+        // callers write `outcome.ToStorageString()`). The container is alive through its members, so it must not be
+        // flagged. Only rows already past the alive-by-evidence drop and the earlier rules reach here.
+        if (TypeContainerKinds.Contains(row.Kind) && parentsWithLiveMember.Contains(row.SymbolId))
+            return LiveMemberContainer;
 
         if (row.HasStructuralFactSelfOrAncestor)
             return FrameworkBound;

--- a/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
+++ b/src/Miller.Core/DeadCode/DeadCodeCandidates.cs
@@ -1,0 +1,282 @@
+namespace Miller.Core.DeadCode;
+
+/// <summary>
+/// A single dead-code candidate — a symbol that survived exclusion, showed no inbound evidence of life, and was not
+/// caught by any named suppression rule. It is a fact to check, not a verdict: <see cref="EvidenceLabel"/> states
+/// which evidence was consulted (<c>name</c> / <c>name+resolver</c>), never a certainty grade.
+/// </summary>
+public sealed record DeadCodeCandidate(
+    string SymbolId, string Name, string Kind, string Language, string Path,
+    int StartLine, string? Visibility, string EvidenceLabel,
+    int NameMatches, int ResolvedInbound, int PendingResolvedInbound, int CallsInbound);
+
+/// <summary>
+/// The result of <see cref="DeadCodeCandidates.Evaluate"/>: the surviving candidates, the per-rule suppression
+/// counts (ALL nine rule ids always present, even when 0), the examined count (symbols that survived exclusion),
+/// and the provisional candidates still awaiting the reader's literal scan (<see cref="NeedsLiteralScan"/>).
+/// </summary>
+public sealed record DeadCodeResult(
+    IReadOnlyList<DeadCodeCandidate> Candidates,
+    IReadOnlyDictionary<string, int> Suppressions,
+    int Examined,
+    IReadOnlyList<DeadCodeSymbolRow> NeedsLiteralScan);
+
+/// <summary>
+/// Pure candidate / suppression / evidence-label evaluator for <c>miller references candidates</c> (dead-code
+/// candidates design, rev 2). ZERO I/O: it operates only on plain row records supplied by the Indexing reader. The
+/// rule is deliberately one-directional — resolution and literal evidence can only SAVE a symbol from being flagged,
+/// never add a flag — preserving the conservative "collisions hide dead code rather than flag live code" stance.
+/// </summary>
+public static class DeadCodeCandidates
+{
+    // ---- suppression rule ids (single source of the ids AND their table order) -------------------------------
+    private const string PublicApi = "public_api";
+    private const string VisibilityUnknown = "visibility_unknown";
+    private const string TestSymbol = "test_symbol";
+    private const string EntryPoint = "entry_point";
+    private const string FrameworkBound = "framework_bound";
+    private const string Annotated = "annotated";
+    private const string GeneratedPath = "generated_path";
+    private const string LowEvidenceLanguage = "low_evidence_language";
+    private const string StringLiteralMatch = "string_literal_match";
+
+    /// <summary>
+    /// The definition kinds worth reporting (design rule 1), in canonical order:
+    /// function, method, class, struct, interface, enum, delegate, property, constant. A symbol whose kind is not
+    /// in this set is excluded entirely (not examined, not suppressed).
+    /// </summary>
+    public static IReadOnlySet<string> CandidateKinds { get; } = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "function", "method", "class", "struct", "interface", "enum", "delegate", "property", "constant",
+    };
+
+    /// <summary>
+    /// The nine suppression rule ids in TABLE ORDER — the single source of the ids and their output order, so the
+    /// Indexing / Server layers cannot drift the set or its ordering.
+    /// </summary>
+    public static IReadOnlyList<string> SuppressionRuleIds { get; } =
+    [
+        PublicApi, VisibilityUnknown, TestSymbol, EntryPoint, FrameworkBound,
+        Annotated, GeneratedPath, LowEvidenceLanguage, StringLiteralMatch,
+    ];
+
+    // Visibility values treated as exported / public (conservative — suppressing more avoids false positives).
+    private static readonly IReadOnlySet<string> ExportedVisibilities =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "public", "exported" };
+
+    // Path segments that mark generated / vendored trees (checked as a leading segment or "/<segment>").
+    private static readonly string[] GeneratedSegments = ["obj/", "bin/", "node_modules/", "wwwroot/lib/"];
+
+    /// <summary>
+    /// True when the name is a syntax-invoked member shape that is never referenced by an identifier bearing its own
+    /// name — finalizers/destructors (<c>~</c>), indexers (<c>this[</c>), operator overloads (<c>operator</c> /
+    /// <c>op_</c>), and <c>Finalize</c>. Such members pass every evidence check yet are invoked by syntax, so they
+    /// are excluded up front. A small named table, extensible per language.
+    /// </summary>
+    public static bool IsSyntaxInvokedName(string name, string kind)
+    {
+        _ = kind; // reserved: the table is keyed by name today, but kept per-(name, kind) for per-language growth.
+        if (string.IsNullOrEmpty(name))
+            return false;
+
+        return name.StartsWith('~')
+            || name.Contains("this[", StringComparison.Ordinal)
+            || name.StartsWith("operator", StringComparison.Ordinal)
+            || name.StartsWith("op_", StringComparison.Ordinal)
+            || name == "Finalize";
+    }
+
+    /// <summary>
+    /// Resolved-identifier percentage (0–100) for one language, rounded to ONE decimal
+    /// (<see cref="MidpointRounding.AwayFromZero"/>). <c>identifiers == 0</c> yields <c>0.0</c> (no divide-by-zero).
+    /// Single-sourced so the ≥ 10% evidence-label threshold and downstream output rendering cannot drift apart.
+    /// </summary>
+    public static double ResolvedPercent(int identifiers, int resolved)
+    {
+        if (identifiers == 0)
+            return 0.0;
+
+        return Math.Round((double)resolved / identifiers * 100.0, 1, MidpointRounding.AwayFromZero);
+    }
+
+    /// <summary>
+    /// Evaluate the candidate + suppression rules over the reader's rows. See the design doc for the full decision
+    /// logic; the short version: exclude non-candidate kinds and syntax-invoked names, drop alive-by-evidence
+    /// symbols silently, then apply the nine suppression rules in table order (first match wins the count). What
+    /// remains is a candidate; a candidate whose <see cref="DeadCodeSymbolRow.LiteralMatch"/> is <c>null</c> is
+    /// provisional and also listed in <see cref="DeadCodeResult.NeedsLiteralScan"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> or <paramref name="coverage"/> is null.</exception>
+    public static DeadCodeResult Evaluate(
+        IReadOnlyList<DeadCodeSymbolRow> rows,
+        IReadOnlyList<LanguageCoverageRow> coverage)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(coverage);
+
+        var coverageByLanguage = new Dictionary<string, LanguageCoverageRow>(StringComparer.Ordinal);
+        foreach (var row in coverage)
+            coverageByLanguage[row.Language] = row; // last write wins for a duplicated language
+
+        var suppressions = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var id in SuppressionRuleIds)
+            suppressions[id] = 0;
+
+        var candidates = new List<DeadCodeCandidate>();
+        var needsLiteralScan = new List<DeadCodeSymbolRow>();
+        int examined = 0;
+
+        foreach (var row in rows)
+        {
+            // Exclusion — not counted, not examined.
+            if (!CandidateKinds.Contains(row.Kind) || IsSyntaxInvokedName(row.Name, row.Kind))
+                continue;
+
+            examined++;
+
+            // Alive-by-evidence — silently dropped, NOT a suppression.
+            if (row.NameMatchesOutside > 0 || row.ResolvedInbound > 0
+                || row.PendingResolvedInbound > 0 || row.CallsInbound > 0)
+                continue;
+
+            var suppressingRule = FirstSuppressionRule(row, coverageByLanguage);
+            if (suppressingRule is not null)
+            {
+                suppressions[suppressingRule]++;
+                continue;
+            }
+
+            candidates.Add(new DeadCodeCandidate(
+                row.SymbolId, row.Name, row.Kind, row.Language, row.Path,
+                row.StartLine, row.Visibility, EvidenceLabel(row, coverageByLanguage),
+                row.NameMatchesOutside, row.ResolvedInbound, row.PendingResolvedInbound, row.CallsInbound));
+
+            // A candidate not yet literal-scanned is provisional: the reader still has to scan it (rules 1–8 already
+            // passed, so string_literal_match will be its first-and-only matching rule if the scan finds a hit).
+            if (row.LiteralMatch is null)
+                needsLiteralScan.Add(row);
+        }
+
+        return new DeadCodeResult(candidates, suppressions, examined, needsLiteralScan);
+    }
+
+    /// <summary>
+    /// Pure two-phase finish: after the reader scans <see cref="DeadCodeResult.NeedsLiteralScan"/>, remove every
+    /// candidate whose <see cref="DeadCodeCandidate.SymbolId"/> is in <paramref name="matchedSymbolIds"/>, move each
+    /// into the <c>string_literal_match</c> suppression count, and return a new result with
+    /// <see cref="DeadCodeResult.NeedsLiteralScan"/> emptied.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="result"/> or <paramref name="matchedSymbolIds"/> is null.</exception>
+    public static DeadCodeResult ApplyLiteralScan(DeadCodeResult result, ISet<string> matchedSymbolIds)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(matchedSymbolIds);
+
+        var survivors = new List<DeadCodeCandidate>(result.Candidates.Count);
+        int matched = 0;
+        foreach (var candidate in result.Candidates)
+        {
+            if (matchedSymbolIds.Contains(candidate.SymbolId))
+                matched++;
+            else
+                survivors.Add(candidate);
+        }
+
+        var suppressions = new Dictionary<string, int>(result.Suppressions, StringComparer.Ordinal);
+        suppressions[StringLiteralMatch] = suppressions.GetValueOrDefault(StringLiteralMatch) + matched;
+
+        return new DeadCodeResult(survivors, suppressions, result.Examined, []);
+    }
+
+    // ---- rule application ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The first suppression rule (in table order) that matches <paramref name="row"/>, or null when none do. Only
+    /// reached for symbols that survived exclusion and were not alive-by-evidence.
+    /// </summary>
+    private static string? FirstSuppressionRule(
+        DeadCodeSymbolRow row,
+        IReadOnlyDictionary<string, LanguageCoverageRow> coverageByLanguage)
+    {
+        if (!string.IsNullOrWhiteSpace(row.Visibility) && ExportedVisibilities.Contains(row.Visibility))
+            return PublicApi;
+
+        if (string.IsNullOrWhiteSpace(row.Visibility))
+            return VisibilityUnknown;
+
+        if (row.IsTestSelfOrAncestor)
+            return TestSymbol;
+
+        if (IsEntryPoint(row))
+            return EntryPoint;
+
+        if (row.HasStructuralFactSelfOrAncestor)
+            return FrameworkBound;
+
+        if (row.HasAnnotation)
+            return Annotated;
+
+        if (IsGeneratedPath(row.Path))
+            return GeneratedPath;
+
+        // Present in coverage with zero identifiers — nothing to test liveness against (e.g. css/html). A language
+        // absent from coverage does NOT fire this rule (it can still be a candidate with the "name" label).
+        if (coverageByLanguage.TryGetValue(row.Language, out var cov) && cov.IdentifierCount == 0)
+            return LowEvidenceLanguage;
+
+        if (row.LiteralMatch == true)
+            return StringLiteralMatch;
+
+        return null;
+    }
+
+    private static bool IsEntryPoint(DeadCodeSymbolRow row)
+    {
+        if (row.Name is "Main" or "main")
+            return true;
+
+        var fileName = FileName(Normalize(row.Path));
+        return string.Equals(fileName, "Program.cs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsGeneratedPath(string path)
+    {
+        var normalized = Normalize(path);
+
+        foreach (var segment in GeneratedSegments)
+        {
+            if (normalized.StartsWith(segment, StringComparison.OrdinalIgnoreCase)
+                || normalized.Contains("/" + segment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        var fileName = FileName(normalized);
+        return fileName.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".designer.cs", StringComparison.OrdinalIgnoreCase)
+            || fileName.Contains(".generated.", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---- evidence label --------------------------------------------------------------------------------------
+
+    private static string EvidenceLabel(
+        DeadCodeSymbolRow row,
+        IReadOnlyDictionary<string, LanguageCoverageRow> coverageByLanguage)
+    {
+        // Absent from coverage -> treat as 0% resolved -> "name".
+        if (coverageByLanguage.TryGetValue(row.Language, out var cov)
+            && ResolvedPercent(cov.IdentifierCount, cov.ResolvedCount) >= 10.0)
+            return "name+resolver";
+
+        return "name";
+    }
+
+    // ---- path helpers ----------------------------------------------------------------------------------------
+
+    private static string Normalize(string path) => path.Replace('\\', '/');
+
+    private static string FileName(string normalizedPath)
+    {
+        int slash = normalizedPath.LastIndexOf('/');
+        return slash < 0 ? normalizedPath : normalizedPath[(slash + 1)..];
+    }
+}

--- a/src/Miller.Core/DeadCode/DeadCodeRows.cs
+++ b/src/Miller.Core/DeadCode/DeadCodeRows.cs
@@ -1,0 +1,42 @@
+namespace Miller.Core.DeadCode;
+
+/// <summary>
+/// One candidate-kind symbol plus the inbound-evidence and suppression facts the reader gathered for it. A pure
+/// projection consumed by <see cref="DeadCodeCandidates.Evaluate"/>; Miller.Core stays free of julie's row shape.
+/// </summary>
+/// <remarks>
+/// The closure booleans (<see cref="IsTestSelfOrAncestor"/>, <see cref="HasStructuralFactSelfOrAncestor"/>) are
+/// computed by the reader's <c>parent_symbol_id</c> walk; Core TRUSTS them as given rather than re-walking parents.
+/// <see cref="HasAnnotation"/> is SELF-only. <see cref="LiteralMatch"/> drives the two-phase literal scan:
+/// <c>null</c> = not yet scanned (provisional candidate), <c>true</c> = the name was found in a string literal
+/// (suppressed), <c>false</c> = scanned with no match (candidate). <see cref="StartByte"/> / <see cref="EndByte"/>
+/// are carried faithfully for downstream consumers even though the evaluator itself does not read them.
+/// </remarks>
+public sealed record DeadCodeSymbolRow(
+    string SymbolId,
+    string Name,
+    string Kind,
+    string Language,
+    string Path,
+    int StartLine,
+    long StartByte,
+    long EndByte,
+    string? Visibility,
+    bool IsTestSelfOrAncestor,
+    string? ParentSymbolId,
+    bool HasAnnotation,
+    bool HasStructuralFactSelfOrAncestor,
+    int NameMatchesOutside,
+    int ResolvedInbound,
+    int PendingResolvedInbound,
+    int CallsInbound,
+    bool? LiteralMatch);
+
+/// <summary>
+/// Per-language identifier / resolution counts for the artifact, computed by the reader at query time (never
+/// hardcoded). Feeds the <c>low_evidence_language</c> suppression and the per-language evidence-label threshold.
+/// </summary>
+public sealed record LanguageCoverageRow(
+    string Language,
+    int IdentifierCount,
+    int ResolvedCount);

--- a/src/Miller.Core/DeadCode/DeadCodeRows.cs
+++ b/src/Miller.Core/DeadCode/DeadCodeRows.cs
@@ -7,7 +7,9 @@ namespace Miller.Core.DeadCode;
 /// <remarks>
 /// The closure booleans (<see cref="IsTestSelfOrAncestor"/>, <see cref="HasStructuralFactSelfOrAncestor"/>) are
 /// computed by the reader's <c>parent_symbol_id</c> walk; Core TRUSTS them as given rather than re-walking parents.
-/// <see cref="HasAnnotation"/> is SELF-only. <see cref="LiteralMatch"/> drives the two-phase literal scan:
+/// <see cref="HasAnnotation"/> is SELF-only. <see cref="IsOverrideMember"/> is computed by the reader from
+/// <c>symbols.signature</c> via <see cref="DeadCodeCandidates.IsOverrideSignature"/> (Core owns the policy, the
+/// reader owns the julie column). <see cref="LiteralMatch"/> drives the two-phase literal scan:
 /// <c>null</c> = not yet scanned (provisional candidate), <c>true</c> = the name was found in a string literal
 /// (suppressed), <c>false</c> = scanned with no match (candidate). <see cref="StartByte"/> / <see cref="EndByte"/>
 /// are carried faithfully for downstream consumers even though the evaluator itself does not read them.
@@ -26,6 +28,7 @@ public sealed record DeadCodeSymbolRow(
     string? ParentSymbolId,
     bool HasAnnotation,
     bool HasStructuralFactSelfOrAncestor,
+    bool IsOverrideMember,
     int NameMatchesOutside,
     int ResolvedInbound,
     int PendingResolvedInbound,

--- a/src/Miller.Indexing/ComplexityRankingReader.cs
+++ b/src/Miller.Indexing/ComplexityRankingReader.cs
@@ -63,33 +63,86 @@ public static class ComplexityRankingReader
         var results = new List<ComplexityHotspot>();
         using SqliteDataReader reader = command.ExecuteReader();
         while (reader.Read())
+            results.Add(MapRow(reader));
+
+        return results;
+    }
+
+    /// <summary>
+    /// Reads every complexity row on the given workspace-relative paths, with no severity floor
+    /// and no limit. Used by risk ranking to join complexity against churn BEFORE limiting;
+    /// callers bound the path set (e.g. by the paths a git range touched), not the row count.
+    /// </summary>
+    public static IReadOnlyList<ComplexityHotspot> ReadForPaths(
+        string symbolsDbPath,
+        IReadOnlyCollection<string> paths,
+        bool includeTests = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbolsDbPath);
+        ArgumentNullException.ThrowIfNull(paths);
+        if (paths.Count == 0)
+            return [];
+
+        using SqliteConnection connection = SqliteReadOnlyAccess.Open(symbolsDbPath);
+        JulieSchemaGate.Verify(connection);
+
+        var results = new List<ComplexityHotspot>();
+        // Stay far below SQLite's parameter ceiling; churn path sets are small but unbounded ranges exist.
+        foreach (string[] chunk in paths.Distinct(StringComparer.Ordinal).Chunk(500))
         {
-            int decisionCount = reader.GetInt32(8);
-            int nesting = reader.GetInt32(10);
-            results.Add(new ComplexityHotspot(
-                Severity: Classify(decisionCount, nesting),
-                ComplexityMetricId: reader.GetString(0),
-                Path: reader.GetString(1),
-                Language: reader.GetString(2),
-                Scope: reader.GetString(3),
-                SymbolId: reader.IsDBNull(4) ? null : reader.GetString(4),
-                AlgorithmId: reader.GetString(5),
-                CoveredLines: reader.GetInt32(6),
-                CoveredBytes: reader.GetInt32(7),
-                DecisionCount: decisionCount,
-                LoopCount: reader.GetInt32(9),
-                MaxNestingDepth: nesting,
-                ParameterCount: reader.IsDBNull(11) ? null : reader.GetInt32(11),
-                StartLine: reader.GetInt32(12),
-                EndLine: reader.GetInt32(13),
-                StartByte: reader.GetInt32(14),
-                EndByte: reader.GetInt32(15),
-                SymbolName: reader.IsDBNull(16) ? null : reader.GetString(16),
-                SymbolKind: reader.IsDBNull(17) ? null : reader.GetString(17),
-                IsTest: reader.GetInt64(18) != 0));
+            using SqliteCommand command = connection.CreateCommand();
+            string[] parameterNames = new string[chunk.Length];
+            for (var i = 0; i < chunk.Length; i++)
+            {
+                parameterNames[i] = "$p" + i;
+                command.Parameters.AddWithValue(parameterNames[i], chunk[i]);
+            }
+            command.CommandText = $"""
+                SELECT cm.complexity_metric_id, cm.path, cm.language, cm.scope, cm.symbol_id, cm.algorithm_id,
+                       cm.covered_lines, cm.covered_bytes, cm.decision_count, cm.loop_count, cm.max_nesting_depth,
+                       cm.parameter_count, cm.start_line, cm.end_line, cm.start_byte, cm.end_byte,
+                       s.name, s.kind, COALESCE(s.is_test, 0) AS is_test
+                FROM complexity_metrics cm
+                LEFT JOIN symbols s ON s.symbol_id = cm.symbol_id
+                WHERE ($include_tests = 1 OR COALESCE(s.is_test, 0) = 0)
+                  AND cm.path IN ({string.Join(", ", parameterNames)})
+                ORDER BY cm.path, cm.start_line, cm.complexity_metric_id;
+                """;
+            command.Parameters.AddWithValue("$include_tests", includeTests ? 1 : 0);
+
+            using SqliteDataReader reader = command.ExecuteReader();
+            while (reader.Read())
+                results.Add(MapRow(reader));
         }
 
         return results;
+    }
+
+    private static ComplexityHotspot MapRow(SqliteDataReader reader)
+    {
+        int decisionCount = reader.GetInt32(8);
+        int nesting = reader.GetInt32(10);
+        return new ComplexityHotspot(
+            Severity: Classify(decisionCount, nesting),
+            ComplexityMetricId: reader.GetString(0),
+            Path: reader.GetString(1),
+            Language: reader.GetString(2),
+            Scope: reader.GetString(3),
+            SymbolId: reader.IsDBNull(4) ? null : reader.GetString(4),
+            AlgorithmId: reader.GetString(5),
+            CoveredLines: reader.GetInt32(6),
+            CoveredBytes: reader.GetInt32(7),
+            DecisionCount: decisionCount,
+            LoopCount: reader.GetInt32(9),
+            MaxNestingDepth: nesting,
+            ParameterCount: reader.IsDBNull(11) ? null : reader.GetInt32(11),
+            StartLine: reader.GetInt32(12),
+            EndLine: reader.GetInt32(13),
+            StartByte: reader.GetInt32(14),
+            EndByte: reader.GetInt32(15),
+            SymbolName: reader.IsDBNull(16) ? null : reader.GetString(16),
+            SymbolKind: reader.IsDBNull(17) ? null : reader.GetString(17),
+            IsTest: reader.GetInt64(18) != 0);
     }
 
     public static bool TryParseSeverity(string? value, out ComplexitySeverity severity)

--- a/src/Miller.Indexing/DeadCodeCandidateReader.cs
+++ b/src/Miller.Indexing/DeadCodeCandidateReader.cs
@@ -1,0 +1,472 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+using Miller.Core.DeadCode;
+
+namespace Miller.Indexing;
+
+/// <summary>Literal-scan accounting for the two-phase dead-code pass: how many literal-bearing files were read
+/// under the freshness guard, and how many were skipped because their on-disk bytes no longer match the artifact.</summary>
+public sealed record DeadCodeLiteralScan(int FilesScanned, int FilesSkippedStale);
+
+/// <summary>Artifact-identity block for a dead-code report: the artifact id, the max extraction revision, and the
+/// reference-resolution status/version metadata (status falls back to <c>"unknown"</c> and version to <c>null</c>
+/// when the artifact predates the v4 keys).</summary>
+public sealed record DeadCodeArtifact(
+    string? ArtifactId,
+    long? Revision,
+    string ReferenceResolutionStatus,
+    string? ReferenceResolutionVersion);
+
+/// <summary>The final dead-code report the CLI renders: the evaluated <see cref="DeadCodeResult"/> (two-phase
+/// literal scan already applied), the per-language coverage rows, the literal-scan accounting, and the artifact
+/// block. Produced by <see cref="DeadCodeCandidateReader.Read"/> — the reader owns all query-time computation.</summary>
+public sealed record DeadCodeCandidateReport(
+    DeadCodeResult Result,
+    IReadOnlyList<LanguageCoverageRow> LanguageCoverage,
+    DeadCodeLiteralScan LiteralScan,
+    DeadCodeArtifact Artifact);
+
+/// <summary>
+/// Reads a julie-extract v4 artifact and produces the FINAL <see cref="DeadCodeCandidateReport"/> for
+/// <c>miller references candidates</c>. The reader owns everything I/O-shaped: the schema gate, the required-table
+/// validation, the ancestor-closure walks, the four inbound-evidence counts, the per-language coverage universe,
+/// and the two-phase literal scan. <see cref="DeadCodeCandidates"/> (Miller.Core) owns the pure decision logic.
+/// </summary>
+public static class DeadCodeCandidateReader
+{
+    // JulieSchemaGate only gates metadata VALUES, not table presence. A v4-stamped artifact missing the resolution
+    // overlay would otherwise throw a raw SqliteException (CLI exit 1); these three tables are hard requirements
+    // for the analysis, so their absence is an incompatible-extract condition (CLI exit 3).
+    private static readonly string[] RequiredResolutionTables =
+        ["identifier_resolutions", "pending_resolutions", "pending_relationships"];
+
+    /// <summary>
+    /// Open <paramref name="symbolsDbPath"/> read-only, gate + validate it, gather the candidate rows and coverage,
+    /// evaluate, run the literal scan over the survivors (re-reading source under <paramref name="workspaceRoot"/>
+    /// with a blake3 freshness guard), and return the finished report.
+    /// </summary>
+    public static DeadCodeCandidateReport Read(string symbolsDbPath, string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbolsDbPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+
+        using SqliteConnection connection = SqliteReadOnlyAccess.Open(symbolsDbPath);
+        JulieSchemaGate.Verify(connection);
+        RequireResolutionTables(connection);
+
+        // Closure inputs over ALL symbols (small): the parent map + the is_test / structural-fact / annotation sets.
+        var parent = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var isTest = new HashSet<string>(StringComparer.Ordinal);
+        LoadSymbolClosureInputs(connection, parent, isTest);
+
+        var structuralFactSymbols = LoadDistinctIds(connection,
+            "SELECT DISTINCT containing_symbol_id FROM structural_facts WHERE containing_symbol_id IS NOT NULL;");
+        var annotatedSymbols = LoadDistinctIds(connection, "SELECT DISTINCT symbol_id FROM symbol_annotations;");
+
+        var rows = LoadCandidateRows(connection, parent, isTest, structuralFactSymbols, annotatedSymbols);
+        var coverage = LoadCoverage(connection);
+
+        var result = DeadCodeCandidates.Evaluate(rows, coverage);
+        var (finalResult, literalScan) = RunLiteralScan(connection, workspaceRoot, result);
+        var artifact = ReadArtifact(connection);
+
+        return new DeadCodeCandidateReport(finalResult, coverage, literalScan, artifact);
+    }
+
+    // ---- required-table validation ---------------------------------------------------------------------------
+
+    private static void RequireResolutionTables(SqliteConnection connection)
+    {
+        foreach (var table in RequiredResolutionTables)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=$n LIMIT 1;";
+            cmd.Parameters.AddWithValue("$n", table);
+            if (cmd.ExecuteScalar() is null)
+                throw new IncompatibleExtractException(
+                    $"DB has no '{table}' table; it is not a schema-{MillerExtractContract.ExpectedSchemaVersion} " +
+                    $"julie-extract artifact with workspace reference resolution. Re-run restore + `scan` with the " +
+                    $"pinned julie-extract (v{MillerExtractContract.PinnedJulieExtractVersion}).");
+        }
+    }
+
+    // ---- closure inputs --------------------------------------------------------------------------------------
+
+    private static void LoadSymbolClosureInputs(
+        SqliteConnection connection, Dictionary<string, string?> parent, HashSet<string> isTest)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT symbol_id, parent_symbol_id, is_test FROM symbols;";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            string id = reader.GetString(0);
+            parent[id] = reader.IsDBNull(1) ? null : reader.GetString(1);
+            if (!reader.IsDBNull(2) && reader.GetInt64(2) != 0)
+                isTest.Add(id);
+        }
+    }
+
+    private static HashSet<string> LoadDistinctIds(SqliteConnection connection, string sql)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            if (!reader.IsDBNull(0))
+                set.Add(reader.GetString(0));
+        return set;
+    }
+
+    /// <summary>Walk self → parent → … testing membership in <paramref name="set"/>; cycle-safe via a visited set.</summary>
+    private static bool SelfOrAncestorInSet(
+        string id, IReadOnlyDictionary<string, string?> parent, IReadOnlySet<string> set)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        string? current = id;
+        while (current is not null && seen.Add(current))
+        {
+            if (set.Contains(current))
+                return true;
+            if (!parent.TryGetValue(current, out current))
+                break;
+        }
+
+        return false;
+    }
+
+    // ---- candidate rows --------------------------------------------------------------------------------------
+
+    private readonly record struct CandidateTuple(
+        string SymbolId, string FileId, string Path, string Language, string Name, string Kind,
+        string? Visibility, int StartLine, long? StartByte, long? EndByte);
+
+    private static List<DeadCodeSymbolRow> LoadCandidateRows(
+        SqliteConnection connection,
+        IReadOnlyDictionary<string, string?> parent,
+        IReadOnlySet<string> isTest,
+        IReadOnlySet<string> structuralFactSymbols,
+        IReadOnlySet<string> annotatedSymbols)
+    {
+        // Read every candidate-kind symbol into memory FIRST (closing the reader) so the per-symbol count
+        // subqueries below can run on the same connection without a live reader open.
+        var tuples = LoadCandidateTuples(connection);
+
+        // Four reusable, parameterized count commands — per-symbol INDEXED subqueries (never materialize all
+        // identifiers). The inside-S test treats a NULL span / NULL containing symbol as "not inside" (COALESCE→0).
+        using var nameCmd = CreateCountCommand(connection, """
+            SELECT COUNT(*) FROM identifiers i
+            WHERE i.name = $name
+              AND COALESCE(i.containing_symbol_id = $sid, 0) = 0
+              AND COALESCE((i.file_id = $fid AND i.start_byte >= $sb AND i.end_byte <= $eb), 0) = 0;
+            """, includeName: true);
+        using var resolvedCmd = CreateCountCommand(connection, """
+            SELECT COUNT(*) FROM identifier_resolutions ir
+            JOIN identifiers i ON i.identifier_id = ir.identifier_id
+            WHERE ir.target_symbol_id = $sid
+              AND COALESCE(i.containing_symbol_id = $sid, 0) = 0
+              AND COALESCE((i.file_id = $fid AND i.start_byte >= $sb AND i.end_byte <= $eb), 0) = 0;
+            """, includeName: false);
+        using var pendingCmd = CreateCountCommand(connection, """
+            SELECT COUNT(*) FROM pending_resolutions pr
+            JOIN pending_relationships p ON p.pending_relationship_id = pr.pending_relationship_id
+            WHERE pr.target_symbol_id = $sid
+              AND COALESCE(p.caller_scope_symbol_id = $sid, 0) = 0
+              AND COALESCE((p.file_id = $fid AND p.start_byte >= $sb AND p.end_byte <= $eb), 0) = 0;
+            """, includeName: false);
+        using var callsCmd = CreateCountCommand(connection, """
+            SELECT COUNT(*) FROM relationships r
+            WHERE r.to_symbol_id = $sid AND r.from_symbol_id <> $sid;
+            """, includeName: false);
+
+        var rows = new List<DeadCodeSymbolRow>(tuples.Count);
+        foreach (var t in tuples)
+        {
+            object sb = (object?)t.StartByte ?? DBNull.Value;
+            object eb = (object?)t.EndByte ?? DBNull.Value;
+
+            BindCountParams(nameCmd, t.SymbolId, t.FileId, sb, eb, t.Name);
+            BindCountParams(resolvedCmd, t.SymbolId, t.FileId, sb, eb, null);
+            BindCountParams(pendingCmd, t.SymbolId, t.FileId, sb, eb, null);
+            BindCountParams(callsCmd, t.SymbolId, t.FileId, sb, eb, null);
+
+            parent.TryGetValue(t.SymbolId, out string? parentSymbolId);
+
+            rows.Add(new DeadCodeSymbolRow(
+                SymbolId: t.SymbolId,
+                Name: t.Name,
+                Kind: t.Kind,
+                Language: t.Language,
+                Path: t.Path,
+                StartLine: t.StartLine,
+                StartByte: t.StartByte ?? 0L,
+                EndByte: t.EndByte ?? 0L,
+                Visibility: t.Visibility,
+                IsTestSelfOrAncestor: SelfOrAncestorInSet(t.SymbolId, parent, isTest),
+                ParentSymbolId: parentSymbolId,
+                HasAnnotation: annotatedSymbols.Contains(t.SymbolId),
+                HasStructuralFactSelfOrAncestor: SelfOrAncestorInSet(t.SymbolId, parent, structuralFactSymbols),
+                NameMatchesOutside: ExecCount(nameCmd),
+                ResolvedInbound: ExecCount(resolvedCmd),
+                PendingResolvedInbound: ExecCount(pendingCmd),
+                CallsInbound: ExecCount(callsCmd),
+                LiteralMatch: null));
+        }
+
+        return rows;
+    }
+
+    private static List<CandidateTuple> LoadCandidateTuples(SqliteConnection connection)
+    {
+        var kinds = DeadCodeCandidates.CandidateKinds.ToArray();
+        var placeholders = new string[kinds.Length];
+
+        using var cmd = connection.CreateCommand();
+        for (int i = 0; i < kinds.Length; i++)
+        {
+            placeholders[i] = "$k" + i.ToString(CultureInfo.InvariantCulture);
+            cmd.Parameters.AddWithValue(placeholders[i], kinds[i]);
+        }
+
+        cmd.CommandText = $"""
+            SELECT symbol_id, file_id, path, language, name, kind, visibility, start_line, start_byte, end_byte
+            FROM symbols
+            WHERE kind IN ({string.Join(", ", placeholders)})
+            ORDER BY path, start_line, symbol_id;
+            """;
+
+        var tuples = new List<CandidateTuple>();
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            tuples.Add(new CandidateTuple(
+                SymbolId: reader.GetString(0),
+                FileId: reader.GetString(1),
+                Path: reader.GetString(2),
+                Language: reader.GetString(3),
+                Name: reader.GetString(4),
+                Kind: reader.GetString(5),
+                Visibility: reader.IsDBNull(6) ? null : reader.GetString(6),
+                StartLine: reader.IsDBNull(7) ? 0 : (int)reader.GetInt64(7),
+                StartByte: reader.IsDBNull(8) ? null : reader.GetInt64(8),
+                EndByte: reader.IsDBNull(9) ? null : reader.GetInt64(9)));
+        }
+
+        return tuples;
+    }
+
+    private static SqliteCommand CreateCountCommand(SqliteConnection connection, string sql, bool includeName)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.Add("$sid", SqliteType.Text);
+        cmd.Parameters.Add("$fid", SqliteType.Text);
+        cmd.Parameters.Add("$sb", SqliteType.Integer);
+        cmd.Parameters.Add("$eb", SqliteType.Integer);
+        if (includeName)
+            cmd.Parameters.Add("$name", SqliteType.Text);
+        return cmd;
+    }
+
+    private static void BindCountParams(
+        SqliteCommand cmd, string symbolId, string fileId, object startByte, object endByte, string? name)
+    {
+        cmd.Parameters["$sid"].Value = symbolId;
+        cmd.Parameters["$fid"].Value = fileId;
+        cmd.Parameters["$sb"].Value = startByte;
+        cmd.Parameters["$eb"].Value = endByte;
+        if (name is not null)
+            cmd.Parameters["$name"].Value = name;
+    }
+
+    private static int ExecCount(SqliteCommand cmd) =>
+        Convert.ToInt32(cmd.ExecuteScalar() ?? 0L, CultureInfo.InvariantCulture);
+
+    // ---- coverage universe -----------------------------------------------------------------------------------
+
+    private static List<LanguageCoverageRow> LoadCoverage(SqliteConnection connection)
+    {
+        // Universe = UNION of languages in symbols AND files (NOT the identifiers table alone) — a language with
+        // symbols but zero identifiers (css/html) MUST appear so Core's low_evidence_language rule can fire.
+        var languages = new SortedSet<string>(StringComparer.Ordinal);
+        AddLanguages(connection, "SELECT DISTINCT language FROM symbols;", languages);
+        AddLanguages(connection, "SELECT DISTINCT language FROM files;", languages);
+
+        var identifierCounts = LoadCountsByLanguage(connection,
+            "SELECT language, COUNT(*) FROM identifiers GROUP BY language;");
+        var resolvedCounts = LoadCountsByLanguage(connection, """
+            SELECT i.language, COUNT(*)
+            FROM identifier_resolutions ir
+            JOIN identifiers i ON i.identifier_id = ir.identifier_id
+            WHERE ir.outcome = 'resolved'
+            GROUP BY i.language;
+            """);
+
+        var rows = new List<LanguageCoverageRow>(languages.Count);
+        foreach (var language in languages)
+            rows.Add(new LanguageCoverageRow(
+                language,
+                identifierCounts.GetValueOrDefault(language),
+                resolvedCounts.GetValueOrDefault(language)));
+
+        return rows;
+    }
+
+    private static void AddLanguages(SqliteConnection connection, string sql, SortedSet<string> languages)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            if (!reader.IsDBNull(0))
+                languages.Add(reader.GetString(0));
+    }
+
+    private static Dictionary<string, int> LoadCountsByLanguage(SqliteConnection connection, string sql)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            if (!reader.IsDBNull(0))
+                counts[reader.GetString(0)] = (int)reader.GetInt64(1);
+        return counts;
+    }
+
+    // ---- literal scan (phase 2) ------------------------------------------------------------------------------
+
+    private readonly record struct LiteralRegion(
+        string Path, int StartByte, int EndByte, string ContentHash, long ContentBytes);
+
+    private static (DeadCodeResult Result, DeadCodeLiteralScan Scan) RunLiteralScan(
+        SqliteConnection connection, string workspaceRoot, DeadCodeResult result)
+    {
+        // Only runs when provisional candidates survive; skip the disk reads entirely otherwise.
+        if (result.NeedsLiteralScan.Count == 0)
+            return (result, new DeadCodeLiteralScan(0, 0));
+
+        var nameToSymbolIds = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var row in result.NeedsLiteralScan)
+        {
+            if (!nameToSymbolIds.TryGetValue(row.Name, out var ids))
+                nameToSymbolIds[row.Name] = ids = [];
+            ids.Add(row.SymbolId);
+        }
+
+        var regions = ReadStringLiteralRegions(connection);
+        var matched = new HashSet<string>(StringComparer.Ordinal);
+        int filesScanned = 0;
+        int filesSkippedStale = 0;
+        var fileText = new Dictionary<string, string?>(StringComparer.Ordinal); // path → verified text (once/file)
+
+        foreach (var region in regions)
+        {
+            if (!fileText.TryGetValue(region.Path, out string? text))
+            {
+                text = ReadVerifiedFileText(workspaceRoot, region);
+                fileText[region.Path] = text;
+                if (text is null)
+                    filesSkippedStale++;
+                else
+                    filesScanned++;
+            }
+
+            if (text is null)
+                continue;
+
+            string? literal = SourceTextDecoder.SliceUtf8ByteSpan(text, region.StartByte, region.EndByte);
+            if (literal is null)
+                continue;
+
+            foreach (var (name, ids) in nameToSymbolIds)
+                if (literal.Contains(name, StringComparison.Ordinal))
+                    foreach (var id in ids)
+                        matched.Add(id);
+        }
+
+        return (DeadCodeCandidates.ApplyLiteralScan(result, matched),
+            new DeadCodeLiteralScan(filesScanned, filesSkippedStale));
+    }
+
+    private static List<LiteralRegion> ReadStringLiteralRegions(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        // ORDER BY path so every literal-bearing file's regions are contiguous (read once, per the fileText cache).
+        cmd.CommandText = """
+            SELECT sr.path, sr.start_byte, sr.end_byte, f.content_hash, f.content_bytes
+            FROM source_regions sr
+            JOIN files f ON f.file_id = sr.file_id
+            WHERE sr.kind = 'string_literal'
+            ORDER BY sr.path, sr.start_byte, sr.source_region_id;
+            """;
+
+        var regions = new List<LiteralRegion>();
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            regions.Add(new LiteralRegion(
+                Path: reader.GetString(0),
+                StartByte: (int)reader.GetInt64(1),
+                EndByte: (int)reader.GetInt64(2),
+                ContentHash: reader.GetString(3),
+                ContentBytes: reader.GetInt64(4)));
+        }
+
+        return regions;
+    }
+
+    /// <summary>
+    /// The freshness-guarded source re-read mirrored from <c>SearchIndexWriter.ReadVerifiedFileText</c>: resolve
+    /// under the workspace root, require the on-disk byte length AND blake3 to match the artifact's stored facts,
+    /// then decode. Returns null (⇒ STALE / missing) on any mismatch — a stale file never suppresses a candidate.
+    /// </summary>
+    private static string? ReadVerifiedFileText(string workspaceRoot, LiteralRegion region)
+    {
+        try
+        {
+            string? abs = WorkspaceRelativePath.ResolveUnderRoot(workspaceRoot, region.Path);
+            if (abs is null || !File.Exists(abs))
+                return null;
+
+            byte[] bytes = File.ReadAllBytes(abs);
+            if (bytes.LongLength != region.ContentBytes)
+                return null;
+            if (!StringComparer.OrdinalIgnoreCase.Equals(
+                    ContentHasher.Blake3Hex(bytes), ContentHasher.NormalizeHash(region.ContentHash)))
+                return null;
+
+            return SourceTextDecoder.TryDecode(bytes, out string text) ? text : null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    // ---- artifact block --------------------------------------------------------------------------------------
+
+    private static DeadCodeArtifact ReadArtifact(SqliteConnection connection) => new(
+        ArtifactId: ReadMetadataValue(connection, "artifact_id"),
+        Revision: ReadMaxRevision(connection),
+        ReferenceResolutionStatus: ReadMetadataValue(connection, "reference_resolution_status") ?? "unknown",
+        ReferenceResolutionVersion: ReadMetadataValue(connection, "reference_resolution_version"));
+
+    private static string? ReadMetadataValue(SqliteConnection connection, string key)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT value FROM artifact_metadata WHERE key = $key LIMIT 1;";
+        cmd.Parameters.AddWithValue("$key", key);
+        object? value = cmd.ExecuteScalar();
+        return value is string text ? text : null;
+    }
+
+    private static long? ReadMaxRevision(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT MAX(revision_id) FROM extraction_revisions;";
+        object? value = cmd.ExecuteScalar();
+        return value is null or DBNull ? null : Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Miller.Indexing/DeadCodeCandidateReader.cs
+++ b/src/Miller.Indexing/DeadCodeCandidateReader.cs
@@ -140,7 +140,7 @@ public static class DeadCodeCandidateReader
 
     private readonly record struct CandidateTuple(
         string SymbolId, string FileId, string Path, string Language, string Name, string Kind,
-        string? Visibility, int StartLine, long? StartByte, long? EndByte);
+        string? Visibility, int StartLine, long? StartByte, long? EndByte, string? Signature);
 
     private static List<DeadCodeSymbolRow> LoadCandidateRows(
         SqliteConnection connection,
@@ -207,6 +207,7 @@ public static class DeadCodeCandidateReader
                 ParentSymbolId: parentSymbolId,
                 HasAnnotation: annotatedSymbols.Contains(t.SymbolId),
                 HasStructuralFactSelfOrAncestor: SelfOrAncestorInSet(t.SymbolId, parent, structuralFactSymbols),
+                IsOverrideMember: DeadCodeCandidates.IsOverrideSignature(t.Signature),
                 NameMatchesOutside: ExecCount(nameCmd),
                 ResolvedInbound: ExecCount(resolvedCmd),
                 PendingResolvedInbound: ExecCount(pendingCmd),
@@ -230,7 +231,8 @@ public static class DeadCodeCandidateReader
         }
 
         cmd.CommandText = $"""
-            SELECT symbol_id, file_id, path, language, name, kind, visibility, start_line, start_byte, end_byte
+            SELECT symbol_id, file_id, path, language, name, kind, visibility, start_line, start_byte, end_byte,
+                   signature
             FROM symbols
             WHERE kind IN ({string.Join(", ", placeholders)})
             ORDER BY path, start_line, symbol_id;
@@ -250,7 +252,8 @@ public static class DeadCodeCandidateReader
                 Visibility: reader.IsDBNull(6) ? null : reader.GetString(6),
                 StartLine: reader.IsDBNull(7) ? 0 : (int)reader.GetInt64(7),
                 StartByte: reader.IsDBNull(8) ? null : reader.GetInt64(8),
-                EndByte: reader.IsDBNull(9) ? null : reader.GetInt64(9)));
+                EndByte: reader.IsDBNull(9) ? null : reader.GetInt64(9),
+                Signature: reader.IsDBNull(10) ? null : reader.GetString(10)));
         }
 
         return tuples;

--- a/src/Miller.Indexing/DeadCodeCandidateReader.cs
+++ b/src/Miller.Indexing/DeadCodeCandidateReader.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using Miller.Core.DeadCode;
 
@@ -362,26 +363,34 @@ public static class DeadCodeCandidateReader
         var matched = new HashSet<string>(StringComparer.Ordinal);
         int filesScanned = 0;
         int filesSkippedStale = 0;
-        var fileText = new Dictionary<string, string?>(StringComparer.Ordinal); // path → verified text (once/file)
+        // path → verified raw bytes (read + hashed ONCE per file). Regions slice these bytes directly: the
+        // artifact's span offsets are byte offsets into exactly the bytes the hash covered, so slicing raw bytes
+        // avoids the per-region full-file UTF-8 re-encode the old text-based slice paid (regions × file-size CPU;
+        // adversarial-review finding on PR #5).
+        var fileBytes = new Dictionary<string, byte[]?>(StringComparer.Ordinal);
 
         foreach (var region in regions)
         {
-            if (!fileText.TryGetValue(region.Path, out string? text))
+            if (!fileBytes.TryGetValue(region.Path, out byte[]? bytes))
             {
-                text = ReadVerifiedFileText(workspaceRoot, region);
-                fileText[region.Path] = text;
-                if (text is null)
+                bytes = ReadVerifiedFileBytes(workspaceRoot, region);
+                fileBytes[region.Path] = bytes;
+                if (bytes is null)
                     filesSkippedStale++;
                 else
                     filesScanned++;
             }
 
-            if (text is null)
+            if (bytes is null)
                 continue;
 
-            string? literal = SourceTextDecoder.SliceUtf8ByteSpan(text, region.StartByte, region.EndByte);
-            if (literal is null)
+            if (region.StartByte < 0 || region.EndByte <= region.StartByte || region.StartByte >= bytes.Length)
                 continue;
+
+            int end = Math.Min(region.EndByte, bytes.Length);
+            // Invalid UTF-8 inside the slice decodes to U+FFFD, which can never match a candidate name — same
+            // conservative outcome as the old skip-undecodable-file behavior, scoped per region.
+            string literal = Encoding.UTF8.GetString(bytes, region.StartByte, end - region.StartByte);
 
             foreach (var (name, ids) in nameToSymbolIds)
                 if (literal.Contains(name, StringComparison.Ordinal))
@@ -422,10 +431,11 @@ public static class DeadCodeCandidateReader
 
     /// <summary>
     /// The freshness-guarded source re-read mirrored from <c>SearchIndexWriter.ReadVerifiedFileText</c>: resolve
-    /// under the workspace root, require the on-disk byte length AND blake3 to match the artifact's stored facts,
-    /// then decode. Returns null (⇒ STALE / missing) on any mismatch — a stale file never suppresses a candidate.
+    /// under the workspace root, require the on-disk byte length AND blake3 to match the artifact's stored facts.
+    /// Returns the RAW verified bytes (the artifact's span offsets index these bytes exactly); null (⇒ STALE /
+    /// missing) on any mismatch — a stale file never suppresses a candidate.
     /// </summary>
-    private static string? ReadVerifiedFileText(string workspaceRoot, LiteralRegion region)
+    private static byte[]? ReadVerifiedFileBytes(string workspaceRoot, LiteralRegion region)
     {
         try
         {
@@ -440,7 +450,7 @@ public static class DeadCodeCandidateReader
                     ContentHasher.Blake3Hex(bytes), ContentHasher.NormalizeHash(region.ContentHash)))
                 return null;
 
-            return SourceTextDecoder.TryDecode(bytes, out string text) ? text : null;
+            return bytes;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
         {

--- a/src/Miller.Indexing/MillerExtractContract.cs
+++ b/src/Miller.Indexing/MillerExtractContract.cs
@@ -22,6 +22,6 @@ internal static class MillerExtractContract
     public const string ExpectedHashAlgorithm = "blake3";
 
     // Download pin only (restore-script + julie-pins.json target). This is the PRODUCT version,
-    // orthogonal to the runtime schema/contract gate above (D7): product 2.9.x ships schema 4 / contract 3.
-    public const string PinnedJulieExtractVersion = "2.9.0"; // julie-extractors release tag v2.9.0 (published 2026-07-07).
+    // orthogonal to the runtime schema/contract gate above (D7): product 2.9.x/2.10.x ships schema 4 / contract 3.
+    public const string PinnedJulieExtractVersion = "2.10.0"; // julie-extractors v2.10.0 (variable_ref emission; release pending — pins sha256s still v2.9.0 until assets publish).
 }

--- a/src/Miller.Indexing/MillerExtractContract.cs
+++ b/src/Miller.Indexing/MillerExtractContract.cs
@@ -10,16 +10,18 @@ namespace Miller.Indexing;
 /// </summary>
 internal static class MillerExtractContract
 {
-    // julie-extract v3: sqlite_schema_version 3 / extract_contract_version 3 / report_schema_version 3.
-    // v3 adds parser-backed structural_facts and complexity_metrics, while keeping symbol body_hash as the
-    // clone-ready normalized body fingerprint.
-    public const long ExpectedSchemaVersion = 3;
-    public const long ExpectedSqliteSchemaVersion = 3;
+    // julie-extract schema v4 (product 2.9.0): sqlite_schema_version 4 / extract_contract_version 3 /
+    // report_schema_version 3. v4 adds workspace reference resolution: pending_resolutions and
+    // identifier_resolutions overlay tables, an FK-consistent identifiers.target_symbol_id, and the
+    // artifact_metadata key reference_resolution_version (currently 1). The extract contract and report
+    // schema are unchanged from v3.
+    public const long ExpectedSchemaVersion = 4;
+    public const long ExpectedSqliteSchemaVersion = 4;
     public const long ExpectedExtractContractVersion = 3;
     public const long ExpectedReportSchemaVersion = 3;
     public const string ExpectedHashAlgorithm = "blake3";
 
     // Download pin only (restore-script + julie-pins.json target). This is the PRODUCT version,
-    // orthogonal to the runtime schema/contract gate above (D7): product 2.5.x ships schema/contract 3.
-    public const string PinnedJulieExtractVersion = "2.8.1"; // julie-extractors release tag v2.8.1 (published 2026-07-04).
+    // orthogonal to the runtime schema/contract gate above (D7): product 2.9.x ships schema 4 / contract 3.
+    public const string PinnedJulieExtractVersion = "2.9.0"; // julie-extractors release tag v2.9.0 (published 2026-07-07).
 }

--- a/src/Miller.Indexing/WorkspaceIndexFactsReader.cs
+++ b/src/Miller.Indexing/WorkspaceIndexFactsReader.cs
@@ -20,6 +20,23 @@ public static class WorkspaceIndexFactsReader
         return new WorkspaceIndexFacts(documentCount, knownExtensionsCount);
     }
 
+    /// <summary>Bounded scalar counts for report/status surfaces; does not hydrate symbols.</summary>
+    public static WorkspaceSymbolCounts ReadSymbolCounts(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+        using SqliteConnection connection = SqliteReadOnlyAccess.Open(dbPath);
+        JulieSchemaGate.Verify(connection);
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT language)
+            FROM symbols WHERE name IS NOT NULL;
+            """;
+        using SqliteDataReader reader = command.ExecuteReader();
+        reader.Read();
+        return new WorkspaceSymbolCounts(reader.GetInt64(0), reader.GetInt64(1), reader.GetInt64(2));
+    }
+
     private static long ReadDocumentCount(SqliteConnection connection)
     {
         using SqliteCommand command = connection.CreateCommand();
@@ -58,3 +75,5 @@ public static class WorkspaceIndexFactsReader
 }
 
 public sealed record WorkspaceIndexFacts(long DocumentCount, int KnownExtensionsCount);
+
+public sealed record WorkspaceSymbolCounts(long Symbols, long Files, long Languages);

--- a/src/Miller.Server/Cli/CliCapabilities.cs
+++ b/src/Miller.Server/Cli/CliCapabilities.cs
@@ -61,6 +61,7 @@ internal static class CliCapabilities
         "metrics clones --json",
         "metrics complexity --json",
         "metrics risk --json",
+        "report --json",
         "telemetry export --jsonl",
         "symbols export --jsonl",
         "references export --jsonl",
@@ -95,6 +96,7 @@ internal static class CliCapabilities
         ("trace", "trace --json", 1, "docs/contracts/trace-json-v1.md"),
         ("patterns", "patterns --json", 1, "docs/contracts/patterns-json-v1.md"),
         ("metrics", "metrics <churn|clones|complexity|risk> --json", 1, "docs/contracts/metrics-json-v1.md"),
+        ("report", "report --json", 1, "docs/contracts/report-json-v1.md"),
         ("impact_index_revision_delta", "impact --json --from-index-revision N --from-artifact-id ID", 1,
             "docs/contracts/impact-index-revision-delta-v1.md"),
     ];

--- a/src/Miller.Server/Cli/CliCapabilities.cs
+++ b/src/Miller.Server/Cli/CliCapabilities.cs
@@ -65,6 +65,7 @@ internal static class CliCapabilities
         "telemetry export --jsonl",
         "symbols export --jsonl",
         "references export --jsonl",
+        "references candidates --json",
         "complexity export --jsonl",
         "workspace status --json",
         "workspace health --json",
@@ -99,6 +100,7 @@ internal static class CliCapabilities
         ("report", "report --json", 1, "docs/contracts/report-json-v1.md"),
         ("impact_index_revision_delta", "impact --json --from-index-revision N --from-artifact-id ID", 1,
             "docs/contracts/impact-index-revision-delta-v1.md"),
+        ("references_candidates", "references candidates --json", 1, "docs/contracts/references-candidates-v1.md"),
     ];
 
     public static string Render(bool json)
@@ -124,6 +126,7 @@ internal static class CliCapabilities
         sb.AppendLine($"symbol_search_sidecar: {(sidecar.Enabled ? "enabled" : "disabled")}");
         sb.AppendLine($"source_region_index: {(sidecar.RegionOptions.Enabled ? "enabled" : "disabled")}");
         sb.AppendLine("reference_aware_context: enabled");
+        sb.AppendLine("references_candidates: enabled");
         sb.AppendLine("features:");
         foreach (string feature in NegotiatedFeatures(ImpactIndexRevisionDeltaActive))
             sb.AppendLine("  - " + feature);
@@ -180,6 +183,7 @@ internal static class CliCapabilities
             w.WriteNumber("source_region_max_bytes", sidecar.RegionOptions.MaxRegionBytes);
             w.WriteBoolean("content_corpus", true);
             w.WriteBoolean("reference_aware_context", true);
+            w.WriteBoolean("references_candidates", true);
             w.WriteBoolean("dashboard", true);
             w.WriteEndObject();
 

--- a/src/Miller.Server/Cli/CliCapabilities.cs
+++ b/src/Miller.Server/Cli/CliCapabilities.cs
@@ -60,6 +60,7 @@ internal static class CliCapabilities
         "metrics churn --json",
         "metrics clones --json",
         "metrics complexity --json",
+        "metrics risk --json",
         "telemetry export --jsonl",
         "symbols export --jsonl",
         "references export --jsonl",
@@ -93,7 +94,7 @@ internal static class CliCapabilities
         ("refresh_wait", "refresh --json --wait", 1, "docs/contracts/refresh-wait-v1.md"),
         ("trace", "trace --json", 1, "docs/contracts/trace-json-v1.md"),
         ("patterns", "patterns --json", 1, "docs/contracts/patterns-json-v1.md"),
-        ("metrics", "metrics <churn|clones|complexity> --json", 1, "docs/contracts/metrics-json-v1.md"),
+        ("metrics", "metrics <churn|clones|complexity|risk> --json", 1, "docs/contracts/metrics-json-v1.md"),
         ("impact_index_revision_delta", "impact --json --from-index-revision N --from-artifact-id ID", 1,
             "docs/contracts/impact-index-revision-delta-v1.md"),
     ];

--- a/src/Miller.Server/Cli/CliDispatch.cs
+++ b/src/Miller.Server/Cli/CliDispatch.cs
@@ -103,6 +103,8 @@ public static class CliDispatch
                     return Patterns(rest, context, stdout, stderr);
                 case "metrics":
                     return Metrics(rest, context, stdout, stderr);
+                case "report":
+                    return Report(rest, context, stdout, stderr);
                 case "telemetry":
                     return Telemetry(rest, context, stdout, stderr);
                 case "symbols":
@@ -608,6 +610,63 @@ public static class CliDispatch
                 or SqliteException)
         {
             err.WriteLine("metrics failed: " + ex.Message);
+            return 3;
+        }
+    }
+
+    private static int Report(IReadOnlyList<string> args, WorkspaceContext ctx, TextWriter outw, TextWriter err)
+    {
+        const string usage = "miller report [--json] [--workspace-id SELECTOR] [--workspace DIR] [--range REV..REV] [--limit N] [--include-tests|--exclude-tests]";
+        if (args.Count > 0 && args[0] is "--help" or "-h" or "help")
+            return Usage(err, usage);
+
+        CliOptions o = CliOptions.Parse(args.ToArray(), "json", "include-tests", "exclude-tests");
+        if (o.Positionals.Count > 0)
+            return Usage(err, usage);
+        if (!TryResolveReadContext(ctx, o, err, out ctx))
+            return 2;
+        if (!RequireIndex(ctx, err))
+            return 3;
+
+        try
+        {
+            // Markers ride the region search sidecar; the section reports itself unavailable when the
+            // sidecar is disabled or the search.db cannot be opened, instead of failing the report.
+            IRegionSearchIndex? regionIndex = null;
+            SymbolSearchSidecar sidecar = SymbolSearchSidecar.FromEnvironment();
+            if (sidecar.Enabled && sidecar.RegionOptions.Enabled)
+            {
+                try
+                {
+                    using var freshness = new FreshnessReader(ctx.ExtractDbPath);
+                    long revision = freshness.LatestRevision();
+                    regionIndex = FtsRegionSearchIndex.Open(
+                        SymbolSearchSidecar.SearchDbPathFor(ctx.ExtractDbPath), revision);
+                }
+                catch (Exception ex) when (ex is InvalidOperationException or IOException or SqliteException)
+                {
+                    regionIndex = null;
+                }
+            }
+
+            ReportToolResult result = ReportTool.Run(
+                ctx.ExtractDbPath,
+                ctx.WorkspaceRoot,
+                range: o.Value("range", "HEAD~20..HEAD"),
+                sectionLimit: o.Int("limit", ReportTool.DefaultSectionLimit),
+                json: o.Has("json"),
+                includeTests: !o.Has("exclude-tests"),
+                historyReader: new ProcessGitHistoryReader(),
+                regionIndex: regionIndex);
+            WriteOutput(outw, result.Output);
+            return 0;
+        }
+        catch (Exception ex) when (
+            ex is FileNotFoundException or InvalidOperationException or IOException
+                or UnauthorizedAccessException or ArgumentException or NotSupportedException
+                or SqliteException)
+        {
+            err.WriteLine("report failed: " + ex.Message);
             return 3;
         }
     }
@@ -1955,8 +2014,10 @@ public static class CliDispatch
                              op = list | summary | search
                              [--workspace-id SELECTOR] [--workspace DIR] [--pattern ID] [--query TEXT] [--language LANG] [--path GLOB] [--where key=value] [--limit N] [--json]
           metrics <op>       Report deterministic local metrics.
-                             op = churn | clones | complexity
+                             op = churn | clones | complexity | risk
                              [--workspace-id SELECTOR] [--workspace DIR] [--limit N] [--json] [--range REV..REV] [--include-commits] [--min-count N] [--max-symbols-per-group N] [--min-severity low|moderate|high] [--include-tests|--exclude-tests]
+          report             One composed repo-quality report: index counts, extraction health, markers, complexity, clones, churn, risk.
+                             [--json] [--workspace-id SELECTOR] [--workspace DIR] [--range REV..REV] [--limit N] [--include-tests|--exclude-tests]
           telemetry <op>     Export machine-global Miller telemetry.
                              export [--jsonl] [--workspace-id ID|all]
           symbols <op>       Bulk-export every symbol row for fleet rollups.   # JSONL

--- a/src/Miller.Server/Cli/CliDispatch.cs
+++ b/src/Miller.Server/Cli/CliDispatch.cs
@@ -569,13 +569,13 @@ public static class CliDispatch
 
     private static int Metrics(IReadOnlyList<string> args, WorkspaceContext ctx, TextWriter outw, TextWriter err)
     {
-        const string usage = "miller metrics <churn|clones|complexity> [--workspace-id SELECTOR] [--workspace DIR] [--limit N] [--json] [--range REV..REV] [--include-commits] [--min-count N] [--max-symbols-per-group N] [--min-severity low|moderate|high] [--include-tests|--exclude-tests]";
+        const string usage = "miller metrics <churn|clones|complexity|risk> [--workspace-id SELECTOR] [--workspace DIR] [--limit N] [--json] [--range REV..REV] [--include-commits] [--min-count N] [--max-symbols-per-group N] [--min-severity low|moderate|high] [--include-tests|--exclude-tests]";
         if (args.Count > 0 && args[0] is "--help" or "-h" or "help")
             return Usage(err, usage);
 
         bool firstTokenIsFlag = args.Count > 0 && args[0].StartsWith("--", StringComparison.Ordinal);
         string operation = args.Count == 0 || firstTokenIsFlag ? "complexity" : args[0].ToLowerInvariant();
-        if (operation is not ("churn" or "clones" or "clone" or "duplicate" or "duplicates" or "complexity" or "hotspots"))
+        if (operation is not ("churn" or "clones" or "clone" or "duplicate" or "duplicates" or "complexity" or "hotspots" or "risk"))
             return Usage(err, usage);
 
         CliOptions o = CliOptions.Parse((firstTokenIsFlag ? args : args.Skip(1)).ToArray(), "json", "include-tests", "exclude-tests", "include-commits");

--- a/src/Miller.Server/Cli/CliDispatch.cs
+++ b/src/Miller.Server/Cli/CliDispatch.cs
@@ -1,4 +1,10 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
+using Miller.Core.DeadCode;
 using Miller.Indexing;
 using Miller.Server.Git;
 using Miller.Server.Hosting;
@@ -112,6 +118,10 @@ public static class CliDispatch
                         "miller symbols export [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]",
                         SymbolExportReader.WriteJsonLines);
                 case "references":
+                    // `references candidates` is the deterministic dead-code candidate listing (Miller-owned,
+                    // named suppressions); every other op (i.e. `export`) keeps the bulk JSONL fact feed unchanged.
+                    if (rest.Count > 0 && rest[0].Equals("candidates", StringComparison.OrdinalIgnoreCase))
+                        return ReferencesCandidates(rest.Skip(1).ToList(), context, stdout, stderr);
                     return ArtifactExport(rest, context, stdout, stderr,
                         "miller references export [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]",
                         ReferenceExportReader.WriteJsonLines);
@@ -711,6 +721,182 @@ public static class CliDispatch
         export(ctx.ExtractDbPath, outw);
         return 0;
     }
+
+    // The deterministic dead-code candidate listing (`references candidates`; dead-code candidates design rev 2):
+    // a fact list with NAMED suppressions, not a verdict. The Indexing reader owns all query-time work (the schema
+    // gate, the required-table validation, the four inbound-evidence counts, coverage, and the two-phase literal
+    // scan); an incompatible/partial artifact surfaces through the shared IncompatibleExtractException → exit-3
+    // mapping in Run. `--limit` bounds ONLY the candidate list; examined / suppressions / literal_scan /
+    // language_coverage stay full totals.
+    private static int ReferencesCandidates(
+        IReadOnlyList<string> args, WorkspaceContext ctx, TextWriter outw, TextWriter err)
+    {
+        const string usage =
+            "miller references candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]";
+        if (args.Count > 0 && args[0] is "--help" or "-h" or "help")
+            return Usage(err, usage);
+
+        CliOptions o = CliOptions.Parse(args, "json");
+        if (o.Positionals.Count > 0)
+            return Usage(err, usage);
+        if (!TryResolveReadContext(ctx, o, err, out ctx))
+            return 2;
+        if (!RequireIndex(ctx, err))
+            return 3;
+
+        int limit = o.Int("limit", DeadCodeCandidatesDefaultLimit);
+        DeadCodeCandidateReport report = DeadCodeCandidateReader.Read(ctx.ExtractDbPath, ctx.WorkspaceRoot);
+        outw.WriteLine(o.Has("json")
+            ? RenderCandidatesJson(report, limit)
+            : RenderCandidatesCompact(report, limit));
+        return 0;
+    }
+
+    private const int DeadCodeCandidatesDefaultLimit = 50;
+
+    // Sort the surviving candidates by (path, start_line) and take the first `limit` — the ONLY block `--limit`
+    // bounds. A stable OrderBy preserves the reader's symbol_id tiebreak within an equal (path, start_line).
+    private static List<DeadCodeCandidate> ShownCandidates(DeadCodeResult result, int limit) =>
+        result.Candidates
+            .OrderBy(c => c.Path, StringComparer.Ordinal)
+            .ThenBy(c => c.StartLine)
+            .Take(limit < 0 ? 0 : limit)
+            .ToList();
+
+    private static string RenderCandidatesCompact(DeadCodeCandidateReport report, int limit)
+    {
+        DeadCodeResult result = report.Result;
+        List<DeadCodeCandidate> shown = ShownCandidates(result, limit);
+
+        var sb = new StringBuilder();
+        sb.Append("candidates: ").Append(result.Candidates.Count).Append(" of ").Append(result.Examined)
+            .Append(" symbols examined · resolver: ").Append(report.Artifact.ReferenceResolutionStatus)
+            .Append(" — candidates are facts to check, not deletions to make.");
+
+        foreach (DeadCodeCandidate c in shown)
+        {
+            sb.Append('\n')
+                .Append(c.Name).Append(' ').Append(c.Kind).Append(' ').Append(c.Language).Append(' ')
+                .Append(c.Path).Append(':').Append(c.StartLine).Append(' ')
+                .Append(c.Visibility ?? "unknown").Append(" evidence=").Append(c.EvidenceLabel)
+                .Append(" [name_matches=").Append(c.NameMatches)
+                .Append(" resolved_in=").Append(c.ResolvedInbound)
+                .Append(" pending_in=").Append(c.PendingResolvedInbound)
+                .Append(" calls_in=").Append(c.CallsInbound).Append(']');
+        }
+
+        if (result.Candidates.Count > shown.Count)
+            sb.Append('\n').Append("showing top ").Append(shown.Count).Append(" of ")
+                .Append(result.Candidates.Count).Append(" by path");
+
+        sb.Append('\n').Append("suppressed:");
+        foreach (string id in DeadCodeCandidates.SuppressionRuleIds)
+            sb.Append(' ').Append(id).Append('=').Append(result.Suppressions[id]);
+
+        sb.Append('\n').Append("literal_scan: files_scanned=").Append(report.LiteralScan.FilesScanned)
+            .Append(" files_skipped_stale=").Append(report.LiteralScan.FilesSkippedStale);
+
+        sb.Append('\n').Append("coverage:");
+        bool first = true;
+        foreach (LanguageCoverageRow cov in report.LanguageCoverage)
+        {
+            double pct = DeadCodeCandidates.ResolvedPercent(cov.IdentifierCount, cov.ResolvedCount);
+            sb.Append(first ? " " : "; ");
+            first = false;
+            sb.Append(cov.Language).Append(": ").Append(pct.ToString("0.0", CultureInfo.InvariantCulture)).Append('%')
+                .Append(pct >= 10.0 ? " resolved" : " — name-evidence only");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string RenderCandidatesJson(DeadCodeCandidateReport report, int limit)
+    {
+        DeadCodeResult result = report.Result;
+        List<DeadCodeCandidate> shown = ShownCandidates(result, limit);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var w = new Utf8JsonWriter(buffer,
+            new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }))
+        {
+            w.WriteStartObject();
+            w.WriteNumber("schema_version", DeadCodeCandidatesSchemaVersion);
+
+            w.WritePropertyName("candidates");
+            w.WriteStartArray();
+            foreach (DeadCodeCandidate c in shown)
+            {
+                w.WriteStartObject();
+                w.WriteString("symbol_id", c.SymbolId);
+                w.WriteString("name", c.Name);
+                w.WriteString("kind", c.Kind);
+                w.WriteString("language", c.Language);
+                w.WriteString("path", c.Path);
+                w.WriteNumber("start_line", c.StartLine);
+                if (c.Visibility is null) w.WriteNull("visibility"); else w.WriteString("visibility", c.Visibility);
+                w.WriteString("evidence_label", c.EvidenceLabel);
+                w.WritePropertyName("evidence");
+                w.WriteStartObject();
+                w.WriteNumber("name_matches", c.NameMatches);
+                w.WriteNumber("resolved_inbound", c.ResolvedInbound);
+                w.WriteNumber("pending_resolved_inbound", c.PendingResolvedInbound);
+                w.WriteNumber("calls_inbound", c.CallsInbound);
+                w.WriteEndObject();
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+
+            w.WritePropertyName("suppressions");
+            w.WriteStartObject();
+            foreach (string id in DeadCodeCandidates.SuppressionRuleIds)
+                w.WriteNumber(id, result.Suppressions[id]);
+            w.WriteEndObject();
+
+            w.WritePropertyName("literal_scan");
+            w.WriteStartObject();
+            w.WriteNumber("files_scanned", report.LiteralScan.FilesScanned);
+            w.WriteNumber("files_skipped_stale", report.LiteralScan.FilesSkippedStale);
+            w.WriteEndObject();
+
+            w.WritePropertyName("language_coverage");
+            w.WriteStartArray();
+            foreach (LanguageCoverageRow cov in report.LanguageCoverage)
+            {
+                w.WriteStartObject();
+                w.WriteString("language", cov.Language);
+                w.WriteNumber("identifiers", cov.IdentifierCount);
+                w.WriteNumber("resolved_pct", DeadCodeCandidates.ResolvedPercent(cov.IdentifierCount, cov.ResolvedCount));
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+
+            w.WriteNumber("examined", result.Examined);
+
+            w.WritePropertyName("artifact");
+            w.WriteStartObject();
+            if (report.Artifact.ArtifactId is null)
+                w.WriteNull("artifact_id");
+            else
+                w.WriteString("artifact_id", report.Artifact.ArtifactId);
+            if (report.Artifact.Revision is null)
+                w.WriteNull("revision");
+            else
+                w.WriteNumber("revision", report.Artifact.Revision.Value);
+            w.WriteString("reference_resolution_status", report.Artifact.ReferenceResolutionStatus);
+            if (report.Artifact.ReferenceResolutionVersion is null)
+                w.WriteNull("reference_resolution_version");
+            else
+                w.WriteString("reference_resolution_version", report.Artifact.ReferenceResolutionVersion);
+            w.WriteEndObject();
+
+            w.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    // The references-candidates-v1 JSON envelope version (docs/contracts/references-candidates-v1.md).
+    private const int DeadCodeCandidatesSchemaVersion = 1;
 
     private static int Refresh(IReadOnlyList<string> args, WorkspaceContext ctx, TextWriter outw, TextWriter err)
     {
@@ -2022,8 +2208,9 @@ public static class CliDispatch
                              export [--jsonl] [--workspace-id ID|all]
           symbols <op>       Bulk-export every symbol row for fleet rollups.   # JSONL
                              export [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]
-          references <op>    Bulk-export identifier/reference usage facts.   # JSONL
-                             export [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]
+          references <op>    Bulk-export identifier/reference usage facts, or list dead-code candidates.
+                             export     [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]   # JSONL fact feed
+                             candidates [--json] [--limit N] [--workspace-id SELECTOR] [--workspace DIR]
           complexity <op>    Bulk-export per-symbol/per-file complexity metrics.   # JSONL
                              export [--jsonl] [--workspace-id SELECTOR] [--workspace DIR]
           refresh            Refresh a registered workspace index and return after convergence attempt.

--- a/src/Miller.Server/Hosting/IndexBootstrapService.cs
+++ b/src/Miller.Server/Hosting/IndexBootstrapService.cs
@@ -128,9 +128,11 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
 
-        string canonicalRoot = source == WorkspaceBindingResolver.WorkspaceSource.Cwd
-            ? WorkspaceRootSafety.CanonicalizeAndRejectSensitiveRoot(workspaceRoot, fromCwd: true)
-            : PathCanonicalizer.CanonicalizeRoot(workspaceRoot);
+        // EVERY binding source passes the sensitive-root guard, not just Cwd. A session launched with
+        // cwd=$HOME defers bootstrap correctly, but the MCP client then offers file://$HOME as its root —
+        // trusting the Roots (or Env) source unguarded kicked off a full home-directory scan (2026-07-06).
+        string canonicalRoot = WorkspaceRootSafety.CanonicalizeAndRejectSensitiveRoot(
+            workspaceRoot, fromCwd: source == WorkspaceBindingResolver.WorkspaceSource.Cwd);
 
         lock (_gate)
         {

--- a/src/Miller.Server/Hosting/IndexBootstrapService.cs
+++ b/src/Miller.Server/Hosting/IndexBootstrapService.cs
@@ -24,7 +24,8 @@ public sealed record BootstrapSnapshot(
     DateTimeOffset? StartedAtUtc,
     string? FailureMessage,
     string? LastFailureMessage,
-    int RunGeneration);
+    int RunGeneration,
+    bool IsBound);
 
 internal enum BindOutcome
 {
@@ -129,7 +130,8 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
                     _startedAtUtc,
                     _failureMessage,
                     _lastFailureMessage,
-                    _runGeneration);
+                    _runGeneration,
+                    _bound is not null);
             }
         }
     }
@@ -313,6 +315,8 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
 
             result = RunBootstrap(canonicalRoot, source);
             published = PublishBoundWorkspace(result, runGeneration);
+            if (!published && !result.UsesExistingLedger)
+                result.Bound.Ledger?.Dispose();
         }
         catch (Exception ex)
         {

--- a/src/Miller.Server/Hosting/IndexBootstrapService.cs
+++ b/src/Miller.Server/Hosting/IndexBootstrapService.cs
@@ -10,6 +10,30 @@ using Miller.Server.Tools;
 
 namespace Miller.Server;
 
+public enum BootstrapPhase
+{
+    Idle,
+    Running,
+    Bound,
+    Failed,
+}
+
+public sealed record BootstrapSnapshot(
+    BootstrapPhase Phase,
+    string? CanonicalRoot,
+    DateTimeOffset? StartedAtUtc,
+    string? FailureMessage,
+    string? LastFailureMessage,
+    int RunGeneration);
+
+internal enum BindOutcome
+{
+    Started,
+    AlreadyBound,
+    JoinedRunning,
+    RebindDeferred,
+}
+
 /// <summary>
 /// The startup bootstrap (M2 §7). Registered as an <see cref="IHostedService"/> BEFORE the MCP host so its
 /// <see cref="StartAsync"/> runs to completion — building the in-memory index and opening the telemetry
@@ -32,10 +56,14 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
     private readonly ILogger<IndexBootstrapService> _logger;
     private readonly object _gate = new();
 
-    private IndexHolder? _holder;
-    private SmartTargetResolver? _resolver;
-    private WorkspaceContext? _workspace;
-    private TelemetryLedger? _ledger;
+    private BoundWorkspace? _bound;
+    private BootstrapPhase _phase = BootstrapPhase.Idle;
+    private string? _snapshotRoot;
+    private DateTimeOffset? _startedAtUtc;
+    private string? _failureMessage;
+    private string? _lastFailureMessage;
+    private int _runGeneration;
+    private TaskCompletionSource _runCompletion = CreateBindingGate();
 
     public IndexBootstrapService(ILogger<IndexBootstrapService> logger)
     {
@@ -43,33 +71,68 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
         _logger = logger;
     }
 
+    private sealed record BoundWorkspace(
+        IndexHolder Holder,
+        SmartTargetResolver Resolver,
+        WorkspaceContext Workspace,
+        TelemetryLedger? Ledger);
+
+    private sealed record BootstrapRunResult(
+        BoundWorkspace Bound,
+        string StableWorkspaceId,
+        WorkspaceRegistryState RegistryStateAfterLoad,
+        bool DidScan,
+        long? ScanRevision,
+        long BuiltRevision,
+        int Pruned,
+        long ElapsedMilliseconds,
+        int DocumentCount,
+        bool UsesExistingLedger);
+
+    private BoundWorkspace CurrentBound =>
+        Volatile.Read(ref _bound) ?? throw new InvalidOperationException("Holder requested before bootstrap completed.");
+
     /// <summary>
     /// The live index holder (M3): seeded with the initial index + its built revision; the freshness service
     /// swaps a fresh index in as the writer advances. Throws if accessed before <see cref="StartAsync"/> completes.
     /// </summary>
-    public IndexHolder Holder =>
-        _holder ?? throw new InvalidOperationException("Holder requested before bootstrap completed.");
+    public IndexHolder Holder => CurrentBound.Holder;
 
     /// <summary>The initially-built repository index. Prefer <see cref="Holder"/> for live freshness.</summary>
     public MillerRepositoryIndex Index => Holder.Current;
 
-    public SmartTargetResolver Resolver =>
-        _resolver ?? throw new InvalidOperationException("Resolver requested before bootstrap completed.");
+    public SmartTargetResolver Resolver => CurrentBound.Resolver;
 
-    public WorkspaceContext Workspace =>
-        _workspace ?? throw new InvalidOperationException("WorkspaceContext requested before bootstrap completed.");
+    public WorkspaceContext Workspace => CurrentBound.Workspace;
 
     public TelemetryLedger Ledger =>
-        _ledger ?? throw new InvalidOperationException("TelemetryLedger requested before bootstrap completed.");
+        CurrentBound.Ledger ?? throw new InvalidOperationException("TelemetryLedger requested before bootstrap completed.");
 
     /// <summary>True once a primary workspace has been bootstrapped (eager or deferred).</summary>
-    public bool IsBound => _holder is not null;
+    public bool IsBound => Volatile.Read(ref _bound) is not null;
 
     /// <summary>True when startup deferred binding until MCP roots or the first tool call.</summary>
     public bool IsDeferred { get; private set; }
 
     /// <summary>Increments when the primary workspace is (re)bound; background services observe changes.</summary>
     public int BindingGeneration => Volatile.Read(ref _bindingGeneration);
+
+    public BootstrapSnapshot Snapshot
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return new BootstrapSnapshot(
+                    _phase,
+                    _phase == BootstrapPhase.Bound ? _bound?.Workspace.CanonicalRoot : _snapshotRoot,
+                    _startedAtUtc,
+                    _failureMessage,
+                    _lastFailureMessage,
+                    _runGeneration);
+            }
+        }
+    }
 
     private int _bindingGeneration;
     private TaskCompletionSource _bindingReady = CreateBindingGate();
@@ -83,6 +146,24 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
         if (IsBound)
             return Task.CompletedTask;
         return _bindingReady.Task.WaitAsync(cancellationToken);
+    }
+
+    public Task WaitForRunAsync(int runGeneration, CancellationToken cancellationToken)
+    {
+        Task wait;
+        lock (_gate)
+        {
+            if (runGeneration <= 0 ||
+                runGeneration != _runGeneration ||
+                _phase != BootstrapPhase.Running)
+            {
+                return Task.CompletedTask;
+            }
+
+            wait = _runCompletion.Task;
+        }
+
+        return wait.WaitAsync(cancellationToken);
     }
 
     internal sealed record BootstrapScanDecision(
@@ -116,15 +197,17 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
 
     /// <summary>
     /// Test-only hook: when set, invoked instead of <see cref="RunBootstrap"/> after canonical-root resolution.
-    /// Return true when the interceptor fully handled binding (including <see cref="SignalBound"/> if needed).
+    /// Return true when the interceptor fully handled binding.
     /// </summary>
     internal Func<string, WorkspaceBindingResolver.WorkspaceSource, bool>? TestBootstrapInterceptor { get; set; }
+
+    internal Action<string>? TestRunBootstrapOverride { get; set; }
 
     /// <summary>
     /// Bind and bootstrap the primary workspace. Idempotent when already bound to the same canonical root;
     /// re-bootstraps when the canonical root changes (MCP roots/list_changed).
     /// </summary>
-    internal void BootstrapForRoot(string workspaceRoot, WorkspaceBindingResolver.WorkspaceSource source)
+    internal BindOutcome BootstrapForRoot(string workspaceRoot, WorkspaceBindingResolver.WorkspaceSource source)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
 
@@ -134,34 +217,76 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
         string canonicalRoot = WorkspaceRootSafety.CanonicalizeAndRejectSensitiveRoot(
             workspaceRoot, fromCwd: source == WorkspaceBindingResolver.WorkspaceSource.Cwd);
 
+        int runGeneration = 0;
+        bool dispatch = false;
         lock (_gate)
         {
-            if (_workspace?.CanonicalRoot is not null &&
-                IndexBootstrapService.RootPathsEqual(_workspace.CanonicalRoot, canonicalRoot))
+            if (_phase == BootstrapPhase.Running)
             {
-                return;
+                if (RootPathsEqual(_snapshotRoot, canonicalRoot))
+                    return BindOutcome.JoinedRunning;
+
+                _logger.LogWarning(
+                    "Workspace rebind to {NewRoot} deferred while bootstrap for {RunningRoot} is still running.",
+                    canonicalRoot, _snapshotRoot ?? "(unknown)");
+                return BindOutcome.RebindDeferred;
             }
 
-            if (_holder is not null)
+            var bound = _bound;
+            if (bound?.Workspace.CanonicalRoot is not null &&
+                RootPathsEqual(bound.Workspace.CanonicalRoot, canonicalRoot))
+            {
+                if (_phase == BootstrapPhase.Failed)
+                {
+                    _phase = BootstrapPhase.Bound;
+                    _snapshotRoot = bound.Workspace.CanonicalRoot;
+                    _startedAtUtc = null;
+                    _failureMessage = null;
+                    _lastFailureMessage = null;
+                }
+                return BindOutcome.AlreadyBound;
+            }
+
+            if (bound is not null)
             {
                 _logger.LogInformation(
                     "Rebinding primary workspace from {OldRoot} to {NewRoot}.",
-                    _workspace?.CanonicalRoot ?? "(unknown)", canonicalRoot);
+                    bound.Workspace.CanonicalRoot ?? "(unknown)", canonicalRoot);
             }
 
             if (TestBootstrapInterceptor?.Invoke(canonicalRoot, source) == true)
-                return;
+                return BindOutcome.Started;
 
-            RunBootstrap(canonicalRoot, source);
-            SignalBound();
+            runGeneration = StartRunLocked(canonicalRoot);
+            dispatch = true;
         }
+
+        if (dispatch)
+            _ = Task.Run(() => RunBootstrapInBackground(canonicalRoot, source, runGeneration));
+
+        return BindOutcome.Started;
     }
 
-    private void SignalBound()
+    private int StartRunLocked(string canonicalRoot)
+    {
+        if (_phase != BootstrapPhase.Failed)
+            _lastFailureMessage = null;
+
+        _phase = BootstrapPhase.Running;
+        _snapshotRoot = canonicalRoot;
+        _startedAtUtc = DateTimeOffset.UtcNow;
+        _failureMessage = null;
+        _runGeneration++;
+        _runCompletion = CreateBindingGate();
+        return _runGeneration;
+    }
+
+    private void SignalBoundLocked()
     {
         int gen = Interlocked.Increment(ref _bindingGeneration);
         var gate = Interlocked.Exchange(ref _bindingReady, CreateBindingGate());
         gate.TrySetResult();
+        _runCompletion.TrySetResult();
         _logger.LogDebug("Primary workspace bound (generation {Generation}).", gen);
     }
 
@@ -173,12 +298,37 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
         BootstrapForRoot(startup.Path, startup.Source);
     }
 
-    private void RunBootstrap(string canonicalRoot, WorkspaceBindingResolver.WorkspaceSource source)
+    private void RunBootstrapInBackground(
+        string canonicalRoot, WorkspaceBindingResolver.WorkspaceSource source, int runGeneration)
+    {
+        BootstrapRunResult? result = null;
+        bool published = false;
+        try
+        {
+            if (TestRunBootstrapOverride is { } runOverride)
+            {
+                runOverride(canonicalRoot);
+                return;
+            }
+
+            result = RunBootstrap(canonicalRoot, source);
+            published = PublishBoundWorkspace(result, runGeneration);
+        }
+        catch (Exception ex)
+        {
+            if (result is not null && !published && !result.UsesExistingLedger)
+                result.Bound.Ledger?.Dispose();
+            MarkBootstrapFailed(canonicalRoot, runGeneration, ex);
+        }
+    }
+
+    private BootstrapRunResult RunBootstrap(string canonicalRoot, WorkspaceBindingResolver.WorkspaceSource source)
     {
         // The telemetry ledger is opened late but must be disposed if ANY later step throws (otherwise the
         // ledger stays open + the telemetry DB locked, but is never assigned to _ledger so Dispose() misses
         // it). Track it in a local and dispose on failure before the exception propagates.
         TelemetryLedger? ledger = null;
+        bool usesExistingLedger = false;
         try
         {
             var startedAt = System.Diagnostics.Stopwatch.GetTimestamp();
@@ -296,12 +446,6 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
             long builtRevision = scanRevision
                 ?? ReadLatestRevisionOrZero(canonicalDbPath, stableWorkspaceId);
 
-            if (didScan)
-                MarkRegistryScanned(workspace, stableWorkspaceId, scanRevision ?? builtRevision);
-            else
-                RegisterBootstrapWorkspace(
-                    workspace, stableWorkspaceId, scanDecision.RegistryStateAfterLoad, builtRevision);
-
             // Open the SEPARATE, writable telemetry ledger (never the read-only extract) + prune old rows.
             // The ledger is MACHINE-GLOBAL (shared <home>/.miller/telemetry.db across every workspace), so its
             // directory is NOT the per-repo .miller created above — ensure it exists before opening. Each row
@@ -310,14 +454,16 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
             // the open connection (the outer catch covers every OTHER post-open step the same way).
             Directory.CreateDirectory(Path.GetDirectoryName(workspace.TelemetryDbPath)!);
             int pruned;
-            if (_ledger is null)
+            var existingLedger = Volatile.Read(ref _bound)?.Ledger;
+            if (existingLedger is null)
             {
                 ledger = OpenAndPrune(
                     workspace.TelemetryDbPath, stableWorkspaceId, workspace.WorkspaceRoot, retentionDays: 30, out pruned);
             }
             else
             {
-                ledger = _ledger;
+                ledger = existingLedger;
+                usesExistingLedger = true;
                 pruned = 0;
             }
 
@@ -328,29 +474,103 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
             var holder = new IndexHolder(index, builtRevision, ReadArtifactIdOrNull(canonicalDbPath));
             var resolver = new SmartTargetResolver(holder); // holder-backed: live freshness per call (M3 step 10)
 
-            if (ReferenceEquals(ledger, _ledger))
-                ledger.RebindWorkspace(stableWorkspaceId, workspace.WorkspaceRoot);
-
-            _holder = holder;
-            _resolver = resolver;
-            _workspace = workspace;
-            _ledger = ledger; // only published once every preceding step succeeded
-
             var elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startedAt);
-            _logger.LogInformation(
-                "Bootstrap ready: {Count} symbols indexed at revision {Rev}, workspace_id={Ws}, " +
-                "{Pruned} telemetry rows pruned, in {Ms}ms.",
-                index.DocumentCount, builtRevision, stableWorkspaceId, pruned,
-                (long)elapsed.TotalMilliseconds);
+            return new BootstrapRunResult(
+                new BoundWorkspace(holder, resolver, workspace, ledger),
+                stableWorkspaceId,
+                scanDecision.RegistryStateAfterLoad,
+                didScan,
+                scanRevision,
+                builtRevision,
+                pruned,
+                (long)elapsed.TotalMilliseconds,
+                index.DocumentCount,
+                usesExistingLedger);
         }
         catch
         {
             // Partial-initialization cleanup: if the ledger was opened but a later step threw, dispose it so
             // the telemetry DB is not left locked / its WAL in an indeterminate state. _ledger was not yet
             // assigned, so Dispose() would otherwise leak it.
-            if (ledger is not null && !ReferenceEquals(ledger, _ledger))
+            if (ledger is not null && !usesExistingLedger)
                 ledger.Dispose();
             throw;
+        }
+    }
+
+    private bool PublishBoundWorkspace(BootstrapRunResult result, int runGeneration)
+    {
+        lock (_gate)
+        {
+            if (_phase != BootstrapPhase.Running || _runGeneration != runGeneration)
+                return false;
+
+            if (result.DidScan)
+                MarkRegistryScanned(result.Bound.Workspace, result.StableWorkspaceId, result.ScanRevision ?? result.BuiltRevision);
+            else
+                RegisterBootstrapWorkspace(
+                    result.Bound.Workspace,
+                    result.StableWorkspaceId,
+                    result.RegistryStateAfterLoad,
+                    result.BuiltRevision);
+
+            if (result.UsesExistingLedger)
+                result.Bound.Ledger?.RebindWorkspace(result.StableWorkspaceId, result.Bound.Workspace.WorkspaceRoot);
+
+            _bound = result.Bound;
+            _phase = BootstrapPhase.Bound;
+            _snapshotRoot = result.Bound.Workspace.CanonicalRoot;
+            _startedAtUtc = null;
+            _failureMessage = null;
+            _lastFailureMessage = null;
+            SignalBoundLocked();
+
+            _logger.LogInformation(
+                "Bootstrap ready: {Count} symbols indexed at revision {Rev}, workspace_id={Ws}, " +
+                "{Pruned} telemetry rows pruned, in {Ms}ms.",
+                result.DocumentCount, result.BuiltRevision, result.StableWorkspaceId, result.Pruned,
+                result.ElapsedMilliseconds);
+            return true;
+        }
+    }
+
+    private void MarkBootstrapFailed(string canonicalRoot, int runGeneration, Exception error)
+    {
+        bool shouldMarkRegistry;
+        lock (_gate)
+        {
+            if (_phase != BootstrapPhase.Running || _runGeneration != runGeneration)
+                return;
+
+            string message = error.Message;
+            _phase = BootstrapPhase.Failed;
+            _snapshotRoot = canonicalRoot;
+            _failureMessage = message;
+            _lastFailureMessage = message;
+            _runCompletion.TrySetResult();
+            shouldMarkRegistry = true;
+        }
+
+        _logger.LogError(error, "Bootstrap failed for {Root}.", canonicalRoot);
+        if (!shouldMarkRegistry)
+            return;
+
+        try
+        {
+            string stableWorkspaceId = WorkspaceId.FromCanonicalRoot(canonicalRoot);
+            string canonicalDbPath = Path.Combine(canonicalRoot, ".miller", "symbols.db");
+            Directory.CreateDirectory(Path.GetDirectoryName(canonicalDbPath)!);
+            var workspace = WorkspaceContext.Create(canonicalRoot, AppContext.BaseDirectory) with
+            {
+                WorkspaceId = stableWorkspaceId,
+                CanonicalRoot = canonicalRoot,
+                CanonicalExtractDbPath = canonicalDbPath,
+            };
+            MarkRegistryError(workspace, stableWorkspaceId, error.Message);
+        }
+        catch (Exception markError)
+        {
+            _logger.LogWarning(markError, "Failed to mark bootstrap error for {Root}.", canonicalRoot);
         }
     }
 
@@ -640,20 +860,24 @@ public sealed class IndexBootstrapService : IHostedService, IDisposable
         ArgumentNullException.ThrowIfNull(holder);
         lock (_gate)
         {
-            if (_workspace?.CanonicalRoot is not null &&
+            var bound = _bound;
+            if (bound?.Workspace.CanonicalRoot is not null &&
                 workspace.CanonicalRoot is not null &&
-                IndexBootstrapService.RootPathsEqual(_workspace.CanonicalRoot, workspace.CanonicalRoot))
+                IndexBootstrapService.RootPathsEqual(bound.Workspace.CanonicalRoot, workspace.CanonicalRoot))
             {
                 return;
             }
-            _workspace = workspace;
-            _holder = holder;
-            _resolver = new SmartTargetResolver(holder);
-            SignalBound();
+            _bound = new BoundWorkspace(holder, new SmartTargetResolver(holder), workspace, Ledger: null);
+            _phase = BootstrapPhase.Bound;
+            _snapshotRoot = workspace.CanonicalRoot;
+            _startedAtUtc = null;
+            _failureMessage = null;
+            _lastFailureMessage = null;
+            SignalBoundLocked();
         }
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    public void Dispose() => _ledger?.Dispose();
+    public void Dispose() => Volatile.Read(ref _bound)?.Ledger?.Dispose();
 }

--- a/src/Miller.Server/Hosting/WorkspaceBindingService.cs
+++ b/src/Miller.Server/Hosting/WorkspaceBindingService.cs
@@ -88,13 +88,16 @@ public sealed class WorkspaceBindingService : IWorkspaceBindingService
             _logger.LogInformation(
                 "Binding primary workspace to {Root} (source={Source}).",
                 resolved.Path, resolved.Source);
-            _bootstrap.BootstrapForRoot(resolved.Path, resolved.Source);
+            var outcome = _bootstrap.BootstrapForRoot(resolved.Path, resolved.Source);
 
-            lock (_gate)
+            if (outcome != BindOutcome.RebindDeferred)
             {
-                _rootsDirty = false;
-                if (rootUris is not null)
-                    _cachedRootUris = rootUris;
+                lock (_gate)
+                {
+                    _rootsDirty = false;
+                    if (rootUris is not null)
+                        _cachedRootUris = rootUris;
+                }
             }
         }
         finally

--- a/src/Miller.Server/Hosting/WorkspaceBindingService.cs
+++ b/src/Miller.Server/Hosting/WorkspaceBindingService.cs
@@ -72,7 +72,7 @@ public sealed class WorkspaceBindingService : IWorkspaceBindingService
     {
         ArgumentNullException.ThrowIfNull(server);
 
-        if (_bootstrap.IsBound && !NeedsRefresh())
+        if (IsSettled())
             return;
 
         IReadOnlyList<string>? rootUris = await GetRootUrisAsync(server, cancellationToken).ConfigureAwait(false);
@@ -82,13 +82,13 @@ public sealed class WorkspaceBindingService : IWorkspaceBindingService
     private async Task EnsurePrimaryBoundCoreAsync(
         IReadOnlyList<string>? rootUris, CancellationToken cancellationToken)
     {
-        if (_bootstrap.IsBound && !NeedsRefresh())
+        if (IsSettled())
             return;
 
         await _bindLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_bootstrap.IsBound && !NeedsRefresh())
+            if (IsSettled())
                 return;
 
             var resolved = WorkspaceBindingResolver.TryResolve(Environment.CurrentDirectory, rootUris)
@@ -114,6 +114,16 @@ public sealed class WorkspaceBindingService : IWorkspaceBindingService
             _bindLock.Release();
         }
     }
+
+    /// <summary>
+    /// Settled = bound with no rebind pending or in flight. Keyed on the snapshot PHASE, not
+    /// <c>IsBound</c>: after a failed background rebind the old workspace stays bound (IsBound true)
+    /// but the phase is Failed — the next ensure call must re-enter <c>BootstrapForRoot</c> to start
+    /// the retry (design: Failed → BootstrapForRoot (retry) → Running), or the Failed state strands
+    /// with no in-band recovery.
+    /// </summary>
+    private bool IsSettled() =>
+        _bootstrap.Snapshot.Phase == BootstrapPhase.Bound && !NeedsRefresh();
 
     private bool NeedsRefresh()
     {

--- a/src/Miller.Server/Hosting/WorkspaceBindingService.cs
+++ b/src/Miller.Server/Hosting/WorkspaceBindingService.cs
@@ -10,7 +10,11 @@ public interface IWorkspaceBindingService
 
     bool IsDeferred { get; }
 
+    BootstrapSnapshot Snapshot { get; }
+
     Task WaitUntilBoundAsync(CancellationToken cancellationToken);
+
+    Task WaitForRunAsync(int runGeneration, CancellationToken cancellationToken);
 
     Task EnsurePrimaryBoundAsync(McpServer server, CancellationToken cancellationToken);
 
@@ -42,8 +46,13 @@ public sealed class WorkspaceBindingService : IWorkspaceBindingService
 
     public bool IsDeferred => _bootstrap.IsDeferred;
 
+    public BootstrapSnapshot Snapshot => _bootstrap.Snapshot;
+
     public Task WaitUntilBoundAsync(CancellationToken cancellationToken) =>
         _bootstrap.WaitUntilBoundAsync(cancellationToken);
+
+    public Task WaitForRunAsync(int runGeneration, CancellationToken cancellationToken) =>
+        _bootstrap.WaitForRunAsync(runGeneration, cancellationToken);
 
     public void MarkRootsDirty()
     {

--- a/src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
+++ b/src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
@@ -23,11 +23,20 @@ public static class WorkspaceBindingCallToolFilter
                 await binding.EnsurePrimaryBoundAsync(server, cancellationToken).ConfigureAwait(false);
 
                 var snapshot = binding.Snapshot;
-                if (IsWorkspaceTool(request) && snapshot.Phase != BootstrapPhase.Bound)
-                    return TextResult(RenderWorkspaceSnapshot(snapshot), isError: false);
-
                 if (snapshot.Phase == BootstrapPhase.Bound)
                     return await next(request, cancellationToken).ConfigureAwait(false);
+
+                // The workspace tool is exempt on IsBound, not Phase: while a rebind is running or
+                // after one failed, the previous workspace is still bound and the tool constructs —
+                // it must flow through so `workspace status` keeps working (and renders the rebind
+                // notice). Only when nothing is bound does the filter render the snapshot itself,
+                // because the tool cannot construct before the first bind.
+                if (IsWorkspaceTool(request))
+                {
+                    if (snapshot.IsBound)
+                        return await next(request, cancellationToken).ConfigureAwait(false);
+                    return TextResult(RenderWorkspaceSnapshot(snapshot), isError: false);
+                }
 
                 if (snapshot.LastFailureMessage is { Length: > 0 } lastFailure)
                     return TextResult(FailedText(lastFailure), isError: true);

--- a/src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
+++ b/src/Miller.Server/Telemetry/WorkspaceBindingCallToolFilter.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
+using Miller.Server;
 using Miller.Server.Hosting;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -17,9 +19,121 @@ public static class WorkspaceBindingCallToolFilter
             var binding = request.Services?.GetService<IWorkspaceBindingService>();
             var server = request.Services?.GetService<McpServer>();
             if (binding is not null && server is not null)
+            {
                 await binding.EnsurePrimaryBoundAsync(server, cancellationToken).ConfigureAwait(false);
+
+                var snapshot = binding.Snapshot;
+                if (IsWorkspaceTool(request) && snapshot.Phase != BootstrapPhase.Bound)
+                    return TextResult(RenderWorkspaceSnapshot(snapshot), isError: false);
+
+                if (snapshot.Phase == BootstrapPhase.Bound)
+                    return await next(request, cancellationToken).ConfigureAwait(false);
+
+                if (snapshot.LastFailureMessage is { Length: > 0 } lastFailure)
+                    return TextResult(FailedText(lastFailure), isError: true);
+
+                if (snapshot.Phase == BootstrapPhase.Failed)
+                    return TextResult(FailedText(snapshot.FailureMessage ?? "unknown error"), isError: true);
+
+                if (snapshot.Phase == BootstrapPhase.Running)
+                {
+                    TimeSpan grace = BootstrapGraceTimeout();
+                    if (grace > TimeSpan.Zero)
+                    {
+                        bool completed = await WaitForRunWithinGraceAsync(
+                            binding, snapshot.RunGeneration, grace, cancellationToken).ConfigureAwait(false);
+                        if (completed)
+                        {
+                            snapshot = binding.Snapshot;
+                            if (snapshot.Phase == BootstrapPhase.Bound)
+                                return await next(request, cancellationToken).ConfigureAwait(false);
+                            if (snapshot.LastFailureMessage is { Length: > 0 } completedFailure)
+                                return TextResult(FailedText(completedFailure), isError: true);
+                            if (snapshot.Phase == BootstrapPhase.Failed)
+                                return TextResult(
+                                    FailedText(snapshot.FailureMessage ?? "unknown error"), isError: true);
+                        }
+                    }
+
+                    return TextResult(NotReadyText(snapshot), isError: true);
+                }
+            }
 
             return await next(request, cancellationToken).ConfigureAwait(false);
         };
+    }
+
+    private static bool IsWorkspaceTool(RequestContext<CallToolRequestParams> request) =>
+        string.Equals(request.Params?.Name, "workspace", StringComparison.Ordinal);
+
+    private static async Task<bool> WaitForRunWithinGraceAsync(
+        IWorkspaceBindingService binding,
+        int runGeneration,
+        TimeSpan grace,
+        CancellationToken cancellationToken)
+    {
+        var waitTask = binding.WaitForRunAsync(runGeneration, cancellationToken);
+        var timeoutTask = Task.Delay(grace, cancellationToken);
+        var completed = await Task.WhenAny(waitTask, timeoutTask).ConfigureAwait(false);
+        if (ReferenceEquals(completed, timeoutTask))
+        {
+            await timeoutTask.ConfigureAwait(false);
+            return false;
+        }
+
+        await waitTask.ConfigureAwait(false);
+        return true;
+    }
+
+    private static TimeSpan BootstrapGraceTimeout()
+    {
+        const double DefaultSeconds = 5;
+        string? raw = Environment.GetEnvironmentVariable("MILLER_BOOTSTRAP_GRACE_SECONDS");
+        if (string.IsNullOrWhiteSpace(raw))
+            return TimeSpan.FromSeconds(DefaultSeconds);
+
+        if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds) &&
+            seconds >= 0)
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        return TimeSpan.FromSeconds(DefaultSeconds);
+    }
+
+    private static CallToolResult TextResult(string text, bool isError) =>
+        new()
+        {
+            IsError = isError,
+            Content = [new TextContentBlock { Text = text }],
+        };
+
+    private static string NotReadyText(BootstrapSnapshot snapshot) =>
+        $"Miller is indexing this workspace for the first time: {snapshot.CanonicalRoot ?? "(unknown)"} " +
+        $"(started {ElapsedSeconds(snapshot.StartedAtUtc)}s ago). Tool calls will work once indexing completes — " +
+        "retry shortly, or run 'workspace status' for progress.";
+
+    private static string FailedText(string message) =>
+        $"bootstrap failed: {message}; retry started — call again shortly.";
+
+    private static string RenderWorkspaceSnapshot(BootstrapSnapshot snapshot) =>
+        snapshot.Phase switch
+        {
+            BootstrapPhase.Running =>
+                $"bootstrap: running {snapshot.CanonicalRoot ?? "(unknown)"}, " +
+                $"started {ElapsedSeconds(snapshot.StartedAtUtc)}s ago",
+            BootstrapPhase.Failed =>
+                $"bootstrap: failed — {snapshot.FailureMessage ?? snapshot.LastFailureMessage ?? "unknown error"}",
+            BootstrapPhase.Idle => "bootstrap: idle",
+            _ => "bootstrap: unavailable",
+        };
+
+    private static long ElapsedSeconds(DateTimeOffset? startedAtUtc)
+    {
+        if (startedAtUtc is null)
+            return 0;
+
+        var elapsed = DateTimeOffset.UtcNow - startedAtUtc.Value;
+        return Math.Max(0, (long)elapsed.TotalSeconds);
     }
 }

--- a/src/Miller.Server/Tools/MetricsTool.cs
+++ b/src/Miller.Server/Tools/MetricsTool.cs
@@ -43,7 +43,15 @@ public static class MetricsTool
                 json,
                 includeCommits,
                 historyReader),
-            _ => throw new InvalidOperationException("metrics operation must be churn, clones, or complexity."),
+            "risk" => RunRisk(
+                dbPath,
+                workspaceRoot,
+                string.IsNullOrWhiteSpace(range) ? "HEAD~20..HEAD" : range,
+                boundedLimit,
+                json,
+                includeTests,
+                historyReader),
+            _ => throw new InvalidOperationException("metrics operation must be churn, clones, complexity, or risk."),
         };
     }
 
@@ -104,6 +112,26 @@ public static class MetricsTool
             historyReader);
         return new MetricsToolResult(
             json ? RenderChurnJson(report) : RenderChurnCompact(report),
+            report.Rows.Count);
+    }
+
+    private static MetricsToolResult RunRisk(
+        string dbPath,
+        string? workspaceRoot,
+        string range,
+        int limit,
+        bool json,
+        bool includeTests,
+        IGitHistoryReader? historyReader)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceRoot))
+            throw new InvalidOperationException("metrics risk requires a workspace root.");
+        if (historyReader is null)
+            throw new InvalidOperationException("metrics risk requires a git history reader.");
+
+        RiskReport report = RiskRanking.Read(dbPath, workspaceRoot, range, limit, includeTests, historyReader);
+        return new MetricsToolResult(
+            json ? RenderRiskJson(report) : RenderRiskCompact(report),
             report.Rows.Count);
     }
 
@@ -298,6 +326,74 @@ public static class MetricsTool
                 foreach (string commit in row.Commits)
                     writer.WriteStringValue(commit);
                 writer.WriteEndArray();
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static string RenderRiskCompact(RiskReport report)
+    {
+        if (report.Rows.Count == 0)
+            return "No risk rows.";
+
+        var sb = new StringBuilder();
+        sb.Append("# risk ").AppendLine(report.Range);
+        sb.Append("score = ").AppendLine(RiskRanking.ScoreFormula);
+        sb.AppendLine("score\tcommits\tlines\tseverity\tbasis\tpath\tsymbol");
+        foreach (RiskRow row in report.Rows)
+        {
+            sb.Append(row.Score).Append('\t')
+              .Append(row.CommitCount).Append('\t')
+              .Append(row.ChangedLines).Append('\t')
+              .Append(ComplexityRankingReader.SeverityName(row.Severity)).Append('\t')
+              .Append(row.Basis).Append('\t')
+              .Append(row.Path);
+            if (row.Line is { } line)
+                sb.Append(':').Append(line);
+            sb.Append('\t')
+              .Append(row.SymbolName ?? "");
+            if (row.IsTest)
+                sb.Append("\ttest");
+            sb.AppendLine();
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string RenderRiskJson(RiskReport report)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (Utf8JsonWriter writer = NewWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("schema_version", 1);
+            writer.WriteString("operation", "risk");
+            writer.WriteString("range", report.Range);
+            writer.WriteString("score_formula", RiskRanking.ScoreFormula);
+            writer.WriteString(
+                "mapping_note",
+                "risk rows are the intersection of churn and complexity evidence mapped to the current index; churn-only and complexity-only rows are omitted");
+            writer.WriteStartArray("rows");
+            foreach (RiskRow row in report.Rows)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("basis", row.Basis);
+                if (row.SymbolId is null) writer.WriteNull("symbol_id"); else writer.WriteString("symbol_id", row.SymbolId);
+                if (row.SymbolName is null) writer.WriteNull("symbol_name"); else writer.WriteString("symbol_name", row.SymbolName);
+                if (row.SymbolKind is null) writer.WriteNull("symbol_kind"); else writer.WriteString("symbol_kind", row.SymbolKind);
+                writer.WriteString("path", row.Path);
+                if (row.Line is null) writer.WriteNull("line"); else writer.WriteNumber("line", row.Line.Value);
+                writer.WriteNumber("commit_count", row.CommitCount);
+                writer.WriteNumber("changed_lines", row.ChangedLines);
+                writer.WriteString("last_commit_at_utc", row.LastCommitAtUtc);
+                writer.WriteNumber("decision_count", row.DecisionCount);
+                writer.WriteNumber("loop_count", row.LoopCount);
+                writer.WriteNumber("max_nesting_depth", row.MaxNestingDepth);
+                writer.WriteString("severity", ComplexityRankingReader.SeverityName(row.Severity));
+                writer.WriteBoolean("is_test", row.IsTest);
+                writer.WriteNumber("score", row.Score);
                 writer.WriteEndObject();
             }
             writer.WriteEndArray();

--- a/src/Miller.Server/Tools/ReportTool.cs
+++ b/src/Miller.Server/Tools/ReportTool.cs
@@ -1,0 +1,429 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Miller.Indexing;
+using Miller.Server.Git;
+
+namespace Miller.Server.Tools;
+
+/// <summary>
+/// One composed repo-quality report over facts Miller already extracts: index counts, extraction
+/// health, marker counts, complexity hotspots, clone groups, churn, and churn×complexity risk.
+/// Pure composition — no new extraction, no recommendations, and no dead-code section until
+/// reference resolution earns confidence (see the 2026-07-06 bolstering assessment consensus).
+/// Sections that cannot be served (no git history, region search disabled) render as unavailable
+/// with a reason instead of failing the report.
+/// </summary>
+public static class ReportTool
+{
+    public const int DefaultSectionLimit = 10;
+    public const int MaxSectionLimit = 100;
+
+    internal static ReportToolResult Run(
+        string dbPath,
+        string? workspaceRoot,
+        string? range,
+        int sectionLimit,
+        bool json,
+        bool includeTests,
+        IGitHistoryReader? historyReader,
+        IRegionSearchIndex? regionIndex)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+        int limit = Math.Clamp(sectionLimit, 1, MaxSectionLimit);
+        string effectiveRange = string.IsNullOrWhiteSpace(range) ? "HEAD~20..HEAD" : range;
+
+        IndexSection index = ReadIndexSection(dbPath);
+        WorkspaceExtractionHealthFacts extraction = WorkspaceHealthReader.Read(dbPath);
+        MarkerSection markers = ReadMarkerSection(regionIndex, includeTests);
+        IReadOnlyList<ComplexityHotspot> complexity = ComplexityRankingReader.Read(
+            dbPath, limit, ComplexitySeverity.Moderate, includeTests);
+        IReadOnlyList<CloneGroup> clones = CloneGroupReader.Read(
+            dbPath, limit, minCount: 2, MetricsTool.DefaultCloneSymbolsPerGroup);
+        GitSections git = ReadGitSections(dbPath, workspaceRoot, effectiveRange, limit, includeTests, historyReader);
+
+        var report = new ReportFacts(
+            effectiveRange, limit, index, extraction, markers, complexity, clones, git);
+        return new ReportToolResult(json ? RenderJson(report) : RenderCompact(report));
+    }
+
+    private static IndexSection ReadIndexSection(string dbPath)
+    {
+        WorkspaceSymbolCounts counts = WorkspaceIndexFactsReader.ReadSymbolCounts(dbPath);
+        return new IndexSection(counts.Symbols, counts.Files, counts.Languages);
+    }
+
+    private static MarkerSection ReadMarkerSection(IRegionSearchIndex? regionIndex, bool includeTests)
+    {
+        if (regionIndex is null)
+        {
+            return new MarkerSection(
+                Available: false,
+                Reason: "region search index unavailable (search sidecar disabled or search.db missing)",
+                BoundedAt: 0,
+                Counts: [],
+                Total: 0);
+        }
+
+        IReadOnlyList<string> markerNames = MarkerSearch.ParseMarkers(null);
+        IReadOnlyList<MarkerSearchHit> hits = MarkerSearch.FindMarkers(
+            regionIndex,
+            markerNames,
+            MarkerSearch.MaxLimit,
+            excludeTests: !includeTests,
+            filePattern: null,
+            language: null);
+
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (string marker in markerNames)
+            counts[marker] = 0;
+        foreach (MarkerSearchHit hit in hits)
+        {
+            foreach (string marker in hit.Markers)
+                counts[marker] = counts.GetValueOrDefault(marker) + 1;
+        }
+
+        return new MarkerSection(
+            Available: true,
+            Reason: null,
+            BoundedAt: MarkerSearch.MaxLimit,
+            Counts: markerNames.Select(marker => new MarkerCount(marker, counts[marker])).ToArray(),
+            Total: hits.Count);
+    }
+
+    private static GitSections ReadGitSections(
+        string dbPath,
+        string? workspaceRoot,
+        string range,
+        int limit,
+        bool includeTests,
+        IGitHistoryReader? historyReader)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceRoot) || historyReader is null)
+            return GitSections.Unavailable("git history unavailable (no workspace root or history reader)");
+
+        try
+        {
+            // One git history parse feeds both sections: full churn for the risk join, top-N for display.
+            ChurnReport fullChurn = GitChurnAnalyzer.Read(
+                dbPath, workspaceRoot, range, limit: int.MaxValue, includeCommits: false, historyReader);
+            var churn = new ChurnReport(fullChurn.Range, fullChurn.Rows.Take(limit).ToArray());
+            RiskReport risk = RiskRanking.FromChurn(dbPath, fullChurn, limit, includeTests);
+            return new GitSections(Available: true, Reason: null, churn, risk);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return GitSections.Unavailable(ex.Message);
+        }
+    }
+
+    private static string RenderCompact(ReportFacts report)
+    {
+        var sb = new StringBuilder();
+        sb.Append("# miller report  range=").AppendLine(report.Range);
+
+        sb.AppendLine();
+        sb.AppendLine("## index");
+        sb.Append("symbols ").Append(report.Index.Symbols)
+          .Append("  files ").Append(report.Index.Files)
+          .Append("  languages ").Append(report.Index.Languages).AppendLine();
+
+        sb.AppendLine();
+        sb.AppendLine("## extraction health");
+        AppendExtractionCompact(sb, report.Extraction);
+
+        sb.AppendLine();
+        sb.AppendLine("## markers");
+        if (!report.Markers.Available)
+        {
+            sb.Append("markers: unavailable — ").AppendLine(report.Markers.Reason);
+        }
+        else
+        {
+            foreach (MarkerCount count in report.Markers.Counts)
+                sb.Append(count.Marker).Append(' ').Append(count.Count).Append("  ");
+            sb.AppendLine();
+            if (report.Markers.Total >= report.Markers.BoundedAt)
+                sb.Append("(counts bounded at ").Append(report.Markers.BoundedAt).AppendLine(")");
+        }
+
+        sb.AppendLine();
+        sb.Append("## complexity (top ").Append(report.SectionLimit).AppendLine(", severity >= moderate)");
+        if (report.Complexity.Count == 0)
+            sb.AppendLine("none");
+        foreach (ComplexityHotspot hotspot in report.Complexity)
+        {
+            sb.Append(ComplexityRankingReader.SeverityName(hotspot.Severity)).Append('\t')
+              .Append(hotspot.DecisionCount).Append('\t')
+              .Append(hotspot.MaxNestingDepth).Append('\t')
+              .Append(hotspot.Path).Append(':').Append(hotspot.StartLine).Append('\t')
+              .AppendLine(hotspot.SymbolName ?? hotspot.Scope);
+        }
+
+        sb.AppendLine();
+        sb.Append("## clones (top ").Append(report.SectionLimit).AppendLine(")");
+        if (report.Clones.Count == 0)
+            sb.AppendLine("none");
+        foreach (CloneGroup group in report.Clones)
+        {
+            sb.Append(group.BodyHash).Append("  count=").Append(group.Count);
+            if (group.Symbols.Count > 0)
+                sb.Append("  e.g. ").Append(group.Symbols[0].Path).Append(':').Append(group.Symbols[0].Line);
+            sb.AppendLine();
+        }
+
+        sb.AppendLine();
+        sb.Append("## churn (top ").Append(report.SectionLimit).AppendLine(")");
+        if (!report.Git.Available)
+        {
+            sb.Append("churn: unavailable — ").AppendLine(report.Git.Reason);
+        }
+        else
+        {
+            foreach (ChurnRow row in report.Git.Churn!.Rows)
+            {
+                sb.Append(row.CommitCount).Append('\t')
+                  .Append(row.ChangedLines).Append('\t')
+                  .Append(row.Path);
+                if (row.Line is { } line)
+                    sb.Append(':').Append(line);
+                sb.Append('\t').AppendLine(row.SymbolName ?? "");
+            }
+        }
+
+        sb.AppendLine();
+        sb.Append("## risk (top ").Append(report.SectionLimit).AppendLine(")");
+        if (!report.Git.Available)
+        {
+            sb.Append("risk: unavailable — ").AppendLine(report.Git.Reason);
+        }
+        else
+        {
+            sb.Append("score = ").AppendLine(RiskRanking.ScoreFormula);
+            foreach (RiskRow row in report.Git.Risk!.Rows)
+            {
+                sb.Append(row.Score).Append('\t')
+                  .Append(ComplexityRankingReader.SeverityName(row.Severity)).Append('\t')
+                  .Append(row.Path);
+                if (row.Line is { } line)
+                    sb.Append(':').Append(line);
+                sb.Append('\t').AppendLine(row.SymbolName ?? "");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void AppendExtractionCompact(StringBuilder sb, WorkspaceExtractionHealthFacts extraction)
+    {
+        if (extraction.ParseDiagnostics.Available)
+            sb.Append("parse diagnostics: ")
+              .Append(extraction.ParseDiagnostics.Rows.Sum(static row => row.Count)).AppendLine();
+        else
+            sb.Append("parse diagnostics: unavailable — ").AppendLine(extraction.ParseDiagnostics.Error);
+        if (extraction.CapabilityGaps.Available)
+            sb.Append("capability gaps: ")
+              .Append(extraction.CapabilityGaps.Rows.Sum(static row => row.Count)).AppendLine();
+        else
+            sb.Append("capability gaps: unavailable — ").AppendLine(extraction.CapabilityGaps.Error);
+    }
+
+    private static string RenderJson(ReportFacts report)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(
+            buffer, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("schema_version", 1);
+            writer.WriteString("operation", "report");
+            writer.WriteString("range", report.Range);
+            writer.WriteNumber("section_limit", report.SectionLimit);
+
+            writer.WriteStartObject("index");
+            writer.WriteBoolean("available", true);
+            writer.WriteNumber("symbols", report.Index.Symbols);
+            writer.WriteNumber("files", report.Index.Files);
+            writer.WriteNumber("languages", report.Index.Languages);
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("extraction_health");
+            writer.WriteBoolean("available", report.Extraction.ParseDiagnostics.Available);
+            if (report.Extraction.ParseDiagnostics.Available)
+                writer.WriteNumber(
+                    "parse_diagnostic_count",
+                    report.Extraction.ParseDiagnostics.Rows.Sum(static row => row.Count));
+            else
+                writer.WriteString("reason", report.Extraction.ParseDiagnostics.Error);
+            if (report.Extraction.CapabilityGaps.Available)
+                writer.WriteNumber(
+                    "capability_gap_count",
+                    report.Extraction.CapabilityGaps.Rows.Sum(static row => row.Count));
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("markers");
+            writer.WriteBoolean("available", report.Markers.Available);
+            if (!report.Markers.Available)
+            {
+                writer.WriteString("reason", report.Markers.Reason);
+            }
+            else
+            {
+                writer.WriteNumber("bounded_at", report.Markers.BoundedAt);
+                writer.WriteBoolean("truncated", report.Markers.Total >= report.Markers.BoundedAt);
+                writer.WriteStartArray("counts");
+                foreach (MarkerCount count in report.Markers.Counts)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("marker", count.Marker);
+                    writer.WriteNumber("count", count.Count);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+                writer.WriteNumber("total", report.Markers.Total);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("complexity");
+            writer.WriteBoolean("available", true);
+            writer.WriteString("min_severity", "moderate");
+            writer.WriteStartArray("hotspots");
+            foreach (ComplexityHotspot hotspot in report.Complexity)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("severity", ComplexityRankingReader.SeverityName(hotspot.Severity));
+                writer.WriteString("path", hotspot.Path);
+                if (hotspot.SymbolName is null) writer.WriteNull("symbol_name"); else writer.WriteString("symbol_name", hotspot.SymbolName);
+                writer.WriteNumber("decision_count", hotspot.DecisionCount);
+                writer.WriteNumber("loop_count", hotspot.LoopCount);
+                writer.WriteNumber("max_nesting_depth", hotspot.MaxNestingDepth);
+                writer.WriteNumber("start_line", hotspot.StartLine);
+                writer.WriteBoolean("is_test", hotspot.IsTest);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("clones");
+            writer.WriteBoolean("available", true);
+            writer.WriteStartArray("groups");
+            foreach (CloneGroup group in report.Clones)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("body_hash", group.BodyHash);
+                writer.WriteNumber("count", group.Count);
+                writer.WriteStartArray("sample");
+                foreach (CloneSymbol symbol in group.Symbols.Take(3))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("path", symbol.Path);
+                    writer.WriteNumber("line", symbol.Line);
+                    writer.WriteString("name", symbol.Name);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+
+            WriteChurnSection(writer, report.Git);
+            WriteRiskSection(writer, report.Git);
+
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static void WriteChurnSection(Utf8JsonWriter writer, GitSections git)
+    {
+        writer.WriteStartObject("churn");
+        writer.WriteBoolean("available", git.Available);
+        if (!git.Available)
+        {
+            writer.WriteString("reason", git.Reason);
+            writer.WriteEndObject();
+            return;
+        }
+        writer.WriteStartArray("rows");
+        foreach (ChurnRow row in git.Churn!.Rows)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("mapping_basis", row.MappingBasis);
+            if (row.SymbolName is null) writer.WriteNull("symbol_name"); else writer.WriteString("symbol_name", row.SymbolName);
+            writer.WriteString("path", row.Path);
+            if (row.Line is null) writer.WriteNull("line"); else writer.WriteNumber("line", row.Line.Value);
+            writer.WriteNumber("commit_count", row.CommitCount);
+            writer.WriteNumber("changed_lines", row.ChangedLines);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private static void WriteRiskSection(Utf8JsonWriter writer, GitSections git)
+    {
+        writer.WriteStartObject("risk");
+        writer.WriteBoolean("available", git.Available);
+        if (!git.Available)
+        {
+            writer.WriteString("reason", git.Reason);
+            writer.WriteEndObject();
+            return;
+        }
+        writer.WriteString("score_formula", RiskRanking.ScoreFormula);
+        writer.WriteStartArray("rows");
+        foreach (RiskRow row in git.Risk!.Rows)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("basis", row.Basis);
+            if (row.SymbolName is null) writer.WriteNull("symbol_name"); else writer.WriteString("symbol_name", row.SymbolName);
+            writer.WriteString("path", row.Path);
+            if (row.Line is null) writer.WriteNull("line"); else writer.WriteNumber("line", row.Line.Value);
+            writer.WriteNumber("commit_count", row.CommitCount);
+            writer.WriteNumber("changed_lines", row.ChangedLines);
+            writer.WriteNumber("decision_count", row.DecisionCount);
+            writer.WriteNumber("max_nesting_depth", row.MaxNestingDepth);
+            writer.WriteString("severity", ComplexityRankingReader.SeverityName(row.Severity));
+            writer.WriteNumber("score", row.Score);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private sealed record ReportFacts(
+        string Range,
+        int SectionLimit,
+        IndexSection Index,
+        WorkspaceExtractionHealthFacts Extraction,
+        MarkerSection Markers,
+        IReadOnlyList<ComplexityHotspot> Complexity,
+        IReadOnlyList<CloneGroup> Clones,
+        GitSections Git);
+
+    private sealed record IndexSection(long Symbols, long Files, long Languages);
+
+    private sealed record MarkerCount(string Marker, int Count);
+
+    private sealed record MarkerSection(
+        bool Available,
+        string? Reason,
+        int BoundedAt,
+        IReadOnlyList<MarkerCount> Counts,
+        int Total);
+
+    private sealed record GitSections(
+        bool Available,
+        string? Reason,
+        ChurnReport? Churn = null,
+        RiskReport? Risk = null)
+    {
+        public static GitSections Unavailable(string reason) => new(false, reason);
+    }
+}
+
+internal readonly record struct ReportToolResult(string Output);

--- a/src/Miller.Server/Tools/RiskRanking.cs
+++ b/src/Miller.Server/Tools/RiskRanking.cs
@@ -1,0 +1,138 @@
+using Miller.Indexing;
+using Miller.Server.Git;
+
+namespace Miller.Server.Tools;
+
+/// <summary>
+/// Deterministic churn×complexity risk ranking: a risk row exists only where churn evidence and
+/// complexity evidence intersect. Churn-only rows stay in `metrics churn`; complexity-only rows
+/// stay in `metrics complexity`. Churn and complexity are joined over their FULL sets before the
+/// final limit is applied, so a low-churn/high-complexity symbol can outrank a high-churn/trivial one.
+/// </summary>
+public static class RiskRanking
+{
+    public const string ScoreFormula = "commit_count * (decision_count + loop_count + max_nesting_depth)";
+
+    public static RiskReport Read(
+        string symbolsDbPath,
+        string workspaceRoot,
+        string range,
+        int limit,
+        bool includeTests,
+        IGitHistoryReader historyReader)
+    {
+        ChurnReport churn = GitChurnAnalyzer.Read(
+            symbolsDbPath,
+            workspaceRoot,
+            range,
+            limit: int.MaxValue,
+            includeCommits: false,
+            historyReader);
+
+        string[] paths = churn.Rows.Select(static row => row.Path).Distinct(StringComparer.Ordinal).ToArray();
+        IReadOnlyList<ComplexityHotspot> complexity = paths.Length == 0
+            ? []
+            : ComplexityRankingReader.ReadForPaths(symbolsDbPath, paths, includeTests);
+
+        return new RiskReport(range, Join(churn.Rows, complexity, limit));
+    }
+
+    internal static IReadOnlyList<RiskRow> Join(
+        IReadOnlyList<ChurnRow> churnRows,
+        IReadOnlyList<ComplexityHotspot> complexityRows,
+        int limit)
+    {
+        if (limit < 1)
+            limit = 1;
+
+        Dictionary<string, ComplexityAggregate> bySymbol = Aggregate(
+            complexityRows.Where(static row => row.SymbolId is not null),
+            static row => row.SymbolId!);
+        Dictionary<string, ComplexityAggregate> byPath = Aggregate(complexityRows, static row => row.Path);
+
+        var rows = new List<RiskRow>();
+        foreach (ChurnRow churn in churnRows)
+        {
+            ComplexityAggregate aggregate;
+            string basis;
+            if (churn.SymbolId is not null && bySymbol.TryGetValue(churn.SymbolId, out aggregate))
+                basis = "symbol";
+            else if (churn.SymbolId is null && byPath.TryGetValue(churn.Path, out aggregate))
+                basis = "file";
+            else
+                continue;
+
+            long score = churn.CommitCount
+                * ((long)aggregate.DecisionCount + aggregate.LoopCount + aggregate.MaxNestingDepth);
+            rows.Add(new RiskRow(
+                basis,
+                churn.SymbolId,
+                churn.SymbolName,
+                churn.SymbolKind,
+                churn.Path,
+                churn.Line,
+                churn.CommitCount,
+                churn.ChangedLines,
+                churn.LastCommitAtUtc,
+                aggregate.DecisionCount,
+                aggregate.LoopCount,
+                aggregate.MaxNestingDepth,
+                ComplexityRankingReader.Classify(aggregate.DecisionCount, aggregate.MaxNestingDepth),
+                aggregate.IsTest,
+                score));
+        }
+
+        return rows
+            .OrderByDescending(static row => row.Score)
+            .ThenByDescending(static row => row.ChangedLines)
+            .ThenByDescending(static row => row.CommitCount)
+            .ThenBy(static row => row.Path, StringComparer.Ordinal)
+            .ThenBy(static row => row.SymbolName, StringComparer.Ordinal)
+            .Take(limit)
+            .ToArray();
+    }
+
+    private static Dictionary<string, ComplexityAggregate> Aggregate(
+        IEnumerable<ComplexityHotspot> rows,
+        Func<ComplexityHotspot, string> keySelector)
+    {
+        var aggregates = new Dictionary<string, ComplexityAggregate>(StringComparer.Ordinal);
+        foreach (ComplexityHotspot row in rows)
+        {
+            string key = keySelector(row);
+            aggregates[key] = aggregates.TryGetValue(key, out ComplexityAggregate existing)
+                ? new ComplexityAggregate(
+                    existing.DecisionCount + row.DecisionCount,
+                    existing.LoopCount + row.LoopCount,
+                    Math.Max(existing.MaxNestingDepth, row.MaxNestingDepth),
+                    existing.IsTest || row.IsTest)
+                : new ComplexityAggregate(row.DecisionCount, row.LoopCount, row.MaxNestingDepth, row.IsTest);
+        }
+        return aggregates;
+    }
+
+    private readonly record struct ComplexityAggregate(
+        int DecisionCount,
+        int LoopCount,
+        int MaxNestingDepth,
+        bool IsTest);
+}
+
+public sealed record RiskReport(string Range, IReadOnlyList<RiskRow> Rows);
+
+public sealed record RiskRow(
+    string Basis,
+    string? SymbolId,
+    string? SymbolName,
+    string? SymbolKind,
+    string Path,
+    int? Line,
+    int CommitCount,
+    int ChangedLines,
+    DateTimeOffset LastCommitAtUtc,
+    int DecisionCount,
+    int LoopCount,
+    int MaxNestingDepth,
+    ComplexitySeverity Severity,
+    bool IsTest,
+    long Score);

--- a/src/Miller.Server/Tools/RiskRanking.cs
+++ b/src/Miller.Server/Tools/RiskRanking.cs
@@ -29,12 +29,26 @@ public static class RiskRanking
             includeCommits: false,
             historyReader);
 
+        return FromChurn(symbolsDbPath, churn, limit, includeTests);
+    }
+
+    /// <summary>
+    /// Ranks risk from an already-read churn report so callers composing several sections (e.g.
+    /// `miller report`) parse git history once. The churn report must be un-limited (or limited
+    /// far above <paramref name="limit"/>): the join happens over the full churn set.
+    /// </summary>
+    public static RiskReport FromChurn(
+        string symbolsDbPath,
+        ChurnReport churn,
+        int limit,
+        bool includeTests)
+    {
         string[] paths = churn.Rows.Select(static row => row.Path).Distinct(StringComparer.Ordinal).ToArray();
         IReadOnlyList<ComplexityHotspot> complexity = paths.Length == 0
             ? []
             : ComplexityRankingReader.ReadForPaths(symbolsDbPath, paths, includeTests);
 
-        return new RiskReport(range, Join(churn.Rows, complexity, limit));
+        return new RiskReport(churn.Range, Join(churn.Rows, complexity, limit));
     }
 
     internal static IReadOnlyList<RiskRow> Join(

--- a/src/Miller.Server/Tools/WorkspaceRender.cs
+++ b/src/Miller.Server/Tools/WorkspaceRender.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Miller.Indexing;
+using Miller.Server;
 using Miller.Server.Telemetry;
 
 namespace Miller.Server.Tools;
@@ -207,8 +208,13 @@ public static class WorkspaceRender
     /// process's eligibility verdict, the compact role label can explain a permanently-outdated reader
     /// (<c>reader (extractor outdated: own X &lt; index Y)</c>) instead of looking mysteriously idle.
     /// </summary>
-    public static string Status(WorkspaceFacts facts, TelemetrySummary telemetry, bool json, LeaderHealthFacts? leader) =>
-        json ? StatusJson(facts, telemetry, leader) : StatusCompact(facts, telemetry, leader);
+    public static string Status(
+        WorkspaceFacts facts,
+        TelemetrySummary telemetry,
+        bool json,
+        LeaderHealthFacts? leader,
+        BootstrapSnapshot? bootstrap = null) =>
+        json ? StatusJson(facts, telemetry, leader) : StatusCompact(facts, telemetry, leader, bootstrap);
 
     // "leader" / "reader" / "reader (extractor outdated: own X < index Y)" — the D6 role string. The outdated
     // form fires only when the verdict is ineligible AND both versions prove the downgrade direction.
@@ -222,7 +228,11 @@ public static class WorkspaceRender
         return "reader";
     }
 
-    private static string StatusCompact(WorkspaceFacts facts, TelemetrySummary telemetry, LeaderHealthFacts? leader)
+    private static string StatusCompact(
+        WorkspaceFacts facts,
+        TelemetrySummary telemetry,
+        LeaderHealthFacts? leader,
+        BootstrapSnapshot? bootstrap)
     {
         var sb = new StringBuilder();
         sb.Append("# workspace");
@@ -252,11 +262,28 @@ public static class WorkspaceRender
             sb.Append("content_db: ").Append(ContentCorpusLabel(corpus, facts.BuiltRevision)).Append('\n');
         if (!string.IsNullOrEmpty(facts.WarningText))
             sb.Append("warning: ").Append(facts.WarningText).Append('\n');
+        if (bootstrap is { Phase: BootstrapPhase.Running, CanonicalRoot.Length: > 0 })
+        {
+            sb.Append("rebinding: ")
+              .Append(bootstrap.CanonicalRoot)
+              .Append(" (started ")
+              .Append(ElapsedSeconds(bootstrap.StartedAtUtc))
+              .Append("s ago)\n");
+        }
 
         string telemetryLine = TelemetryLine(telemetry);
         if (!string.IsNullOrEmpty(telemetryLine))
             sb.Append(telemetryLine).Append('\n');
         return sb.ToString().TrimEnd('\n');
+    }
+
+    private static long ElapsedSeconds(DateTimeOffset? startedAtUtc)
+    {
+        if (startedAtUtc is null)
+            return 0;
+
+        var elapsed = DateTimeOffset.UtcNow - startedAtUtc.Value;
+        return Math.Max(0, (long)elapsed.TotalSeconds);
     }
 
     private static string SearchSidecarLabel(SearchSidecarFacts facts) => facts.State switch

--- a/src/Miller.Server/Tools/WorkspaceTool.cs
+++ b/src/Miller.Server/Tools/WorkspaceTool.cs
@@ -37,6 +37,7 @@ public sealed class WorkspaceTool
     private readonly IndexerService _indexer;
     private readonly FreshnessService _freshness;
     private readonly IndexFreshProbe _freshProbe;
+    private readonly IndexBootstrapService _bootstrap;
     private readonly TelemetryLedger _ledger;
     private readonly WorkspaceRegistry _registry;
     private readonly CrossWorkspaceRefreshService _crossWorkspaceRefresh;
@@ -55,6 +56,7 @@ public sealed class WorkspaceTool
         IndexerService indexer,
         FreshnessService freshness,
         IndexFreshProbe freshProbe,
+        IndexBootstrapService bootstrap,
         TelemetryLedger ledger,
         JulieExtractRunner runner,
         WorkspaceRegistry registry,
@@ -67,6 +69,7 @@ public sealed class WorkspaceTool
             indexer,
             freshness,
             freshProbe,
+            bootstrap,
             ledger,
             runner,
             registry,
@@ -85,6 +88,7 @@ public sealed class WorkspaceTool
         IndexerService indexer,
         FreshnessService freshness,
         IndexFreshProbe freshProbe,
+        IndexBootstrapService bootstrap,
         TelemetryLedger ledger,
         JulieExtractRunner runner,
         WorkspaceRegistry registry,
@@ -100,6 +104,7 @@ public sealed class WorkspaceTool
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(freshness);
         ArgumentNullException.ThrowIfNull(freshProbe);
+        ArgumentNullException.ThrowIfNull(bootstrap);
         ArgumentNullException.ThrowIfNull(ledger);
         ArgumentNullException.ThrowIfNull(runner);
         ArgumentNullException.ThrowIfNull(registry);
@@ -114,6 +119,7 @@ public sealed class WorkspaceTool
         _indexer = indexer;
         _freshness = freshness;
         _freshProbe = freshProbe;
+        _bootstrap = bootstrap;
         _ledger = ledger;
         _registry = registry;
         _crossWorkspaceRefresh = crossWorkspaceRefresh;
@@ -220,7 +226,11 @@ public sealed class WorkspaceTool
 
     private string RenderStatus(bool json) =>
         WorkspaceRender.Status(
-            AssembleFacts(), _ledger.Summarize(), json, ReadLeaderFacts(_workspace.ExtractDbPath, ownWorkspace: true));
+            AssembleFacts(),
+            _ledger.Summarize(),
+            json,
+            ReadLeaderFacts(_workspace.ExtractDbPath, ownWorkspace: true),
+            _bootstrap.Snapshot);
 
     private string RenderHealth(bool json)
     {

--- a/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
+++ b/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
@@ -34,7 +34,8 @@ public sealed class DeadCodeCandidatesTests
         string? symbolId = null,
         int startLine = 1,
         long startByte = 0,
-        long endByte = 0) =>
+        long endByte = 0,
+        bool isOverrideMember = false) =>
         new(
             SymbolId: symbolId ?? ("sym-" + name),
             Name: name,
@@ -49,6 +50,7 @@ public sealed class DeadCodeCandidatesTests
             ParentSymbolId: parentSymbolId,
             HasAnnotation: hasAnnotation,
             HasStructuralFactSelfOrAncestor: hasStructuralFactSelfOrAncestor,
+            IsOverrideMember: isOverrideMember,
             NameMatchesOutside: nameMatchesOutside,
             ResolvedInbound: resolvedInbound,
             PendingResolvedInbound: pendingResolvedInbound,
@@ -64,14 +66,14 @@ public sealed class DeadCodeCandidatesTests
 
     private static void AssertNoSuppressions(DeadCodeResult result)
     {
-        Assert.Equal(9, result.Suppressions.Count);
+        Assert.Equal(10, result.Suppressions.Count);
         foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
             Assert.Equal(0, result.Suppressions[id]);
     }
 
     private static void AssertOnlySuppression(DeadCodeResult result, string ruleId)
     {
-        Assert.Equal(9, result.Suppressions.Count);
+        Assert.Equal(10, result.Suppressions.Count);
         foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
             Assert.Equal(id == ruleId ? 1 : 0, result.Suppressions[id]);
     }
@@ -79,13 +81,13 @@ public sealed class DeadCodeCandidatesTests
     // ---- public contract shape -------------------------------------------------------------------------------
 
     [Fact]
-    public void SuppressionRuleIds_are_the_nine_ids_in_table_order()
+    public void SuppressionRuleIds_are_the_ten_ids_in_table_order()
     {
         Assert.Equal(
             new[]
             {
-                "public_api", "visibility_unknown", "test_symbol", "entry_point", "framework_bound",
-                "annotated", "generated_path", "low_evidence_language", "string_literal_match",
+                "public_api", "visibility_unknown", "test_symbol", "entry_point", "override_member",
+                "framework_bound", "annotated", "generated_path", "low_evidence_language", "string_literal_match",
             },
             DeadCodeCandidates.SuppressionRuleIds);
     }
@@ -232,6 +234,47 @@ public sealed class DeadCodeCandidatesTests
             CSharpResolverCovered);
         Assert.Empty(result.Candidates);
         AssertOnlySuppression(result, "entry_point");
+    }
+
+    [Fact]
+    public void Rule_override_member_suppresses_override_row()
+    {
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(name: "ExecuteAsync", isOverrideMember: true)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "override_member");
+    }
+
+    [Fact]
+    public void Rule_test_symbol_suppresses_test_path_without_extractor_flag()
+    {
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(name: "BeginScope", path: "tests/Miller.Tests/Server/FakeLogger.cs")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "test_symbol");
+    }
+
+    [Fact]
+    public void Rule_test_symbol_path_check_matches_whole_segments_only()
+    {
+        // "Latest" / "protest" contain the substring but are not test path segments — still a candidate.
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(name: "Widget", path: "src/protest/LatestReport.cs")], CSharpResolverCovered);
+        Assert.Single(result.Candidates);
+        AssertNoSuppressions(result);
+    }
+
+    [Fact]
+    public void IsOverrideSignature_matches_override_modifiers_not_identifier_substrings()
+    {
+        Assert.True(DeadCodeCandidates.IsOverrideSignature(
+            "protected override async Task ExecuteAsync(CancellationToken stoppingToken)"));
+        Assert.True(DeadCodeCandidates.IsOverrideSignature("Protected Overrides Sub OnStart()"));
+        Assert.True(DeadCodeCandidates.IsOverrideSignature("override fun toString(): String"));
+        Assert.False(DeadCodeCandidates.IsOverrideSignature("fn override_config(&self) -> Config"));
+        Assert.False(DeadCodeCandidates.IsOverrideSignature("public int OverrideCount { get; }"));
+        Assert.False(DeadCodeCandidates.IsOverrideSignature(null));
+        Assert.False(DeadCodeCandidates.IsOverrideSignature(""));
     }
 
     [Fact]
@@ -410,8 +453,8 @@ public sealed class DeadCodeCandidatesTests
         Assert.Equal(1, applied.Suppressions["string_literal_match"]);
         Assert.Empty(applied.NeedsLiteralScan);
         Assert.Equal(result.Examined, applied.Examined);
-        // All nine ids still present.
-        Assert.Equal(9, applied.Suppressions.Count);
+        // All ten ids still present.
+        Assert.Equal(10, applied.Suppressions.Count);
     }
 
     [Fact]

--- a/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
+++ b/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
@@ -1,0 +1,442 @@
+using Miller.Core.DeadCode;
+using Xunit;
+
+namespace Miller.Tests.Core;
+
+/// <summary>
+/// Tests for <see cref="DeadCodeCandidates"/> (dead-code-candidates plan Task 1): the pure candidate /
+/// suppression / evidence-label evaluator over plain row records. Pure, in-memory fixtures; ZERO I/O.
+///
+/// <para>Every fixture uses ONLY the load-bearing public contract:
+/// <c>DeadCodeSymbolRow</c> / <c>LanguageCoverageRow</c> inputs and the <c>DeadCodeResult</c> output.
+/// The nine suppression rule ids and their table order are asserted against
+/// <see cref="DeadCodeCandidates.SuppressionRuleIds"/>.</para>
+/// </summary>
+public sealed class DeadCodeCandidatesTests
+{
+    // ---- fixtures --------------------------------------------------------------------------------------------
+
+    private static DeadCodeSymbolRow Row(
+        string name = "Widget",
+        string kind = "method",
+        string language = "csharp",
+        string path = "src/Widget.cs",
+        string? visibility = "private",
+        bool isTestSelfOrAncestor = false,
+        string? parentSymbolId = null,
+        bool hasAnnotation = false,
+        bool hasStructuralFactSelfOrAncestor = false,
+        int nameMatchesOutside = 0,
+        int resolvedInbound = 0,
+        int pendingResolvedInbound = 0,
+        int callsInbound = 0,
+        bool? literalMatch = false,
+        string? symbolId = null,
+        int startLine = 1,
+        long startByte = 0,
+        long endByte = 0) =>
+        new(
+            SymbolId: symbolId ?? ("sym-" + name),
+            Name: name,
+            Kind: kind,
+            Language: language,
+            Path: path,
+            StartLine: startLine,
+            StartByte: startByte,
+            EndByte: endByte,
+            Visibility: visibility,
+            IsTestSelfOrAncestor: isTestSelfOrAncestor,
+            ParentSymbolId: parentSymbolId,
+            HasAnnotation: hasAnnotation,
+            HasStructuralFactSelfOrAncestor: hasStructuralFactSelfOrAncestor,
+            NameMatchesOutside: nameMatchesOutside,
+            ResolvedInbound: resolvedInbound,
+            PendingResolvedInbound: pendingResolvedInbound,
+            CallsInbound: callsInbound,
+            LiteralMatch: literalMatch);
+
+    private static LanguageCoverageRow Coverage(string language, int identifiers, int resolved) =>
+        new(language, identifiers, resolved);
+
+    // csharp with 15.6% resolved -> resolver-covered (>= 10%).
+    private static readonly IReadOnlyList<LanguageCoverageRow> CSharpResolverCovered =
+        [Coverage("csharp", 1000, 156)];
+
+    private static void AssertNoSuppressions(DeadCodeResult result)
+    {
+        Assert.Equal(9, result.Suppressions.Count);
+        foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
+            Assert.Equal(0, result.Suppressions[id]);
+    }
+
+    private static void AssertOnlySuppression(DeadCodeResult result, string ruleId)
+    {
+        Assert.Equal(9, result.Suppressions.Count);
+        foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
+            Assert.Equal(id == ruleId ? 1 : 0, result.Suppressions[id]);
+    }
+
+    // ---- public contract shape -------------------------------------------------------------------------------
+
+    [Fact]
+    public void SuppressionRuleIds_are_the_nine_ids_in_table_order()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "public_api", "visibility_unknown", "test_symbol", "entry_point", "framework_bound",
+                "annotated", "generated_path", "low_evidence_language", "string_literal_match",
+            },
+            DeadCodeCandidates.SuppressionRuleIds);
+    }
+
+    [Fact]
+    public void CandidateKinds_contains_the_nine_definition_kinds_and_excludes_noisy_kinds()
+    {
+        foreach (var kind in new[]
+                 {
+                     "function", "method", "class", "struct", "interface", "enum", "delegate",
+                     "property", "constant",
+                 })
+            Assert.Contains(kind, DeadCodeCandidates.CandidateKinds);
+
+        Assert.Equal(9, DeadCodeCandidates.CandidateKinds.Count);
+        foreach (var excluded in new[] { "variable", "field", "constructor", "import", "namespace", "enum_member" })
+            Assert.DoesNotContain(excluded, DeadCodeCandidates.CandidateKinds);
+    }
+
+    // ---- candidate found -------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_private_zero_evidence_resolver_covered_language_is_candidate_with_name_resolver_label()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row()], CSharpResolverCovered);
+
+        Assert.Equal(1, result.Examined);
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal("sym-Widget", candidate.SymbolId);
+        Assert.Equal("Widget", candidate.Name);
+        Assert.Equal("method", candidate.Kind);
+        Assert.Equal("csharp", candidate.Language);
+        Assert.Equal("src/Widget.cs", candidate.Path);
+        Assert.Equal("private", candidate.Visibility);
+        Assert.Equal("name+resolver", candidate.EvidenceLabel);
+        Assert.Equal(0, candidate.NameMatches);
+        Assert.Equal(0, candidate.ResolvedInbound);
+        Assert.Equal(0, candidate.PendingResolvedInbound);
+        Assert.Equal(0, candidate.CallsInbound);
+        AssertNoSuppressions(result);
+        Assert.Empty(result.NeedsLiteralScan);
+    }
+
+    // ---- alive-by-evidence (silent, not a suppression) -------------------------------------------------------
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("resolved")]
+    [InlineData("pending")]
+    [InlineData("calls")]
+    public void Evaluate_any_inbound_evidence_prevents_candidacy_without_any_suppression(string kind)
+    {
+        var row = kind switch
+        {
+            "name" => Row(nameMatchesOutside: 1),
+            "resolved" => Row(resolvedInbound: 1),
+            "pending" => Row(pendingResolvedInbound: 1),
+            "calls" => Row(callsInbound: 1),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        var result = DeadCodeCandidates.Evaluate([row], CSharpResolverCovered);
+
+        Assert.Equal(1, result.Examined);
+        Assert.Empty(result.Candidates);
+        AssertNoSuppressions(result);
+        Assert.Empty(result.NeedsLiteralScan);
+    }
+
+    // ---- each of the nine suppression rules fires and is counted ---------------------------------------------
+
+    [Fact]
+    public void Rule_public_api_suppresses_exported_visibility()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(visibility: "public")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "public_api");
+    }
+
+    [Fact]
+    public void Rule_public_api_suppresses_javascript_exported_form()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(language: "javascript", visibility: "exported")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "public_api");
+    }
+
+    [Fact]
+    public void Rule_visibility_unknown_suppresses_null_visibility()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(visibility: null)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "visibility_unknown");
+    }
+
+    [Fact]
+    public void Rule_visibility_unknown_suppresses_whitespace_visibility()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(visibility: "   ")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "visibility_unknown");
+    }
+
+    [Fact]
+    public void Rule_test_symbol_suppresses_ancestor_closed_test_flag()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(isTestSelfOrAncestor: true)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "test_symbol");
+    }
+
+    [Fact]
+    public void Rule_test_symbol_fires_on_parent_only_closure_when_symbol_itself_is_not_a_test()
+    {
+        // The row itself is a plain private method; only its ancestor is a test (reader already walked parents).
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(isTestSelfOrAncestor: true, parentSymbolId: "sym-TestFixture")],
+            CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "test_symbol");
+    }
+
+    [Fact]
+    public void Rule_entry_point_suppresses_Main_name()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(name: "Main")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "entry_point");
+    }
+
+    [Fact]
+    public void Rule_entry_point_suppresses_lowercase_main_name()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(name: "main", language: "go")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "entry_point");
+    }
+
+    [Fact]
+    public void Rule_entry_point_suppresses_symbol_in_Program_cs_file()
+    {
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(name: "ConfigureServices", path: "src/Miller.Server/Program.cs")],
+            CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "entry_point");
+    }
+
+    [Fact]
+    public void Rule_framework_bound_suppresses_ancestor_closed_structural_fact()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(hasStructuralFactSelfOrAncestor: true)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "framework_bound");
+    }
+
+    [Fact]
+    public void Rule_annotated_suppresses_self_annotation()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(hasAnnotation: true)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "annotated");
+    }
+
+    [Theory]
+    [InlineData("obj/Debug/net10.0/Foo.cs")]
+    [InlineData("src/App/bin/Foo.cs")]
+    [InlineData("web/node_modules/pkg/index.js")]
+    [InlineData("web/wwwroot/lib/vendor.js")]
+    [InlineData("src/App/Foo.g.cs")]
+    [InlineData("src/App/Foo.Designer.cs")]
+    [InlineData("src/App/Foo.generated.ts")]
+    public void Rule_generated_path_suppresses_conservative_generated_globs(string path)
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(path: path)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "generated_path");
+    }
+
+    [Fact]
+    public void Rule_generated_path_matches_backslash_normalized_windows_path()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(path: @"src\App\obj\Foo.cs")], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "generated_path");
+    }
+
+    [Fact]
+    public void Rule_low_evidence_language_suppresses_language_with_zero_identifiers()
+    {
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(language: "css", path: "src/site.css")],
+            [Coverage("css", 0, 0)]);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "low_evidence_language");
+    }
+
+    [Fact]
+    public void Rule_string_literal_match_suppresses_literal_hit()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(literalMatch: true)], CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "string_literal_match");
+        Assert.Empty(result.NeedsLiteralScan);
+    }
+
+    // ---- first-match-wins precedence -------------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_first_matching_rule_wins_public_and_test_counts_public_api_only()
+    {
+        var result = DeadCodeCandidates.Evaluate(
+            [Row(visibility: "public", isTestSelfOrAncestor: true)],
+            CSharpResolverCovered);
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "public_api");
+    }
+
+    // ---- exclusions: syntax-invoked name shapes are NOT examined / NOT suppressed ----------------------------
+
+    [Theory]
+    [InlineData("~Resource", "method")]
+    [InlineData("this[int index]", "property")]
+    [InlineData("operator +", "method")]
+    [InlineData("op_Addition", "method")]
+    [InlineData("Finalize", "method")]
+    public void IsSyntaxInvokedName_true_for_syntax_invoked_member_shapes(string name, string kind)
+    {
+        Assert.True(DeadCodeCandidates.IsSyntaxInvokedName(name, kind));
+    }
+
+    [Theory]
+    [InlineData("Widget", "method")]
+    [InlineData("Operation", "class")]        // starts with "Op" but not "operator"/"op_"
+    [InlineData("Finalizer", "method")]       // not exactly "Finalize"
+    public void IsSyntaxInvokedName_false_for_ordinary_names(string name, string kind)
+    {
+        Assert.False(DeadCodeCandidates.IsSyntaxInvokedName(name, kind));
+    }
+
+    [Fact]
+    public void Evaluate_excludes_syntax_invoked_and_non_candidate_kinds_from_examined_and_suppressed()
+    {
+        var rows = new[]
+        {
+            Row(name: "~Resource", kind: "method"),
+            Row(name: "this[int index]", kind: "property"),
+            Row(name: "operator +", kind: "method"),
+            Row(name: "op_Addition", kind: "method"),
+            Row(name: "Finalize", kind: "method"),
+            Row(name: "someField", kind: "field"),         // non-candidate kind
+            Row(name: "someVar", kind: "variable"),        // non-candidate kind
+        };
+
+        var result = DeadCodeCandidates.Evaluate(rows, CSharpResolverCovered);
+
+        Assert.Equal(0, result.Examined);
+        Assert.Empty(result.Candidates);
+        AssertNoSuppressions(result);
+        Assert.Empty(result.NeedsLiteralScan);
+    }
+
+    // ---- evidence-label split at the 10% boundary ------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_label_is_name_when_language_coverage_is_below_ten_percent()
+    {
+        // 99 of 1000 = 9.9% -> below threshold.
+        var result = DeadCodeCandidates.Evaluate([Row()], [Coverage("csharp", 1000, 99)]);
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal("name", candidate.EvidenceLabel);
+    }
+
+    [Fact]
+    public void Evaluate_label_is_name_resolver_at_exactly_ten_percent()
+    {
+        // 1 of 10 = 10.0% -> at threshold.
+        var result = DeadCodeCandidates.Evaluate([Row()], [Coverage("csharp", 10, 1)]);
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal("name+resolver", candidate.EvidenceLabel);
+    }
+
+    [Fact]
+    public void Evaluate_label_is_name_when_language_absent_from_coverage()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row()], []);
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal("name", candidate.EvidenceLabel);
+    }
+
+    // ---- two-phase literal scan ------------------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_literal_match_null_yields_provisional_candidate_in_needs_literal_scan()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(literalMatch: null)], CSharpResolverCovered);
+
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal("sym-Widget", candidate.SymbolId);
+        var pending = Assert.Single(result.NeedsLiteralScan);
+        Assert.Equal("sym-Widget", pending.SymbolId);
+        // Not yet suppressed by the literal rule — the reader still has to scan.
+        Assert.Equal(0, result.Suppressions["string_literal_match"]);
+    }
+
+    [Fact]
+    public void Evaluate_literal_match_false_is_a_candidate_not_in_needs_literal_scan()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(literalMatch: false)], CSharpResolverCovered);
+        Assert.Single(result.Candidates);
+        Assert.Empty(result.NeedsLiteralScan);
+    }
+
+    [Fact]
+    public void ApplyLiteralScan_removes_matched_candidate_bumps_string_literal_match_and_empties_needs_scan()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(literalMatch: null)], CSharpResolverCovered);
+
+        var applied = DeadCodeCandidates.ApplyLiteralScan(result, new HashSet<string> { "sym-Widget" });
+
+        Assert.Empty(applied.Candidates);
+        Assert.Equal(1, applied.Suppressions["string_literal_match"]);
+        Assert.Empty(applied.NeedsLiteralScan);
+        Assert.Equal(result.Examined, applied.Examined);
+        // All nine ids still present.
+        Assert.Equal(9, applied.Suppressions.Count);
+    }
+
+    [Fact]
+    public void ApplyLiteralScan_leaves_unmatched_candidate_and_empties_needs_scan()
+    {
+        var result = DeadCodeCandidates.Evaluate([Row(literalMatch: null)], CSharpResolverCovered);
+
+        var applied = DeadCodeCandidates.ApplyLiteralScan(result, new HashSet<string> { "sym-Other" });
+
+        Assert.Single(applied.Candidates);
+        Assert.Equal(0, applied.Suppressions["string_literal_match"]);
+        Assert.Empty(applied.NeedsLiteralScan);
+    }
+
+    // ---- ResolvedPercent -------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0, 0, 0.0)]        // no identifiers -> 0.0 (no divide-by-zero)
+    [InlineData(10, 1, 10.0)]      // exact boundary
+    [InlineData(1000, 156, 15.6)]  // live-scan C# figure
+    [InlineData(1000, 99, 9.9)]    // just below boundary
+    [InlineData(3, 1, 33.3)]       // one-decimal rounding down
+    [InlineData(3, 2, 66.7)]       // one-decimal rounding up
+    public void ResolvedPercent_rounds_to_one_decimal(int identifiers, int resolved, double expected)
+    {
+        Assert.Equal(expected, DeadCodeCandidates.ResolvedPercent(identifiers, resolved));
+    }
+}

--- a/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
+++ b/tests/Miller.Tests/Core/DeadCodeCandidatesTests.cs
@@ -9,7 +9,7 @@ namespace Miller.Tests.Core;
 ///
 /// <para>Every fixture uses ONLY the load-bearing public contract:
 /// <c>DeadCodeSymbolRow</c> / <c>LanguageCoverageRow</c> inputs and the <c>DeadCodeResult</c> output.
-/// The nine suppression rule ids and their table order are asserted against
+/// The eleven suppression rule ids and their table order are asserted against
 /// <see cref="DeadCodeCandidates.SuppressionRuleIds"/>.</para>
 /// </summary>
 public sealed class DeadCodeCandidatesTests
@@ -66,14 +66,14 @@ public sealed class DeadCodeCandidatesTests
 
     private static void AssertNoSuppressions(DeadCodeResult result)
     {
-        Assert.Equal(10, result.Suppressions.Count);
+        Assert.Equal(11, result.Suppressions.Count);
         foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
             Assert.Equal(0, result.Suppressions[id]);
     }
 
     private static void AssertOnlySuppression(DeadCodeResult result, string ruleId)
     {
-        Assert.Equal(10, result.Suppressions.Count);
+        Assert.Equal(11, result.Suppressions.Count);
         foreach (var id in DeadCodeCandidates.SuppressionRuleIds)
             Assert.Equal(id == ruleId ? 1 : 0, result.Suppressions[id]);
     }
@@ -81,13 +81,14 @@ public sealed class DeadCodeCandidatesTests
     // ---- public contract shape -------------------------------------------------------------------------------
 
     [Fact]
-    public void SuppressionRuleIds_are_the_ten_ids_in_table_order()
+    public void SuppressionRuleIds_are_the_eleven_ids_in_table_order()
     {
         Assert.Equal(
             new[]
             {
                 "public_api", "visibility_unknown", "test_symbol", "entry_point", "override_member",
-                "framework_bound", "annotated", "generated_path", "low_evidence_language", "string_literal_match",
+                "live_member_container", "framework_bound", "annotated", "generated_path",
+                "low_evidence_language", "string_literal_match",
             },
             DeadCodeCandidates.SuppressionRuleIds);
     }
@@ -243,6 +244,46 @@ public sealed class DeadCodeCandidatesTests
             [Row(name: "ExecuteAsync", isOverrideMember: true)], CSharpResolverCovered);
         Assert.Empty(result.Candidates);
         AssertOnlySuppression(result, "override_member");
+    }
+
+    [Fact]
+    public void Rule_live_member_container_suppresses_type_whose_member_has_inbound_evidence()
+    {
+        // A static extension class (TelemetryOutcomeExtensions shape): the class NAME appears nowhere, but its
+        // member (outcome.ToStorageString()) has inbound calls. The container must not be flagged.
+        var rows = new[]
+        {
+            Row(name: "TelemetryOutcomeExtensions", kind: "class", visibility: "internal",
+                symbolId: "sym-Container"),
+            Row(name: "ToStorageString", kind: "method", visibility: "public",
+                parentSymbolId: "sym-Container", callsInbound: 1),
+        };
+
+        var result = DeadCodeCandidates.Evaluate(rows, CSharpResolverCovered);
+
+        // The class is suppressed as live_member_container; the member is alive-by-evidence (silent, not counted).
+        Assert.Empty(result.Candidates);
+        AssertOnlySuppression(result, "live_member_container");
+        Assert.Equal(2, result.Examined);
+    }
+
+    [Fact]
+    public void Rule_live_member_container_does_not_fire_when_no_member_has_evidence()
+    {
+        // Same container shape but the member shows ZERO inbound evidence: the container is NOT rescued and
+        // remains a candidate (conservative — a fact to check).
+        var rows = new[]
+        {
+            Row(name: "OrphanContainer", kind: "class", visibility: "internal", symbolId: "sym-Container"),
+            Row(name: "OrphanMethod", kind: "method", visibility: "private", parentSymbolId: "sym-Container"),
+        };
+
+        var result = DeadCodeCandidates.Evaluate(rows, CSharpResolverCovered);
+
+        // No member evidence -> live_member_container count stays 0; both zero-evidence rows are candidates.
+        Assert.Equal(0, result.Suppressions["live_member_container"]);
+        Assert.Contains(result.Candidates, c => c.SymbolId == "sym-Container");
+        Assert.Contains(result.Candidates, c => c.Name == "OrphanMethod");
     }
 
     [Fact]
@@ -453,8 +494,8 @@ public sealed class DeadCodeCandidatesTests
         Assert.Equal(1, applied.Suppressions["string_literal_match"]);
         Assert.Empty(applied.NeedsLiteralScan);
         Assert.Equal(result.Examined, applied.Examined);
-        // All ten ids still present.
-        Assert.Equal(10, applied.Suppressions.Count);
+        // All eleven ids still present.
+        Assert.Equal(11, applied.Suppressions.Count);
     }
 
     [Fact]

--- a/tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs
+++ b/tests/Miller.Tests/Indexing/DeadCodeCandidateReaderTests.cs
@@ -1,0 +1,392 @@
+using Microsoft.Data.Sqlite;
+using Miller.Indexing;
+using Xunit;
+
+namespace Miller.Tests.Indexing;
+
+/// <summary>
+/// Contract tests for <see cref="DeadCodeCandidateReader"/> — the Indexing reader that gathers candidate rows,
+/// the per-language coverage universe, the ancestor-closure booleans, the four inbound-evidence counts, and the
+/// two-phase literal scan, then hands them to <see cref="Miller.Core.DeadCode.DeadCodeCandidates"/>. Fixture-based
+/// (no real julie binary), so these are FAST-suite tests (NOT Scale).
+/// </summary>
+public sealed class DeadCodeCandidateReaderTests
+{
+    // ---- helpers ---------------------------------------------------------------------------------------------
+
+    private static JulieDbFixture.SymbolRow Method(
+        string id, string name, string path, string? visibility = "private", string? parentId = null,
+        int startByte = 0, int endByte = 40, string kind = "method", string language = "csharp", int startLine = 1)
+        => new(id, name, kind, language, path, $"sig {name}", startLine, parentId)
+        { Visibility = visibility, StartByte = startByte, EndByte = endByte };
+
+    private static JulieDbFixture.IdentifierRow Ident(
+        string id, string name, string path, string? containingSymbolId,
+        string language = "csharp", int startByte = 100, int endByte = 110)
+        => new(id, name, "call", language, path, 1, containingSymbolId) { StartByte = startByte, EndByte = endByte };
+
+    private static Miller.Core.DeadCode.DeadCodeCandidate? Candidate(DeadCodeCandidateReport report, string name)
+    {
+        foreach (var c in report.Result.Candidates)
+            if (c.Name == name)
+                return c;
+        return null;
+    }
+
+    private static void DropTable(string dbPath, string table)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        { DataSource = dbPath, Mode = SqliteOpenMode.ReadWrite, Pooling = false, ForeignKeys = false }.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"DROP TABLE {table};";
+        command.ExecuteNonQuery();
+    }
+
+    // ---- candidate emission ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_PrivateSymbolWithNoInboundEvidence_IsEmittedWithZeroCounts()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            // A benign csharp identifier so csharp coverage has IdentifierCount > 0 (else low_evidence_language fires).
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        var cand = Candidate(report, "UnusedHelper");
+        Assert.NotNull(cand);
+        Assert.Equal(0, cand!.NameMatches);
+        Assert.Equal(0, cand.ResolvedInbound);
+        Assert.Equal(0, cand.PendingResolvedInbound);
+        Assert.Equal(0, cand.CallsInbound);
+        Assert.Equal("name", cand.EvidenceLabel);
+        Assert.Equal("csharp", cand.Language);
+    }
+
+    // ---- alive-by-evidence prevents candidacy ----------------------------------------------------------------
+
+    [Fact]
+    public void Read_NameMatchOutsideSymbol_PreventsCandidacy()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Method("sym-cand", "UnusedHelper", "src/Helper.cs"),
+                Method("sym-caller", "Caller", "src/Caller.cs"),
+            },
+            // An identifier whose NAME equals the candidate, in another symbol/file -> NameMatchesOutside > 0.
+            identifiers: new[] { Ident("id-name", "UnusedHelper", "src/Caller.cs", "sym-caller") });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+    }
+
+    [Fact]
+    public void Read_IdentifierResolutionAliasEdge_PreventsCandidacy_IndependentOfName()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Method("sym-cand", "UnusedHelper", "src/Helper.cs"),
+                Method("sym-caller", "Caller", "src/Caller.cs"),
+            },
+            // The identifier NAME is 'Alias', NOT 'UnusedHelper' -> NameMatchesOutside stays 0, but it RESOLVES to S.
+            identifiers: new[] { Ident("id-alias", "Alias", "src/Caller.cs", "sym-caller") });
+        fx.AddIdentifierResolution("id-alias", targetSymbolId: "sym-cand", outcome: "resolved");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+    }
+
+    [Fact]
+    public void Read_PendingResolutionOnly_PreventsCandidacy_WithNoIdentifierResolutionRow()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Method("sym-cand", "UnusedHelper", "src/Helper.cs"),
+                Method("sym-caller", "Caller", "src/Caller.cs"),
+            },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+        // A pending relationship from another symbol/file that resolves to S — and NO identifier_resolutions row.
+        fx.AddPendingRelationship("pr-1", fromSymbolId: "sym-caller", filePath: "src/Caller.cs",
+            callerScopeSymbolId: "sym-caller", startByte: 200, endByte: 210);
+        fx.AddPendingResolution("pr-1", targetSymbolId: "sym-cand");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+    }
+
+    [Fact]
+    public void Read_InboundRelationship_PreventsCandidacy()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Method("sym-cand", "UnusedHelper", "src/Helper.cs"),
+                Method("sym-caller", "Caller", "src/Caller.cs"),
+            },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            relationships: new[] { new JulieDbFixture.RelationshipRow("rel-1", "sym-caller", "sym-cand", "calls") });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+    }
+
+    // ---- ancestor-closure suppressions -----------------------------------------------------------------------
+
+    [Fact]
+    public void Read_ParentOnlyIsTestAncestor_SuppressesAsTestSymbol()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                // Parent is a test container; the child method is NOT is_test itself. The parent kind is a
+                // non-candidate kind ('namespace') so ONLY the child is counted under test_symbol.
+                new JulieDbFixture.SymbolRow("sym-parent", "FixtureTests", "namespace", "csharp",
+                    "tests/FixtureTests.cs", "namespace FixtureTests", 1, null) { Visibility = "private", IsTest = true },
+                Method("sym-cand", "UnusedHelper", "tests/FixtureTests.cs", parentId: "sym-parent"),
+            },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+        Assert.Equal(1, report.Result.Suppressions["test_symbol"]);
+    }
+
+    [Fact]
+    public void Read_ParentOnlyStructuralFactAncestor_SuppressesAsFrameworkBound()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                // Parent kind is a non-candidate kind ('namespace') so ONLY the child is counted under framework_bound.
+                new JulieDbFixture.SymbolRow("sym-parent", "Controller", "namespace", "csharp",
+                    "src/Controller.cs", "namespace Controller", 1, null) { Visibility = "private" },
+                Method("sym-cand", "UnusedHelper", "src/Controller.cs", parentId: "sym-parent"),
+            },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+        // The structural fact is bound to the PARENT, not the candidate itself.
+        fx.AddStructuralFact("fact-1", containingSymbolId: "sym-parent", path: "src/Controller.cs");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+        Assert.Equal(1, report.Result.Suppressions["framework_bound"]);
+    }
+
+    [Fact]
+    public void Read_SelfAnnotation_SuppressesAsAnnotated()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+        fx.AddSymbolAnnotation("ann-1", symbolId: "sym-cand");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+        Assert.Equal(1, report.Result.Suppressions["annotated"]);
+    }
+
+    // ---- coverage universe -----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_LanguageWithSymbolsButZeroIdentifiers_EmittedAsCoverageRowAndSuppressesLowEvidence()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                // css has a candidate-kind symbol but there are ZERO css identifiers.
+                Method("sym-css", "RootBlock", "styles/site.css", kind: "class", language: "css"),
+                // a csharp symbol + identifier so csharp coverage is non-empty (control).
+                Method("sym-cs", "UnusedHelper", "src/Helper.cs"),
+            },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        var css = report.LanguageCoverage.SingleOrDefault(r => r.Language == "css");
+        Assert.NotNull(css);
+        Assert.Equal(0, css!.IdentifierCount);
+        Assert.Equal(0, css.ResolvedCount);
+
+        // The css symbol must NOT surface as a candidate — it is suppressed under low_evidence_language.
+        Assert.Null(Candidate(report, "RootBlock"));
+        Assert.Equal(1, report.Result.Suppressions["low_evidence_language"]);
+
+        // Every candidate's language appears in coverage.
+        foreach (var c in report.Result.Candidates)
+            Assert.Contains(report.LanguageCoverage, r => r.Language == c.Language);
+    }
+
+    [Fact]
+    public void Read_Coverage_CountsIdentifiersAndResolvedPerLanguage()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Method("sym-cand", "UnusedHelper", "src/Helper.cs"),
+                Method("sym-caller", "Caller", "src/Caller.cs"),
+            },
+            identifiers: new[]
+            {
+                Ident("id-a", "Alpha", "src/Caller.cs", "sym-caller"),
+                Ident("id-b", "Beta", "src/Caller.cs", "sym-caller"),
+            });
+        // One of the two csharp identifiers resolves.
+        fx.AddIdentifierResolution("id-a", targetSymbolId: "sym-caller", outcome: "resolved");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        var cs = report.LanguageCoverage.Single(r => r.Language == "csharp");
+        Assert.Equal(2, cs.IdentifierCount);
+        Assert.Equal(1, cs.ResolvedCount);
+    }
+
+    // ---- literal scan (phase 2) ------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_LiteralMatchInFreshFile_SuppressesStringLiteralMatch_AndCountsFileOnce()
+    {
+        // Two string_literal regions in ONE file, both mentioning the candidate name — proves the file is read once.
+        const string labels = "UnusedHelper is a label\n";
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            fileContent: new Dictionary<string, string> { ["src/labels.cs"] = labels },
+            sourceRegions: new[]
+            {
+                new JulieDbFixture.SourceRegionRow("reg-1", "file:src/labels.cs", "src/labels.cs", "csharp",
+                    "string_literal", null, 1, 1, 1, 12, 0, 12, null),
+                new JulieDbFixture.SourceRegionRow("reg-2", "file:src/labels.cs", "src/labels.cs", "csharp",
+                    "string_literal", null, 1, 13, 1, 23, 13, 23, null),
+            });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Null(Candidate(report, "UnusedHelper"));
+        Assert.True(report.Result.Suppressions["string_literal_match"] >= 1);
+        Assert.Equal(1, report.LiteralScan.FilesScanned);
+        Assert.Equal(0, report.LiteralScan.FilesSkippedStale);
+    }
+
+    [Fact]
+    public void Read_LiteralFileWithStaleHash_IsSkipped_AndDoesNotSuppress()
+    {
+        const string labels = "UnusedHelper is a label\n";
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            fileContent: new Dictionary<string, string> { ["src/labels.cs"] = labels },
+            sourceRegions: new[]
+            {
+                new JulieDbFixture.SourceRegionRow("reg-1", "file:src/labels.cs", "src/labels.cs", "csharp",
+                    "string_literal", null, 1, 1, 1, 12, 0, 12, null),
+            });
+        // Edit the on-disk source AFTER extraction so its blake3 no longer matches the stored content_hash.
+        File.WriteAllText(Path.Combine(fx.WorkspaceRoot, "src/labels.cs"), "totally different content now\n");
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        // The stale file is skipped, so the candidate is NOT suppressed by a match it cannot trust.
+        Assert.NotNull(Candidate(report, "UnusedHelper"));
+        Assert.Equal(0, report.LiteralScan.FilesScanned);
+        Assert.Equal(1, report.LiteralScan.FilesSkippedStale);
+    }
+
+    [Fact]
+    public void Read_NoSurvivors_SkipsLiteralScanEntirely()
+    {
+        // The only candidate-kind symbol is public -> suppressed as public_api -> NeedsLiteralScan is empty,
+        // so the literal scan must NOT read the string_literal file even though one exists.
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-pub", "PublicApi", "src/Api.cs", visibility: "public") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            fileContent: new Dictionary<string, string> { ["src/labels.cs"] = "PublicApi label\n" },
+            sourceRegions: new[]
+            {
+                new JulieDbFixture.SourceRegionRow("reg-1", "file:src/labels.cs", "src/labels.cs", "csharp",
+                    "string_literal", null, 1, 1, 1, 9, 0, 9, null),
+            });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Empty(report.Result.Candidates);
+        Assert.Equal(0, report.LiteralScan.FilesScanned);
+        Assert.Equal(0, report.LiteralScan.FilesSkippedStale);
+    }
+
+    // ---- required-table validation -> IncompatibleExtractException (CLI exit 3) ------------------------------
+
+    [Theory]
+    [InlineData("identifier_resolutions")]
+    [InlineData("pending_resolutions")]
+    [InlineData("pending_relationships")]
+    public void Read_MissingRequiredResolutionTable_ThrowsIncompatibleExtract(string table)
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") });
+        DropTable(fx.DbPath, table);
+
+        var ex = Assert.Throws<IncompatibleExtractException>(
+            () => DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot));
+        Assert.Contains(table, ex.Message, StringComparison.Ordinal);
+    }
+
+    // ---- artifact block --------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Read_ArtifactBlock_PopulatedFromMetadataAndRevisions()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            revisions: new[] { new JulieDbFixture.RevisionRow(1), new JulieDbFixture.RevisionRow(2) });
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.StartsWith("artifact-", report.Artifact.ArtifactId);
+        Assert.Equal(2L, report.Artifact.Revision);
+        Assert.Equal("partial", report.Artifact.ReferenceResolutionStatus);
+        Assert.Equal("1", report.Artifact.ReferenceResolutionVersion);
+    }
+
+    [Fact]
+    public void Read_ArtifactBlock_FallsBackWhenReferenceResolutionKeysAbsent()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { Method("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { Ident("id-benign", "SomethingElse", "src/Other.cs", null) },
+            referenceResolutionStatus: null,
+            referenceResolutionVersion: null);
+
+        var report = DeadCodeCandidateReader.Read(fx.DbPath, fx.WorkspaceRoot);
+
+        Assert.Equal("unknown", report.Artifact.ReferenceResolutionStatus);
+        Assert.Null(report.Artifact.ReferenceResolutionVersion);
+    }
+}

--- a/tests/Miller.Tests/Indexing/JulieDbFixture.cs
+++ b/tests/Miller.Tests/Indexing/JulieDbFixture.cs
@@ -108,6 +108,158 @@ internal sealed class JulieDbFixture : IDisposable
             throw new InvalidOperationException($"Expected one files row for '{relPath}', updated {updated}.");
     }
 
+    // ---- v4 reference-resolution + suppression-evidence builders --------------------------------------------
+    // These mutate the already-created DB over a fresh ReadWrite (Pooling=false) connection — the same pattern as
+    // ReplaceFileBytesAndRefreshHash. FK enforcement is OFF on the new connection (SQLite per-connection default),
+    // so a row may reference a symbol/file the fixture did not seed; the identifier_resolutions CHECK is still
+    // enforced (a 'resolved' outcome REQUIRES a non-null target). Consumed by the dead-code reader tests and Task 3.
+
+    private void ExecuteWrite(string sql, Action<SqliteParameterCollection> bind)
+    {
+        // ForeignKeys=false mirrors Create's `PRAGMA foreign_keys=OFF` so a builder may reference a symbol/file
+        // the fixture did not seed; the identifier_resolutions CHECK is enforced regardless of the FK pragma.
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        { DataSource = DbPath, Mode = SqliteOpenMode.ReadWrite, Pooling = false, ForeignKeys = false }.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        bind(command.Parameters);
+        command.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Insert an <c>identifier_resolutions</c> row: the resolved/ambiguous outcome for one identifier reference.
+    /// A <c>resolved</c> outcome REQUIRES a non-null <paramref name="targetSymbolId"/> (the CHECK enforces it).
+    /// </summary>
+    public void AddIdentifierResolution(
+        string identifierId, string? targetSymbolId, string outcome = "resolved",
+        int tier = 1, double confidence = 1.0, string method = "exact", int candidates = 1,
+        long resolvedAtRevision = 1)
+    {
+        ExecuteWrite("""
+            INSERT INTO identifier_resolutions
+                (identifier_id, target_symbol_id, tier, confidence, method, outcome, candidates, resolved_at_revision)
+            VALUES ($id, $target, $tier, $conf, $method, $outcome, $cands, $rev);
+            """, p =>
+        {
+            p.AddWithValue("$id", identifierId);
+            p.AddWithValue("$target", (object?)targetSymbolId ?? DBNull.Value);
+            p.AddWithValue("$tier", tier);
+            p.AddWithValue("$conf", confidence);
+            p.AddWithValue("$method", method);
+            p.AddWithValue("$outcome", outcome);
+            p.AddWithValue("$cands", candidates);
+            p.AddWithValue("$rev", resolvedAtRevision);
+        });
+    }
+
+    /// <summary>
+    /// Insert a <c>pending_relationships</c> row (a deferred call/reference awaiting resolution). <c>file_id</c>
+    /// is derived from <paramref name="filePath"/> via the shared helper; <paramref name="startByte"/>/
+    /// <paramref name="endByte"/> are the (nullable) origin span the reader's inside-S test consults.
+    /// </summary>
+    public void AddPendingRelationship(
+        string pendingRelationshipId, string fromSymbolId, string filePath,
+        string? callerScopeSymbolId = null, int? startByte = null, int? endByte = null,
+        string kind = "call", string targetDisplayName = "Target", string targetTerminalName = "Target",
+        int startLine = 1, double confidence = 1.0)
+    {
+        ExecuteWrite("""
+            INSERT INTO pending_relationships
+                (pending_relationship_id, from_symbol_id, caller_scope_symbol_id, file_id, path, kind,
+                 target_display_name, target_terminal_name, target_receiver, target_namespace_json,
+                 target_import_context, start_line, start_column, end_line, end_column, start_byte, end_byte,
+                 confidence, metadata_json)
+            VALUES ($id, $from, $caller, $fid, $path, $kind, $display, $terminal, NULL, '[]', NULL,
+                    $sl, NULL, NULL, NULL, $sb, $eb, $conf, NULL);
+            """, p =>
+        {
+            p.AddWithValue("$id", pendingRelationshipId);
+            p.AddWithValue("$from", fromSymbolId);
+            p.AddWithValue("$caller", (object?)callerScopeSymbolId ?? DBNull.Value);
+            p.AddWithValue("$fid", FileId(filePath));
+            p.AddWithValue("$path", filePath);
+            p.AddWithValue("$kind", kind);
+            p.AddWithValue("$display", targetDisplayName);
+            p.AddWithValue("$terminal", targetTerminalName);
+            p.AddWithValue("$sl", startLine);
+            p.AddWithValue("$sb", (object?)startByte ?? DBNull.Value);
+            p.AddWithValue("$eb", (object?)endByte ?? DBNull.Value);
+            p.AddWithValue("$conf", confidence);
+        });
+    }
+
+    /// <summary>
+    /// Insert a <c>pending_resolutions</c> row: the resolved target for a pending relationship. Independent of
+    /// <c>identifier_resolutions</c> — a pending relationship can resolve with NO identifier_resolutions row.
+    /// </summary>
+    public void AddPendingResolution(
+        string pendingRelationshipId, string targetSymbolId,
+        int tier = 1, double confidence = 1.0, string method = "exact", long resolvedAtRevision = 1)
+    {
+        ExecuteWrite("""
+            INSERT INTO pending_resolutions
+                (pending_relationship_id, target_symbol_id, tier, confidence, method, resolved_at_revision)
+            VALUES ($id, $target, $tier, $conf, $method, $rev);
+            """, p =>
+        {
+            p.AddWithValue("$id", pendingRelationshipId);
+            p.AddWithValue("$target", targetSymbolId);
+            p.AddWithValue("$tier", tier);
+            p.AddWithValue("$conf", confidence);
+            p.AddWithValue("$method", method);
+            p.AddWithValue("$rev", resolvedAtRevision);
+        });
+    }
+
+    /// <summary>
+    /// Insert a <c>structural_facts</c> row bound to <paramref name="containingSymbolId"/> (the framework-bound
+    /// source the reader treats as a suppression signal on the symbol OR any ancestor).
+    /// </summary>
+    public void AddStructuralFact(
+        string structuralFactId, string? containingSymbolId, string path,
+        string language = "csharp", string patternId = "custom.pattern.v1",
+        string captureName = "attribute", string nodeKind = "attribute")
+    {
+        ExecuteWrite("""
+            INSERT INTO structural_facts
+                (structural_fact_id, file_id, path, language, pattern_id, capture_name, node_kind,
+                 containing_symbol_id, start_line, start_column, end_line, end_column, start_byte, end_byte,
+                 confidence, metadata_json)
+            VALUES ($id, $fid, $path, $lang, $pattern, $capture, $node, $symbol,
+                    1, 1, 1, 2, 0, 1, 1.0, NULL);
+            """, p =>
+        {
+            p.AddWithValue("$id", structuralFactId);
+            p.AddWithValue("$fid", FileId(path));
+            p.AddWithValue("$path", path);
+            p.AddWithValue("$lang", language);
+            p.AddWithValue("$pattern", patternId);
+            p.AddWithValue("$capture", captureName);
+            p.AddWithValue("$node", nodeKind);
+            p.AddWithValue("$symbol", (object?)containingSymbolId ?? DBNull.Value);
+        });
+    }
+
+    /// <summary>
+    /// Insert a <c>symbol_annotations</c> row for <paramref name="symbolId"/> (the SELF-only annotated signal the
+    /// reader reads via <c>SELECT DISTINCT symbol_id FROM symbol_annotations</c>).
+    /// </summary>
+    public void AddSymbolAnnotation(
+        string annotationId, string symbolId, string annotation = "Obsolete", string annotationKey = "obsolete")
+    {
+        ExecuteWrite("""
+            INSERT INTO symbol_annotations (annotation_id, symbol_id, annotation, annotation_key, raw_text, carrier)
+            VALUES ($id, $sid, $ann, $key, NULL, NULL);
+            """, p =>
+        {
+            p.AddWithValue("$id", annotationId);
+            p.AddWithValue("$sid", symbolId);
+            p.AddWithValue("$ann", annotation);
+            p.AddWithValue("$key", annotationKey);
+        });
+    }
+
     /// <summary>
     /// A row as written into the synthesized v1 <c>symbols</c> table. The first eight fields are the M1 read
     /// projection; the remaining detail/body columns (M2 <c>ReadDetail</c>/<c>ReadBody</c>) and the typed test
@@ -277,7 +429,9 @@ internal sealed class JulieDbFixture : IDisposable
         IReadOnlyList<RelationshipRow>? relationships = null,
         string? hashAlgorithm = MillerExtractContract.ExpectedHashAlgorithm,
         IReadOnlyList<FileSpec>? extraFiles = null,
-        IReadOnlyList<SourceRegionRow>? sourceRegions = null)
+        IReadOnlyList<SourceRegionRow>? sourceRegions = null,
+        string? referenceResolutionStatus = "partial",
+        string? referenceResolutionVersion = "1")
     {
         string dir = Path.Combine(Path.GetTempPath(), "miller-julie-fixture-" + Guid.NewGuid().ToString("N"));
         System.IO.Directory.CreateDirectory(dir);
@@ -325,6 +479,13 @@ internal sealed class JulieDbFixture : IDisposable
             Exec(conn, LanguageCapabilityFixturesDdl);
             Exec(conn, LanguageCapabilityGapsDdl);
             Exec(conn, PendingRelationshipsDdl);
+            Exec(conn, PendingRelationshipsIndexesDdl);
+            // v4 reference-resolution overlay tables + their pinned indexes (created empty; seeded by the
+            // AddIdentifierResolution / AddPendingResolution builders when a test needs resolution evidence).
+            Exec(conn, IdentifierResolutionsDdl);
+            Exec(conn, IdentifierResolutionsIndexDdl);
+            Exec(conn, PendingResolutionsDdl);
+            Exec(conn, PendingResolutionsIndexDdl);
             Exec(conn, TypeFactsDdl);
             if (createMetadataTable) Exec(conn, MetadataDdl);
 
@@ -584,6 +745,13 @@ internal sealed class JulieDbFixture : IDisposable
 
                 if (hashAlgorithm is not null)
                     Meta("hash_algorithm", hashAlgorithm);
+
+                // v4 reference-resolution metadata keys (schema 4 / product 2.9.0). Included by default for
+                // fidelity; a test passes null for either to exercise the reader's unknown/null fallbacks.
+                if (referenceResolutionStatus is not null)
+                    Meta("reference_resolution_status", referenceResolutionStatus);
+                if (referenceResolutionVersion is not null)
+                    Meta("reference_resolution_version", referenceResolutionVersion);
             }
         }
 
@@ -1182,6 +1350,9 @@ internal sealed class JulieDbFixture : IDisposable
         );
         """;
 
+    // v4 pinned shape: the columns are unchanged from v1, but the FKs (from_symbol_id / caller_scope_symbol_id /
+    // file_id) and the four lookup indexes are added so the synthetic artifact matches the reference-resolution
+    // contract the dead-code reader depends on (schema v4 / product 2.9.0).
     private const string PendingRelationshipsDdl = """
         CREATE TABLE IF NOT EXISTS pending_relationships (
             pending_relationship_id TEXT PRIMARY KEY,
@@ -1202,9 +1373,55 @@ internal sealed class JulieDbFixture : IDisposable
             start_byte INTEGER,
             end_byte INTEGER,
             confidence REAL NOT NULL,
-            metadata_json TEXT
+            metadata_json TEXT,
+            FOREIGN KEY (from_symbol_id) REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+            FOREIGN KEY (caller_scope_symbol_id) REFERENCES symbols(symbol_id) ON DELETE SET NULL,
+            FOREIGN KEY (file_id) REFERENCES files(file_id) ON DELETE CASCADE
         );
         """;
+
+    private const string PendingRelationshipsIndexesDdl = """
+        CREATE INDEX IF NOT EXISTS idx_pending_terminal ON pending_relationships(target_terminal_name);
+        CREATE INDEX IF NOT EXISTS idx_pending_file ON pending_relationships(file_id);
+        CREATE INDEX IF NOT EXISTS idx_pending_from ON pending_relationships(from_symbol_id);
+        CREATE INDEX IF NOT EXISTS idx_pending_caller_scope ON pending_relationships(caller_scope_symbol_id);
+        """;
+
+    // v4 overlay: identifier_resolutions (the resolved/ambiguous outcome for a plain identifier reference). The
+    // CHECK ties outcome='resolved' to a non-null target_symbol_id — a faithful copy of the pinned contract.
+    private const string IdentifierResolutionsDdl = """
+        CREATE TABLE IF NOT EXISTS identifier_resolutions (
+            identifier_id TEXT PRIMARY KEY REFERENCES identifiers(identifier_id) ON DELETE CASCADE,
+            target_symbol_id TEXT REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+            tier INTEGER,
+            confidence REAL,
+            method TEXT,
+            outcome TEXT NOT NULL,
+            candidates INTEGER,
+            resolved_at_revision INTEGER NOT NULL,
+            CHECK ((outcome = 'resolved') = (target_symbol_id IS NOT NULL))
+        );
+        """;
+
+    private const string IdentifierResolutionsIndexDdl =
+        "CREATE INDEX IF NOT EXISTS idx_identifier_resolutions_target ON identifier_resolutions(target_symbol_id);";
+
+    // v4 overlay: pending_resolutions (the resolved target for a deferred/pending relationship). Independent of
+    // identifier_resolutions — a pending relationship can resolve with no identifier_resolutions row.
+    private const string PendingResolutionsDdl = """
+        CREATE TABLE IF NOT EXISTS pending_resolutions (
+            pending_relationship_id TEXT PRIMARY KEY
+                REFERENCES pending_relationships(pending_relationship_id) ON DELETE CASCADE,
+            target_symbol_id TEXT NOT NULL REFERENCES symbols(symbol_id) ON DELETE CASCADE,
+            tier INTEGER NOT NULL,
+            confidence REAL NOT NULL,
+            method TEXT NOT NULL,
+            resolved_at_revision INTEGER NOT NULL
+        );
+        """;
+
+    private const string PendingResolutionsIndexDdl =
+        "CREATE INDEX IF NOT EXISTS idx_pending_resolutions_target ON pending_resolutions(target_symbol_id);";
 
     private const string TypeFactsDdl = """
         CREATE TABLE IF NOT EXISTS type_facts (

--- a/tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs
+++ b/tests/Miller.Tests/Indexing/JulieDbFixtureCurrentSchemaTests.cs
@@ -296,4 +296,115 @@ public sealed class JulieDbFixtureCurrentSchemaTests
             "pending_relationships", "type_facts" })
             Assert.True(TableExists(c, t), $"v1 artifact table '{t}' must exist");
     }
+
+    // ---- v4 reference-resolution tables (identifier_resolutions / pending_resolutions) + pinned indexes ----
+
+    [Fact]
+    public void Fixture_EmitsV4ResolutionTables()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+        using var c = Open(fx.DbPath);
+        foreach (var t in new[] { "identifier_resolutions", "pending_resolutions", "pending_relationships" })
+            Assert.True(TableExists(c, t), $"v4 resolution table '{t}' must exist");
+    }
+
+    [Fact]
+    public void Fixture_IdentifierResolutions_UseCurrentColumnSet()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+        using var c = Open(fx.DbPath);
+        foreach (var column in new[]
+        {
+            "identifier_id", "target_symbol_id", "tier", "confidence", "method",
+            "outcome", "candidates", "resolved_at_revision",
+        })
+            Assert.True(ColumnExists(c, "identifier_resolutions", column),
+                $"identifier_resolutions.{column} must exist");
+    }
+
+    [Fact]
+    public void Fixture_IdentifierResolutions_EnforceOutcomeTargetCheckConstraint()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+
+        // A 'resolved' outcome REQUIRES a non-null target_symbol_id (CHECK ((outcome='resolved') = (target IS NOT NULL))).
+        var resolvedWithoutTarget = Assert.Throws<SqliteException>(() => ExecWrite(fx.DbPath, """
+            INSERT INTO identifier_resolutions
+                (identifier_id, target_symbol_id, tier, confidence, method, outcome, candidates, resolved_at_revision)
+            VALUES ('ir-bad-1', NULL, 1, 1.0, 'exact', 'resolved', 1, 1);
+            """));
+        Assert.Contains("CHECK", resolvedWithoutTarget.Message, StringComparison.OrdinalIgnoreCase);
+
+        // A non-'resolved' outcome REQUIRES a null target_symbol_id.
+        Assert.Throws<SqliteException>(() => ExecWrite(fx.DbPath, """
+            INSERT INTO identifier_resolutions
+                (identifier_id, target_symbol_id, tier, confidence, method, outcome, candidates, resolved_at_revision)
+            VALUES ('ir-bad-2', 'sym-x', 1, 1.0, 'exact', 'ambiguous', 3, 1);
+            """));
+
+        // Both consistent shapes insert cleanly.
+        ExecWrite(fx.DbPath, """
+            INSERT INTO identifier_resolutions
+                (identifier_id, target_symbol_id, tier, confidence, method, outcome, candidates, resolved_at_revision)
+            VALUES ('ir-ok-resolved', 'sym-x', 1, 1.0, 'exact', 'resolved', 1, 1),
+                   ('ir-ok-unresolved', NULL, 1, 1.0, 'exact', 'ambiguous', 3, 1);
+            """);
+        using var c = Open(fx.DbPath);
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM identifier_resolutions;";
+        Assert.Equal(2L, System.Convert.ToInt64(cmd.ExecuteScalar()));
+    }
+
+    [Fact]
+    public void Fixture_PendingResolutions_UseCurrentColumnSet()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+        using var c = Open(fx.DbPath);
+        foreach (var column in new[]
+        {
+            "pending_relationship_id", "target_symbol_id", "tier", "confidence", "method", "resolved_at_revision",
+        })
+            Assert.True(ColumnExists(c, "pending_resolutions", column),
+                $"pending_resolutions.{column} must exist");
+    }
+
+    [Fact]
+    public void Fixture_PendingRelationships_UseCurrentColumnSet()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+        using var c = Open(fx.DbPath);
+        foreach (var column in new[]
+        {
+            "pending_relationship_id", "from_symbol_id", "caller_scope_symbol_id", "file_id", "path", "kind",
+            "target_display_name", "target_terminal_name", "target_receiver", "target_namespace_json",
+            "target_import_context", "start_byte", "end_byte", "confidence",
+        })
+            Assert.True(ColumnExists(c, "pending_relationships", column),
+                $"pending_relationships.{column} must exist");
+    }
+
+    [Fact]
+    public void Fixture_V4ResolutionIndexes_Exist()
+    {
+        using var fx = JulieDbFixture.CreateDefault();
+        using var c = Open(fx.DbPath);
+        foreach (var index in new[]
+        {
+            "idx_identifier_resolutions_target", "idx_pending_terminal", "idx_pending_file",
+            "idx_pending_from", "idx_pending_caller_scope", "idx_pending_resolutions_target",
+        })
+            Assert.True(IndexExists(c, index), $"pinned v4 index '{index}' must exist");
+    }
+
+    private static void ExecWrite(string dbPath, string sql)
+    {
+        // ForeignKeys=false matches the fixture's relaxed-FK philosophy so the CHECK-constraint assertions do not
+        // trip on unseeded target_symbol_id references; the CHECK itself is enforced independent of the FK pragma.
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        { DataSource = dbPath, Mode = SqliteOpenMode.ReadWrite, Pooling = false, ForeignKeys = false }.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
 }

--- a/tests/Miller.Tests/Indexing/MillerExtractContractTests.cs
+++ b/tests/Miller.Tests/Indexing/MillerExtractContractTests.cs
@@ -11,14 +11,16 @@ namespace Miller.Tests.Indexing;
 public sealed class MillerExtractContractTests
 {
     [Fact]
-    public void ContractPinsJulieExtractV3Versions()
+    public void ContractPinsJulieExtractSchemaV4Versions()
     {
-        Assert.Equal(3, MillerExtractContract.ExpectedSchemaVersion);
-        Assert.Equal(3, MillerExtractContract.ExpectedSqliteSchemaVersion);
+        // Schema v4 (product 2.9.0) adds workspace reference resolution; the extract contract and
+        // report schema stayed at 3 (additive artifact change, verified on a live 2.9.0 scan report).
+        Assert.Equal(4, MillerExtractContract.ExpectedSchemaVersion);
+        Assert.Equal(4, MillerExtractContract.ExpectedSqliteSchemaVersion);
         Assert.Equal(3, MillerExtractContract.ExpectedExtractContractVersion);
         Assert.Equal(3, MillerExtractContract.ExpectedReportSchemaVersion);
         Assert.Equal("blake3", MillerExtractContract.ExpectedHashAlgorithm);
-        Assert.Equal("2.8.1", MillerExtractContract.PinnedJulieExtractVersion);
+        Assert.Equal("2.9.0", MillerExtractContract.PinnedJulieExtractVersion);
         Assert.False(string.IsNullOrWhiteSpace(MillerExtractContract.PinnedJulieExtractVersion));
     }
 

--- a/tests/Miller.Tests/Indexing/MillerExtractContractTests.cs
+++ b/tests/Miller.Tests/Indexing/MillerExtractContractTests.cs
@@ -20,7 +20,7 @@ public sealed class MillerExtractContractTests
         Assert.Equal(3, MillerExtractContract.ExpectedExtractContractVersion);
         Assert.Equal(3, MillerExtractContract.ExpectedReportSchemaVersion);
         Assert.Equal("blake3", MillerExtractContract.ExpectedHashAlgorithm);
-        Assert.Equal("2.9.0", MillerExtractContract.PinnedJulieExtractVersion);
+        Assert.Equal("2.10.0", MillerExtractContract.PinnedJulieExtractVersion);
         Assert.False(string.IsNullOrWhiteSpace(MillerExtractContract.PinnedJulieExtractVersion));
     }
 

--- a/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+++ b/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
@@ -2850,4 +2850,266 @@ public sealed class CliDispatchTests : IDisposable
         -  public User GetUser(int id) {
         +  public User GetUser(int id) {
         """;
+
+    // ---------- references candidates (dead-code candidates surface, Task 3) ----------
+
+    private static JulieDbFixture.SymbolRow DeadMethod(
+        string id, string name, string path, string? visibility = "private", string? parentId = null,
+        string kind = "method", string language = "csharp", int startLine = 1)
+        => new(id, name, kind, language, path, $"sig {name}", startLine, parentId)
+        { Visibility = visibility, StartByte = 0, EndByte = 40 };
+
+    private static JulieDbFixture.IdentifierRow DeadIdent(
+        string id, string name, string path, string? containingSymbolId,
+        string language = "csharp", int startByte = 100, int endByte = 110)
+        => new(id, name, "call", language, path, 1, containingSymbolId) { StartByte = startByte, EndByte = endByte };
+
+    private static void DropTable(string dbPath, string table)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        { DataSource = dbPath, Mode = SqliteOpenMode.ReadWrite, Pooling = false, ForeignKeys = false }.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"DROP TABLE {table};";
+        command.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public void ReferencesCandidates_Compact_ListsDeadPrivateSymbol_WithVerbatimResolverHeader()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { DeadMethod("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            // A benign csharp identifier so csharp coverage has IdentifierCount > 0 (else low_evidence_language fires).
+            identifiers: new[] { DeadIdent("id-benign", "SomethingElse", "src/Other.cs", null) });
+
+        var (code, outText, errText) = Run(
+            new[] { "references", "candidates" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        Assert.Equal(0, code);
+        Assert.Empty(errText);
+        // The resolver clause is VERBATIM (Global Constraints), incl. the trailing period.
+        Assert.Contains(
+            "resolver: partial — candidates are facts to check, not deletions to make.",
+            outText);
+        Assert.Contains("candidates: 1 of 1 symbols examined", outText);
+        // One line per candidate.
+        Assert.Contains("UnusedHelper method csharp src/Helper.cs:1 private evidence=name", outText);
+        Assert.Contains("name_matches=0 resolved_in=0 pending_in=0 calls_in=0", outText);
+        // Footer: all nine suppression ids are named (each with a count).
+        foreach (var id in Miller.Core.DeadCode.DeadCodeCandidates.SuppressionRuleIds)
+            Assert.Contains(id + "=", outText);
+        Assert.Contains("literal_scan: files_scanned=", outText);
+        // Per-language coverage: csharp has 1 identifier, 0 resolved -> 0.0% (< 10%) -> name-evidence only.
+        Assert.Contains("csharp: 0.0%", outText);
+        Assert.Contains("name-evidence only", outText);
+    }
+
+    [Fact]
+    public void ReferencesCandidates_Json_EmitsEveryContractField()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { DeadMethod("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { DeadIdent("id-benign", "SomethingElse", "src/Other.cs", null) },
+            revisions: new[] { new JulieDbFixture.RevisionRow(1), new JulieDbFixture.RevisionRow(2) });
+
+        var (code, outText, errText) = Run(
+            new[] { "references", "candidates", "--json" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        Assert.Equal(0, code);
+        Assert.Empty(errText);
+        using JsonDocument doc = JsonDocument.Parse(outText);
+        JsonElement root = doc.RootElement;
+
+        Assert.Equal(1, root.GetProperty("schema_version").GetInt32());
+
+        JsonElement cand = Assert.Single(root.GetProperty("candidates").EnumerateArray());
+        Assert.Equal("sym-cand", cand.GetProperty("symbol_id").GetString());
+        Assert.Equal("UnusedHelper", cand.GetProperty("name").GetString());
+        Assert.Equal("method", cand.GetProperty("kind").GetString());
+        Assert.Equal("csharp", cand.GetProperty("language").GetString());
+        Assert.Equal("src/Helper.cs", cand.GetProperty("path").GetString());
+        Assert.Equal(1, cand.GetProperty("start_line").GetInt32());
+        Assert.Equal("private", cand.GetProperty("visibility").GetString());
+        Assert.Equal("name", cand.GetProperty("evidence_label").GetString());
+        JsonElement ev = cand.GetProperty("evidence");
+        Assert.Equal(0, ev.GetProperty("name_matches").GetInt32());
+        Assert.Equal(0, ev.GetProperty("resolved_inbound").GetInt32());
+        Assert.Equal(0, ev.GetProperty("pending_resolved_inbound").GetInt32());
+        Assert.Equal(0, ev.GetProperty("calls_inbound").GetInt32());
+
+        JsonElement supp = root.GetProperty("suppressions");
+        foreach (var id in Miller.Core.DeadCode.DeadCodeCandidates.SuppressionRuleIds)
+            Assert.True(supp.TryGetProperty(id, out _), $"missing suppression key {id}");
+
+        JsonElement scan = root.GetProperty("literal_scan");
+        Assert.True(scan.TryGetProperty("files_scanned", out _));
+        Assert.True(scan.TryGetProperty("files_skipped_stale", out _));
+
+        JsonElement cov = Assert.Single(
+            root.GetProperty("language_coverage").EnumerateArray(),
+            c => c.GetProperty("language").GetString() == "csharp");
+        Assert.Equal(1, cov.GetProperty("identifiers").GetInt32());
+        Assert.True(cov.TryGetProperty("resolved_pct", out _));
+
+        Assert.Equal(1, root.GetProperty("examined").GetInt32());
+
+        JsonElement art = root.GetProperty("artifact");
+        Assert.StartsWith("artifact-", art.GetProperty("artifact_id").GetString());
+        Assert.Equal(2, art.GetProperty("revision").GetInt64());
+        Assert.Equal("partial", art.GetProperty("reference_resolution_status").GetString());
+        Assert.Equal("1", art.GetProperty("reference_resolution_version").GetString());
+    }
+
+    [Fact]
+    public void ReferencesCandidates_Json_ResolvedPctIsZeroToHundredScaleOneDecimal()
+    {
+        // A language with exactly 10 identifiers, one of which resolves -> 1/10 -> 10.0% (NOT 0.1).
+        var identifiers = Enumerable.Range(0, 10)
+            .Select(n => DeadIdent($"id-py-{n}", $"pyref{n}", "app/x.py", null, language: "python",
+                startByte: 100 + (n * 10), endByte: 105 + (n * 10)))
+            .ToArray();
+
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { DeadMethod("sym-py", "PyHelper", "app/x.py", language: "python") },
+            identifiers: identifiers);
+        fx.AddIdentifierResolution("id-py-0", targetSymbolId: "sym-py", outcome: "resolved");
+
+        var (code, outText, errText) = Run(
+            new[] { "references", "candidates", "--json" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        Assert.Equal(0, code);
+        Assert.Empty(errText);
+        using JsonDocument doc = JsonDocument.Parse(outText);
+        JsonElement python = Assert.Single(
+            doc.RootElement.GetProperty("language_coverage").EnumerateArray(),
+            c => c.GetProperty("language").GetString() == "python");
+        Assert.Equal(10, python.GetProperty("identifiers").GetInt32());
+        Assert.Equal(10.0, python.GetProperty("resolved_pct").GetDouble());
+    }
+
+    [Fact]
+    public void ReferencesCandidates_Limit_TruncatesCandidateListButNotTotals()
+    {
+        JulieDbFixture Build() => JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[]
+            {
+                DeadMethod("sym-a", "AlphaHelper", "src/A.cs"),
+                DeadMethod("sym-b", "BetaHelper", "src/B.cs"),
+                DeadMethod("sym-c", "GammaHelper", "src/C.cs"),
+            },
+            identifiers: new[] { DeadIdent("id-benign", "SomethingElse", "src/Other.cs", null) });
+
+        using (var fx = Build())
+        {
+            var (code, outText, errText) = Run(
+                new[] { "references", "candidates", "--limit", "1", "--json" },
+                Context(fx.DbPath, fx.WorkspaceRoot));
+
+            Assert.Equal(0, code);
+            Assert.Empty(errText);
+            using JsonDocument doc = JsonDocument.Parse(outText);
+            JsonElement root = doc.RootElement;
+            // The candidate list honours --limit (sorted by path, so src/A.cs is first).
+            JsonElement only = Assert.Single(root.GetProperty("candidates").EnumerateArray());
+            Assert.Equal("AlphaHelper", only.GetProperty("name").GetString());
+            // examined is a FULL total (never limited) — all three private methods were examined.
+            Assert.Equal(3, root.GetProperty("examined").GetInt32());
+        }
+
+        using (var fx = Build())
+        {
+            var (code, outText, _) = Run(
+                new[] { "references", "candidates", "--limit", "1" },
+                Context(fx.DbPath, fx.WorkspaceRoot));
+            Assert.Equal(0, code);
+            Assert.Contains("showing top 1 of 3 by path", outText);
+        }
+    }
+
+    [Fact]
+    public void ReferencesCandidates_IncompatibleExtractSchema_IsOperationalExitThree()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { DeadMethod("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { DeadIdent("id-benign", "SomethingElse", "src/Other.cs", null) });
+        DowngradeArtifactSchema(fx.DbPath);
+
+        var (code, _, errText) = Run(
+            new[] { "references", "candidates" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        // cli-eros-v1: an unusable index (schema mismatch) is an OPERATIONAL failure (exit 3), answered by a rebuild.
+        Assert.Equal(3, code);
+        Assert.Contains("references failed", errText);
+    }
+
+    [Fact]
+    public void ReferencesCandidates_V4MissingResolutionTable_IsOperationalExitThree()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema, JulieDbFixture.PinnedContract,
+            new[] { DeadMethod("sym-cand", "UnusedHelper", "src/Helper.cs") },
+            identifiers: new[] { DeadIdent("id-benign", "SomethingElse", "src/Other.cs", null) });
+        // A v4-stamped artifact missing a hard-required resolution table (Task 2 reader validation) -> exit 3.
+        DropTable(fx.DbPath, "identifier_resolutions");
+
+        var (code, _, errText) = Run(
+            new[] { "references", "candidates" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        Assert.Equal(3, code);
+        Assert.Contains("references failed", errText);
+    }
+
+    [Fact]
+    public void ReferencesExport_StillRoutesToJsonlExport_WhenOpIsNotCandidates()
+    {
+        using var fx = JulieDbFixture.CreateForEdit();
+
+        var (code, outText, errText) = Run(
+            new[] { "references", "export", "--jsonl" },
+            Context(fx.DbPath, fx.WorkspaceRoot));
+
+        Assert.Equal(0, code);
+        Assert.Empty(errText);
+        // The export path emits one JSONL row per identifier (schema_version present, no candidates envelope).
+        Assert.Contains("\"identifier_id\":", outText);
+        Assert.DoesNotContain("\"candidates\":", outText);
+    }
+
+    [Fact]
+    public void Capabilities_AdvertisesReferencesCandidatesSurface()
+    {
+        var (jsonCode, jsonOut, _) = Run(
+            new[] { "capabilities", "--json" }, Context(Path.Combine(_dir, "symbols.db")));
+        Assert.Equal(0, jsonCode);
+        using JsonDocument doc = JsonDocument.Parse(jsonOut);
+        JsonElement root = doc.RootElement;
+
+        Assert.True(root.GetProperty("optional_features").GetProperty("references_candidates").GetBoolean());
+        Assert.Contains(
+            "references candidates --json",
+            root.GetProperty("json_commands").EnumerateArray().Select(x => x.GetString()));
+        JsonElement contract = Assert.Single(
+            root.GetProperty("json_contracts").EnumerateArray(),
+            item => item.GetProperty("name").GetString() == "references_candidates");
+        Assert.Equal("references candidates --json", contract.GetProperty("command").GetString());
+        Assert.Equal(1, contract.GetProperty("schema_version").GetInt32());
+        Assert.Equal("docs/contracts/references-candidates-v1.md", contract.GetProperty("doc").GetString());
+
+        var (compactCode, compactOut, _) = Run(
+            new[] { "capabilities" }, Context(Path.Combine(_dir, "symbols.db")));
+        Assert.Equal(0, compactCode);
+        Assert.Contains("references_candidates: enabled", compactOut);
+        Assert.Contains("references candidates --json", compactOut);
+        Assert.Contains("references-candidates-v1.md", compactOut);
+    }
 }

--- a/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+++ b/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
@@ -333,7 +333,7 @@ public sealed class CliDispatchTests : IDisposable
         JsonElement metricsContract = Assert.Single(
             root.GetProperty("json_contracts").EnumerateArray(),
             item => item.GetProperty("name").GetString() == "metrics");
-        Assert.Equal("metrics <churn|clones|complexity> --json", metricsContract.GetProperty("command").GetString());
+        Assert.Equal("metrics <churn|clones|complexity|risk> --json", metricsContract.GetProperty("command").GetString());
         Assert.Equal(1, metricsContract.GetProperty("schema_version").GetInt32());
 
         JsonElement workspaceStatusContract = Assert.Single(

--- a/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+++ b/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
@@ -282,8 +282,8 @@ public sealed class CliDispatchTests : IDisposable
         Assert.StartsWith("1.4.5", root.GetProperty("miller").GetProperty("version").GetString());
 
         JsonElement julie = root.GetProperty("julie_extract");
-        Assert.Equal("2.8.1", julie.GetProperty("pinned_version").GetString());
-        Assert.Equal(3, julie.GetProperty("sqlite_schema_version").GetInt64());
+        Assert.Equal("2.9.0", julie.GetProperty("pinned_version").GetString());
+        Assert.Equal(4, julie.GetProperty("sqlite_schema_version").GetInt64());
         Assert.Equal(3, julie.GetProperty("extract_contract_version").GetInt64());
         Assert.Equal(3, julie.GetProperty("report_schema_version").GetInt64());
         Assert.Equal("blake3", julie.GetProperty("hash_algorithm").GetString());

--- a/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
+++ b/tests/Miller.Tests/Server/Cli/CliDispatchTests.cs
@@ -282,7 +282,7 @@ public sealed class CliDispatchTests : IDisposable
         Assert.StartsWith("1.4.5", root.GetProperty("miller").GetProperty("version").GetString());
 
         JsonElement julie = root.GetProperty("julie_extract");
-        Assert.Equal("2.9.0", julie.GetProperty("pinned_version").GetString());
+        Assert.Equal("2.10.0", julie.GetProperty("pinned_version").GetString());
         Assert.Equal(4, julie.GetProperty("sqlite_schema_version").GetInt64());
         Assert.Equal(3, julie.GetProperty("extract_contract_version").GetInt64());
         Assert.Equal(3, julie.GetProperty("report_schema_version").GetInt64());

--- a/tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs
+++ b/tests/Miller.Tests/Server/Cli/DeadCodeCandidatesScaleTests.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Miller.Indexing;
+using Miller.Server;
+using Miller.Server.Cli;
+using Miller.Tests;
+using Xunit;
+
+namespace Miller.Tests.Server.Cli;
+
+/// <summary>
+/// The dead-code-candidates end-to-end Scale proof: restore julie-extract → scan a tiny throwaway repo with the
+/// REAL pinned binary → run <c>miller references candidates</c> (compact AND <c>--json</c>) through the production
+/// <see cref="CliDispatch"/> against the live v4 artifact, and assert the deterministic surface behaves against a
+/// real extract — the deliberately-dead private helper surfaces as a candidate, the private member referenced ONLY
+/// through a reflection string literal is suppressed under <c>string_literal_match</c> (the two-phase literal scan
+/// reading real <c>source_regions</c>), and per-language coverage renders. Depends on the binary + a real extract,
+/// so it is <c>[Trait("Category","Scale")]</c> and EXCLUDED from the default fast suite; it
+/// <see cref="Assert.Skip"/>s (never fails) if <c>.tools/julie-extract</c> is absent.
+/// </summary>
+[Trait("Category", "Scale")]
+public sealed class DeadCodeCandidatesScaleTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public DeadCodeCandidatesScaleTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void Live_ScanThenReferencesCandidates_FindsDeadHelper_SuppressesReflectionStringMember()
+    {
+        string binary = ScaleTestSupport.RequireJulieServer();
+
+        string work = Path.Combine(Path.GetTempPath(), "miller-deadcode-live-" + Guid.NewGuid().ToString("N"));
+        string repo = Path.Combine(work, "repo");
+        string millerDir = Path.Combine(repo, ".miller");
+        string db = Path.Combine(millerDir, "symbols.db");
+        Directory.CreateDirectory(repo);
+        Directory.CreateDirectory(millerDir);
+
+        try
+        {
+            // WidgetFactory (public) has two private methods that differ ONLY in whether their name appears in a
+            // string literal: InvokeSecretly is referenced solely by the reflection string "InvokeSecretly" (so the
+            // two-phase literal scan must suppress it under string_literal_match), while DeadPrivateHelper is
+            // referenced by nothing at all (so it must surface as a dead-code candidate). Every public member is
+            // suppressed as public_api, so the two private methods are the only symbols reaching the literal scan.
+            File.WriteAllText(Path.Combine(repo, "Widgets.cs"), """
+                using System;
+                using System.Reflection;
+
+                namespace Shop;
+
+                public sealed class WidgetFactory
+                {
+                    public void BuildReflectively()
+                    {
+                        MethodInfo? m = typeof(WidgetFactory).GetMethod(
+                            "InvokeSecretly", BindingFlags.Instance | BindingFlags.NonPublic);
+                        m?.Invoke(this, null);
+                    }
+
+                    public int Run(int seed)
+                    {
+                        return seed + 1;
+                    }
+
+                    // Referenced ONLY through the reflection string above -> string_literal_match suppression.
+                    private void InvokeSecretly()
+                    {
+                        Console.WriteLine("secret");
+                    }
+
+                    // Referenced by nothing (no name match, no resolution, no call) -> a dead-code candidate.
+                    private int DeadPrivateHelper(int value)
+                    {
+                        return value * 2;
+                    }
+                }
+                """);
+
+            // --- scan with the real binary into the Miller-owned .miller/symbols.db ---
+            var runner = new JulieExtractRunner(binary);
+            ExtractReport report = runner.Scan(repo, db, force: true);
+            Assert.NotEqual("failed", report.Status);
+            Assert.True(report.SymbolsExtracted > 0);
+
+            WorkspaceContext ctx = WorkspaceContext.Create(repo, ScaleTestSupport.RepoRoot()) with
+            {
+                ExtractDbPath = db,
+            };
+
+            // --- compact: end-to-end through the production CLI ---
+            var compactOut = new StringWriter();
+            var compactErr = new StringWriter();
+            var clock = Stopwatch.StartNew();
+            int compactCode = CliDispatch.Run(new[] { "references", "candidates" }, ctx, compactOut, compactErr);
+            clock.Stop();
+            string compactText = compactOut.ToString();
+
+            Assert.True(compactCode == 0, $"compact exit {compactCode}; stderr: {compactErr}");
+            Assert.Contains("resolver:", compactText);
+            Assert.Contains("DeadPrivateHelper", compactText);
+            // Per-language coverage renders (csharp is the only language in this fixture).
+            Assert.Contains("csharp:", compactText);
+
+            // --- json: assert the reflection-string member is suppressed, the dead helper is a candidate ---
+            var jsonOut = new StringWriter();
+            var jsonErr = new StringWriter();
+            int jsonCode = CliDispatch.Run(new[] { "references", "candidates", "--json" }, ctx, jsonOut, jsonErr);
+            Assert.True(jsonCode == 0, $"json exit {jsonCode}; stderr: {jsonErr}");
+
+            using JsonDocument doc = JsonDocument.Parse(jsonOut.ToString());
+            JsonElement root = doc.RootElement;
+
+            // The reflection-named private member fell to the two-phase literal scan.
+            Assert.True(
+                root.GetProperty("suppressions").GetProperty("string_literal_match").GetInt32() >= 1,
+                "expected string_literal_match >= 1 (InvokeSecretly suppressed via reflection string literal)");
+
+            string[] candidateNames = root.GetProperty("candidates").EnumerateArray()
+                .Select(c => c.GetProperty("name").GetString()!)
+                .ToArray();
+            Assert.Contains("DeadPrivateHelper", candidateNames);
+            Assert.DoesNotContain("InvokeSecretly", candidateNames);
+
+            // Per-language coverage renders in JSON too, always carrying the resolution status.
+            Assert.Contains(
+                root.GetProperty("language_coverage").EnumerateArray(),
+                c => c.GetProperty("language").GetString() == "csharp");
+            Assert.False(
+                string.IsNullOrWhiteSpace(root.GetProperty("artifact")
+                    .GetProperty("reference_resolution_status").GetString()));
+
+            // PERF (Task 5 judges this on the real 38k-symbol repo): capture the CLI wall-clock here.
+            _output.WriteLine(
+                $"[deadcode-scale] references candidates CLI wall-clock: {clock.ElapsedMilliseconds} ms " +
+                $"(scan {report.SymbolsExtracted} symbols)");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            try { Directory.Delete(work, recursive: true); } catch (IOException) { }
+        }
+    }
+}

--- a/tests/Miller.Tests/Server/LiveWorkspaceTests.cs
+++ b/tests/Miller.Tests/Server/LiveWorkspaceTests.cs
@@ -117,7 +117,7 @@ public sealed class LiveWorkspaceTests : IDisposable
         var crossRefresh = new CrossWorkspaceRefreshService(registry, runner, SymbolSearchSidecar.Disabled);
 
         var tool = new WorkspaceTool(
-            holder, workspace, indexer, freshness, probe, ledger, runner, registry, crossRefresh,
+            holder, workspace, indexer, freshness, probe, bootstrap, ledger, runner, registry, crossRefresh,
             SymbolSearchSidecar.Disabled,
             NullLogger<WorkspaceTool>.Instance);
         return (tool, indexer, holder, ledger, root, dbPath, runner);

--- a/tests/Miller.Tests/Server/ReportToolTests.cs
+++ b/tests/Miller.Tests/Server/ReportToolTests.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Miller.Core.Search;
+using Miller.Indexing;
+using Miller.Server.Git;
+using Miller.Server.Tools;
+using Miller.Tests.Indexing;
+using Xunit;
+
+namespace Miller.Tests.Server;
+
+public sealed class ReportToolTests
+{
+    [Fact]
+    public void RunJson_ComposesIndexHealthComplexityClonesChurnAndRisk()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccee01", "RiskySymbol", "src/Risky.cs", 5),
+                Row("aa11223344556677889900aabbccee02", "CopyA", "src/A.cs", 3),
+                Row("aa11223344556677889900aabbccee03", "CopyB", "src/B.cs", 7),
+            });
+        Exec(fx.DbPath, """
+            UPDATE symbols SET body_hash = 'report-clone-hash' WHERE symbol_id IN
+                ('aa11223344556677889900aabbccee02', 'aa11223344556677889900aabbccee03');
+            """);
+        SeedComplexity(fx.DbPath, "metric-risky", "src/Risky.cs", "aa11223344556677889900aabbccee01", 18, 3);
+
+        ReportToolResult result = ReportTool.Run(
+            fx.DbPath,
+            fx.WorkspaceRoot,
+            range: "HEAD~1..HEAD",
+            sectionLimit: 5,
+            json: true,
+            includeTests: true,
+            historyReader: CommitTouching("src/Risky.cs", 5, "abc1234"),
+            regionIndex: null);
+
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement root = doc.RootElement;
+        Assert.Equal(1, root.GetProperty("schema_version").GetInt32());
+        Assert.Equal("report", root.GetProperty("operation").GetString());
+
+        JsonElement index = root.GetProperty("index");
+        Assert.True(index.GetProperty("available").GetBoolean());
+        Assert.Equal(3, index.GetProperty("symbols").GetInt64());
+        Assert.Equal(3, index.GetProperty("files").GetInt64());
+        Assert.Equal(1, index.GetProperty("languages").GetInt64());
+
+        Assert.True(root.GetProperty("extraction_health").GetProperty("available").GetBoolean());
+
+        JsonElement markers = root.GetProperty("markers");
+        Assert.False(markers.GetProperty("available").GetBoolean());
+        Assert.False(string.IsNullOrWhiteSpace(markers.GetProperty("reason").GetString()));
+
+        JsonElement complexity = root.GetProperty("complexity");
+        Assert.True(complexity.GetProperty("available").GetBoolean());
+        Assert.Equal("RiskySymbol",
+            complexity.GetProperty("hotspots")[0].GetProperty("symbol_name").GetString());
+
+        JsonElement clones = root.GetProperty("clones");
+        Assert.True(clones.GetProperty("available").GetBoolean());
+        Assert.Equal("report-clone-hash",
+            clones.GetProperty("groups")[0].GetProperty("body_hash").GetString());
+
+        JsonElement churn = root.GetProperty("churn");
+        Assert.True(churn.GetProperty("available").GetBoolean());
+        Assert.Equal(1, churn.GetProperty("rows").GetArrayLength());
+
+        JsonElement risk = root.GetProperty("risk");
+        Assert.True(risk.GetProperty("available").GetBoolean());
+        Assert.Equal("RiskySymbol", risk.GetProperty("rows")[0].GetProperty("symbol_name").GetString());
+        Assert.Equal(23, risk.GetProperty("rows")[0].GetProperty("score").GetInt64());
+
+        // Consensus: no dead-code section until reference resolution earns confidence.
+        Assert.False(root.TryGetProperty("dead_code", out _));
+    }
+
+    [Fact]
+    public void RunJson_GitFailureMarksChurnAndRiskUnavailableWithoutFailingTheReport()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccee11", "Symbol", "src/S.cs", 5),
+            });
+
+        ReportToolResult result = ReportTool.Run(
+            fx.DbPath,
+            fx.WorkspaceRoot,
+            range: "HEAD~1..HEAD",
+            sectionLimit: 5,
+            json: true,
+            includeTests: true,
+            historyReader: new StubGitHistoryReader(
+                new GitHistoryResult(Success: false, Commits: [], Error: "not a git repository")),
+            regionIndex: null);
+
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement churn = doc.RootElement.GetProperty("churn");
+        Assert.False(churn.GetProperty("available").GetBoolean());
+        Assert.Contains("not a git repository", churn.GetProperty("reason").GetString());
+        JsonElement risk = doc.RootElement.GetProperty("risk");
+        Assert.False(risk.GetProperty("available").GetBoolean());
+        Assert.True(doc.RootElement.GetProperty("index").GetProperty("available").GetBoolean());
+    }
+
+    [Fact]
+    public void RunJson_CountsMarkersPerMarkerWhenRegionIndexAvailable()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccee21", "Symbol", "src/S.cs", 5),
+            });
+
+        var regionIndex = new StubRegionSearchIndex(
+            Hit("src/S.cs", 10, "TODO fix the widget"),
+            Hit("src/S.cs", 20, "TODO handle nulls"),
+            Hit("src/Other.cs", 4, "HACK temporary shim"));
+
+        ReportToolResult result = ReportTool.Run(
+            fx.DbPath,
+            fx.WorkspaceRoot,
+            range: "HEAD~1..HEAD",
+            sectionLimit: 5,
+            json: true,
+            includeTests: true,
+            historyReader: new StubGitHistoryReader(
+                new GitHistoryResult(Success: false, Commits: [], Error: "no git")),
+            regionIndex: regionIndex);
+
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement markers = doc.RootElement.GetProperty("markers");
+        Assert.True(markers.GetProperty("available").GetBoolean());
+        var counts = markers.GetProperty("counts").EnumerateArray()
+            .ToDictionary(
+                item => item.GetProperty("marker").GetString()!,
+                item => item.GetProperty("count").GetInt32());
+        Assert.Equal(2, counts["TODO"]);
+        Assert.Equal(1, counts["HACK"]);
+        Assert.Equal(3, markers.GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public void RunCompact_RendersSectionsReadably()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccee31", "RiskySymbol", "src/Risky.cs", 5),
+            });
+        SeedComplexity(fx.DbPath, "metric-risky", "src/Risky.cs", "aa11223344556677889900aabbccee31", 18, 3);
+
+        ReportToolResult result = ReportTool.Run(
+            fx.DbPath,
+            fx.WorkspaceRoot,
+            range: "HEAD~1..HEAD",
+            sectionLimit: 5,
+            json: false,
+            includeTests: true,
+            historyReader: CommitTouching("src/Risky.cs", 5, "abc1234"),
+            regionIndex: null);
+
+        Assert.Contains("# miller report", result.Output);
+        Assert.Contains("## index", result.Output);
+        Assert.Contains("## complexity", result.Output);
+        Assert.Contains("## risk", result.Output);
+        Assert.Contains("RiskySymbol", result.Output);
+        Assert.Contains("markers: unavailable", result.Output);
+    }
+
+    private static StubGitHistoryReader CommitTouching(string path, int line, string commit) =>
+        new(new GitHistoryResult(
+            Success: true,
+            Commits:
+            [
+                new GitHistoryCommit(
+                    Commit: commit,
+                    AuthorTimeUtc: DateTimeOffset.Parse("2026-06-20T12:00:00Z"),
+                    Diff: $"""
+                        diff --git a/{path} b/{path}
+                        --- a/{path}
+                        +++ b/{path}
+                        @@ -{line},1 +{line},1 @@
+                        -old
+                        +new
+                        """),
+            ],
+            Error: null));
+
+    private static RegionSearchHit Hit(string path, int line, string text) =>
+        new(path, 1.0, line, "comment", text, text, $"region-{path}-{line}",
+            ContainingSymbolId: null, ContainingSymbolName: null, Language: "csharp");
+
+    private static JulieDbFixture.SymbolRow Row(string id, string name, string path, int line) =>
+        new(id, name, "method", "csharp", path, $"void {name}()", line, null)
+        {
+            EndLine = line + 4,
+            StartByte = line * 10,
+            EndByte = line * 10 + 40,
+        };
+
+    private static void SeedComplexity(
+        string dbPath,
+        string metricId,
+        string path,
+        string symbolId,
+        int decisions,
+        int nesting)
+    {
+        Exec(dbPath, $"""
+            INSERT INTO complexity_metrics
+                (complexity_metric_id, file_id, path, language, scope, symbol_id, algorithm_id, covered_lines,
+                 covered_bytes, decision_count, loop_count, max_nesting_depth, parameter_count, start_line,
+                 start_column, end_line, end_column, start_byte, end_byte)
+            VALUES
+                ('{metricId}', 'file:{path}', '{path}', 'csharp', 'symbol', '{symbolId}', 'julie-ast-complexity-v1',
+                 12, 120, {decisions}, 2, {nesting}, 0, 1, 0, 12, 0, 0, 120);
+            """);
+    }
+
+    private static void Exec(string dbPath, string sql)
+    {
+        var csb = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Pooling = false,
+        };
+        using var connection = new SqliteConnection(csb.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private sealed class StubGitHistoryReader(GitHistoryResult result) : IGitHistoryReader
+    {
+        public GitHistoryResult Read(GitHistoryRequest request) => result;
+    }
+
+    private sealed class StubRegionSearchIndex(params RegionSearchHit[] hits) : IRegionSearchIndex
+    {
+        public int DocumentCount => hits.Length;
+
+        public long Revision => 1;
+
+        public IReadOnlyList<RegionSearchHit> Search(
+            string query,
+            IReadOnlySet<string> kinds,
+            int limit = 10,
+            bool excludeTests = false) =>
+            hits.Where(hit => hit.RawText.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .Take(limit)
+                .ToArray();
+    }
+}

--- a/tests/Miller.Tests/Server/RiskMetricsToolTests.cs
+++ b/tests/Miller.Tests/Server/RiskMetricsToolTests.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Miller.Server.Git;
+using Miller.Server.Tools;
+using Miller.Tests.Indexing;
+using Xunit;
+
+namespace Miller.Tests.Server;
+
+public sealed class RiskMetricsToolTests
+{
+    [Fact]
+    public void RunRiskJson_JoinsChurnAndComplexityOnSymbolId()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccdd31", "RiskySymbol", "src/Risky.cs", 5),
+            });
+        SeedComplexity(fx.DbPath, "metric-risky", "src/Risky.cs", "aa11223344556677889900aabbccdd31", 18, 3);
+
+        MetricsToolResult result = Run(fx, CommitTouching("src/Risky.cs", 5, "abc1234"));
+
+        Assert.Equal(1, result.ResultCount);
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement root = doc.RootElement;
+        Assert.Equal("risk", root.GetProperty("operation").GetString());
+        Assert.Equal(
+            "commit_count * (decision_count + loop_count + max_nesting_depth)",
+            root.GetProperty("score_formula").GetString());
+        JsonElement row = root.GetProperty("rows")[0];
+        Assert.Equal("symbol", row.GetProperty("basis").GetString());
+        Assert.Equal("RiskySymbol", row.GetProperty("symbol_name").GetString());
+        Assert.Equal(1, row.GetProperty("commit_count").GetInt32());
+        Assert.Equal(18, row.GetProperty("decision_count").GetInt32());
+        Assert.Equal(3, row.GetProperty("max_nesting_depth").GetInt32());
+        // 1 commit * (18 decisions + 2 loops + 3 nesting)
+        Assert.Equal(23, row.GetProperty("score").GetInt64());
+        Assert.Equal("high", row.GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public void RunRiskJson_FileOnlyChurnJoinsPathAggregatedComplexity()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                // Symbol exists in the index but NOT on the changed lines, so churn falls back to file_only.
+                Row("aa11223344556677889900aabbccdd41", "ElsewhereSymbol", "src/Blob.cs", 50),
+            });
+        SeedComplexity(fx.DbPath, "metric-blob-1", "src/Blob.cs", null, 9, 2);
+        SeedComplexity(fx.DbPath, "metric-blob-2", "src/Blob.cs", null, 4, 5);
+
+        MetricsToolResult result = Run(fx, CommitTouching("src/Blob.cs", 5, "def5678"));
+
+        Assert.Equal(1, result.ResultCount);
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement row = doc.RootElement.GetProperty("rows")[0];
+        Assert.Equal("file", row.GetProperty("basis").GetString());
+        Assert.Equal("src/Blob.cs", row.GetProperty("path").GetString());
+        // File tier sums decisions/loops and takes max nesting: decisions 9+4=13, loops 2+2=4, nesting max(2,5)=5.
+        Assert.Equal(13, row.GetProperty("decision_count").GetInt32());
+        Assert.Equal(4, row.GetProperty("loop_count").GetInt32());
+        Assert.Equal(5, row.GetProperty("max_nesting_depth").GetInt32());
+        Assert.Equal(22, row.GetProperty("score").GetInt64());
+    }
+
+    [Fact]
+    public void RunRiskJson_OmitsChurnWithoutComplexityAndComplexityWithoutChurn()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccdd51", "ChurnedOnly", "src/ChurnedOnly.cs", 5),
+                Row("aa11223344556677889900aabbccdd52", "ComplexOnly", "src/ComplexOnly.cs", 5),
+            });
+        // Complexity for the un-churned symbol only.
+        SeedComplexity(fx.DbPath, "metric-complex-only", "src/ComplexOnly.cs", "aa11223344556677889900aabbccdd52", 20, 4);
+
+        MetricsToolResult result = Run(fx, CommitTouching("src/ChurnedOnly.cs", 5, "aaa1111"));
+
+        Assert.Equal(0, result.ResultCount);
+        using var doc = JsonDocument.Parse(result.Output);
+        Assert.Equal(0, doc.RootElement.GetProperty("rows").GetArrayLength());
+    }
+
+    [Fact]
+    public void RunRiskJson_JoinsBeforeLimiting()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccdd61", "HotButSimple", "src/HotButSimple.cs", 5),
+                Row("aa11223344556677889900aabbccdd62", "WarmButGnarly", "src/WarmButGnarly.cs", 5),
+            });
+        // HotButSimple: churns in 2 commits but is trivial. WarmButGnarly: churns once but is very complex.
+        SeedComplexity(fx.DbPath, "metric-simple", "src/HotButSimple.cs", "aa11223344556677889900aabbccdd61", 1, 1);
+        SeedComplexity(fx.DbPath, "metric-gnarly", "src/WarmButGnarly.cs", "aa11223344556677889900aabbccdd62", 30, 6);
+
+        var history = new StubGitHistoryReader(new GitHistoryResult(
+            Success: true,
+            Commits:
+            [
+                Commit("c1", "2026-06-20T12:00:00Z", "src/HotButSimple.cs", 5),
+                Commit("c2", "2026-06-21T12:00:00Z", "src/HotButSimple.cs", 5),
+                Commit("c3", "2026-06-22T12:00:00Z", "src/WarmButGnarly.cs", 5),
+            ],
+            Error: null));
+
+        MetricsToolResult result = Run(fx, history, limit: 1);
+
+        // Churn ordering alone would put HotButSimple first (2 commits vs 1); risk score must win:
+        // HotButSimple: 2 * (1 + 2 + 1) = 8. WarmButGnarly: 1 * (30 + 2 + 6) = 38.
+        Assert.Equal(1, result.ResultCount);
+        using var doc = JsonDocument.Parse(result.Output);
+        JsonElement row = doc.RootElement.GetProperty("rows")[0];
+        Assert.Equal("WarmButGnarly", row.GetProperty("symbol_name").GetString());
+        Assert.Equal(38, row.GetProperty("score").GetInt64());
+    }
+
+    [Fact]
+    public void RunRiskJson_ExcludeTestsDropsTestSymbols()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccdd71", "ProdSymbol", "src/Prod.cs", 5),
+                Row("aa11223344556677889900aabbccdd72", "TestSymbol", "tests/Test.cs", 5),
+            });
+        Exec(fx.DbPath, "UPDATE symbols SET is_test = 1 WHERE symbol_id = 'aa11223344556677889900aabbccdd72';");
+        SeedComplexity(fx.DbPath, "metric-prod", "src/Prod.cs", "aa11223344556677889900aabbccdd71", 10, 2);
+        SeedComplexity(fx.DbPath, "metric-test", "tests/Test.cs", "aa11223344556677889900aabbccdd72", 10, 2);
+
+        var history = new StubGitHistoryReader(new GitHistoryResult(
+            Success: true,
+            Commits:
+            [
+                Commit("c1", "2026-06-20T12:00:00Z", "src/Prod.cs", 5),
+                Commit("c2", "2026-06-20T13:00:00Z", "tests/Test.cs", 5),
+            ],
+            Error: null));
+
+        MetricsToolResult result = Run(fx, history, includeTests: false);
+
+        Assert.Equal(1, result.ResultCount);
+        using var doc = JsonDocument.Parse(result.Output);
+        Assert.Equal("ProdSymbol", doc.RootElement.GetProperty("rows")[0].GetProperty("symbol_name").GetString());
+    }
+
+    [Fact]
+    public void RunRiskCompact_RendersHeaderAndRows()
+    {
+        using var fx = JulieDbFixture.Create(
+            JulieDbFixture.PinnedSchema,
+            JulieDbFixture.PinnedContract,
+            new[]
+            {
+                Row("aa11223344556677889900aabbccdd81", "RiskySymbol", "src/Risky.cs", 5),
+            });
+        SeedComplexity(fx.DbPath, "metric-risky", "src/Risky.cs", "aa11223344556677889900aabbccdd81", 18, 3);
+
+        MetricsToolResult result = Run(fx, CommitTouching("src/Risky.cs", 5, "abc1234"), json: false);
+
+        Assert.Equal(1, result.ResultCount);
+        Assert.Contains("# risk HEAD~1..HEAD", result.Output);
+        Assert.Contains("RiskySymbol", result.Output);
+        Assert.Contains("src/Risky.cs:5", result.Output);
+    }
+
+    private static MetricsToolResult Run(
+        JulieDbFixture fx,
+        IGitHistoryReader history,
+        int limit = 10,
+        bool json = true,
+        bool includeTests = true) =>
+        MetricsTool.Run(
+            fx.DbPath,
+            operation: "risk",
+            limit: limit,
+            json: json,
+            minCount: 2,
+            maxSymbolsPerGroup: MetricsTool.DefaultCloneSymbolsPerGroup,
+            minSeverity: "moderate",
+            includeTests: includeTests,
+            workspaceRoot: fx.WorkspaceRoot,
+            range: "HEAD~1..HEAD",
+            includeCommits: false,
+            historyReader: history);
+
+    private static StubGitHistoryReader CommitTouching(string path, int line, string commit) =>
+        new(new GitHistoryResult(
+            Success: true,
+            Commits: [Commit(commit, "2026-06-20T12:00:00Z", path, line)],
+            Error: null));
+
+    private static GitHistoryCommit Commit(string id, string timeUtc, string path, int line) =>
+        new(
+            Commit: id,
+            AuthorTimeUtc: DateTimeOffset.Parse(timeUtc),
+            Diff: $"""
+                diff --git a/{path} b/{path}
+                --- a/{path}
+                +++ b/{path}
+                @@ -{line},1 +{line},1 @@
+                -old
+                +new
+                """);
+
+    private static JulieDbFixture.SymbolRow Row(string id, string name, string path, int line) =>
+        new(id, name, "method", "csharp", path, $"void {name}()", line, null)
+        {
+            EndLine = line + 4,
+            StartByte = line * 10,
+            EndByte = line * 10 + 40,
+        };
+
+    private static void SeedComplexity(
+        string dbPath,
+        string metricId,
+        string path,
+        string? symbolId,
+        int decisions,
+        int nesting)
+    {
+        string symbolIdSql = symbolId is null ? "NULL" : $"'{symbolId}'";
+        Exec(dbPath, $"""
+            INSERT INTO complexity_metrics
+                (complexity_metric_id, file_id, path, language, scope, symbol_id, algorithm_id, covered_lines,
+                 covered_bytes, decision_count, loop_count, max_nesting_depth, parameter_count, start_line,
+                 start_column, end_line, end_column, start_byte, end_byte)
+            VALUES
+                ('{metricId}', 'file:{path}', '{path}', 'csharp', 'symbol', {symbolIdSql}, 'julie-ast-complexity-v1',
+                 12, 120, {decisions}, 2, {nesting}, 0, 1, 0, 12, 0, 0, 120);
+            """);
+    }
+
+    private static void Exec(string dbPath, string sql)
+    {
+        var csb = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Pooling = false,
+        };
+        using var connection = new SqliteConnection(csb.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private sealed class StubGitHistoryReader(GitHistoryResult result) : IGitHistoryReader
+    {
+        public GitHistoryResult Read(GitHistoryRequest request) => result;
+    }
+}

--- a/tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
@@ -227,6 +227,61 @@ public sealed class WorkspaceBindingCallToolFilterTests
     }
 
     [Fact]
+    public async Task RebindRunningWhileBound_WorkspaceToolCallsNextHandler()
+    {
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-rebind-b", runGeneration: 31, isBound: true),
+        };
+        int nextCalls = 0;
+
+        var result = await InvokeFilterAsync(binding, "workspace", (_, _) =>
+        {
+            nextCalls++;
+            return Task.FromResult(TextResult("workspace-status-with-rebind-notice"));
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, nextCalls);
+        Assert.Equal("workspace-status-with-rebind-notice", ResultText(result));
+    }
+
+    [Fact]
+    public async Task RebindFailedWhileBound_WorkspaceToolCallsNextHandler()
+    {
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = FailedSnapshot("/tmp/miller-rebind-b", "rebind failure", runGeneration: 33, isBound: true),
+        };
+        int nextCalls = 0;
+
+        var result = await InvokeFilterAsync(binding, "workspace", (_, _) =>
+        {
+            nextCalls++;
+            return Task.FromResult(TextResult("workspace-status-after-failed-rebind"));
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, nextCalls);
+        Assert.Equal("workspace-status-after-failed-rebind", ResultText(result));
+    }
+
+    [Fact]
+    public async Task RebindRunningWhileBound_NonWorkspaceToolStillReturnsNotReady()
+    {
+        using var env = ScopedEnvironment.Set("MILLER_BOOTSTRAP_GRACE_SECONDS", "0");
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-rebind-b", runGeneration: 35, isBound: true),
+        };
+
+        var result = await InvokeFilterAsync(
+            binding, "search", (_, _) => Task.FromResult(TextResult("stale-answer-from-old-root")),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(true, result.IsError);
+        Assert.Contains("/tmp/miller-rebind-b", ResultText(result), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CallToolFilter_InvokesBindingBeforeToolHandler()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -348,31 +403,36 @@ public sealed class WorkspaceBindingCallToolFilterTests
             StartedAtUtc: null,
             FailureMessage: null,
             LastFailureMessage: null,
-            runGeneration);
+            runGeneration,
+            IsBound: true);
 
     private static BootstrapSnapshot RunningSnapshot(
         string canonicalRoot,
         int runGeneration,
-        string? lastFailureMessage = null) =>
+        string? lastFailureMessage = null,
+        bool isBound = false) =>
         new(
             BootstrapPhase.Running,
             canonicalRoot,
             DateTimeOffset.UtcNow.AddSeconds(1),
             FailureMessage: null,
             lastFailureMessage,
-            runGeneration);
+            runGeneration,
+            isBound);
 
     private static BootstrapSnapshot FailedSnapshot(
         string canonicalRoot,
         string failureMessage,
-        int runGeneration) =>
+        int runGeneration,
+        bool isBound = false) =>
         new(
             BootstrapPhase.Failed,
             canonicalRoot,
             StartedAtUtc: null,
             failureMessage,
             failureMessage,
-            runGeneration);
+            runGeneration,
+            isBound);
 
     private static CallToolResult TextResult(string text, bool isError = false) =>
         new()

--- a/tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingCallToolFilterTests.cs
@@ -1,6 +1,7 @@
 using System.IO.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Miller.Server;
 using Miller.Server.Hosting;
 using Miller.Server.Telemetry;
 using ModelContextProtocol.Client;
@@ -24,7 +25,11 @@ public sealed class WorkspaceBindingCallToolFilterTests
 
         public bool IsDeferred => true;
 
+        public BootstrapSnapshot Snapshot { get; set; } = BoundSnapshot();
+
         public Task WaitUntilBoundAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task WaitForRunAsync(int runGeneration, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task EnsurePrimaryBoundAsync(McpServer server, CancellationToken cancellationToken)
         {
@@ -33,6 +38,192 @@ public sealed class WorkspaceBindingCallToolFilterTests
         }
 
         public void MarkRootsDirty() { }
+    }
+
+    private sealed class ScriptedBindingService : IWorkspaceBindingService
+    {
+        public int EnsureCalls { get; private set; }
+        public int WaitForRunCalls { get; private set; }
+        public int? LastWaitedRunGeneration { get; private set; }
+        public Func<CancellationToken, Task>? OnEnsure { get; set; }
+        public Func<int, CancellationToken, Task>? OnWaitForRun { get; set; }
+
+        public int BindingGeneration => 1;
+
+        public bool IsDeferred => true;
+
+        public BootstrapSnapshot Snapshot { get; set; } = BoundSnapshot();
+
+        public Task WaitUntilBoundAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task EnsurePrimaryBoundAsync(McpServer server, CancellationToken cancellationToken)
+        {
+            EnsureCalls++;
+            return OnEnsure?.Invoke(cancellationToken) ?? Task.CompletedTask;
+        }
+
+        public Task WaitForRunAsync(int runGeneration, CancellationToken cancellationToken)
+        {
+            WaitForRunCalls++;
+            LastWaitedRunGeneration = runGeneration;
+            return OnWaitForRun?.Invoke(runGeneration, cancellationToken) ?? Task.CompletedTask;
+        }
+
+        public void MarkRootsDirty() { }
+    }
+
+    [Fact]
+    public async Task BoundSnapshot_CallsNextHandler()
+    {
+        var binding = new ScriptedBindingService { Snapshot = BoundSnapshot() };
+        int nextCalls = 0;
+
+        var result = await InvokeFilterAsync(binding, "search", (_, _) =>
+        {
+            nextCalls++;
+            return Task.FromResult(TextResult("next-result"));
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, binding.EnsureCalls);
+        Assert.Equal(1, nextCalls);
+        Assert.Equal("next-result", ResultText(result));
+    }
+
+    [Fact]
+    public async Task RunningSnapshot_WhenRunCompletesWithinGrace_CallsNextHandler()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-running", runGeneration: 7),
+        };
+        binding.OnWaitForRun = async (_, ct) =>
+        {
+            await gate.Task.WaitAsync(ct);
+            binding.Snapshot = BoundSnapshot("/tmp/miller-running", runGeneration: 7);
+        };
+
+        var call = InvokeFilterAsync(
+            binding, "search", (_, _) => Task.FromResult(TextResult("after-bind")),
+            TestContext.Current.CancellationToken);
+        gate.SetResult();
+        var result = await call;
+
+        Assert.Equal(1, binding.WaitForRunCalls);
+        Assert.Equal(7, binding.LastWaitedRunGeneration);
+        Assert.Equal("after-bind", ResultText(result));
+    }
+
+    [Fact]
+    public async Task RunningSnapshot_WhenGraceExpires_ReturnsNotReadyToolError()
+    {
+        using var env = ScopedEnvironment.Set("MILLER_BOOTSTRAP_GRACE_SECONDS", "0.01");
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-running", runGeneration: 9),
+        };
+        binding.OnWaitForRun = (_, ct) => Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        var result = await InvokeFilterAsync(
+            binding, "search", (_, _) => Task.FromResult(TextResult("unreachable")),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(true, result.IsError);
+        Assert.Equal(
+            "Miller is indexing this workspace for the first time: /tmp/miller-running (started 0s ago). Tool calls will work once indexing completes — retry shortly, or run 'workspace status' for progress.",
+            ResultText(result));
+    }
+
+    [Fact]
+    public async Task RunningSnapshot_WithZeroGrace_ReturnsNotReadyWithoutWaiting()
+    {
+        using var env = ScopedEnvironment.Set("MILLER_BOOTSTRAP_GRACE_SECONDS", "0");
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-zero", runGeneration: 11),
+        };
+        binding.OnWaitForRun = (_, _) => throw new InvalidOperationException("zero grace must not wait");
+
+        var result = await InvokeFilterAsync(
+            binding, "search", (_, _) => Task.FromResult(TextResult("unreachable")),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(true, result.IsError);
+        Assert.Equal(0, binding.WaitForRunCalls);
+        Assert.Contains("/tmp/miller-zero", ResultText(result), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunningSnapshot_CancellationDuringGrace_PropagatesCancellation()
+    {
+        using var env = ScopedEnvironment.Set("MILLER_BOOTSTRAP_GRACE_SECONDS", "5");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-cancel", runGeneration: 13),
+        };
+        binding.OnWaitForRun = (_, ct) => Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await InvokeFilterAsync(binding, "search", (_, _) => Task.FromResult(TextResult("unreachable")), cts.Token));
+    }
+
+    [Fact]
+    public async Task FailedRetrySnapshot_ReturnsStoredFailureToolError()
+    {
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = FailedSnapshot("/tmp/miller-failed", "synthetic failure", runGeneration: 17),
+        };
+        binding.OnEnsure = _ =>
+        {
+            binding.Snapshot = RunningSnapshot(
+                "/tmp/miller-failed", runGeneration: 18, lastFailureMessage: "synthetic failure");
+            return Task.CompletedTask;
+        };
+
+        var result = await InvokeFilterAsync(
+            binding, "search", (_, _) => Task.FromResult(TextResult("unreachable")),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(true, result.IsError);
+        Assert.Equal("bootstrap failed: synthetic failure; retry started — call again shortly.", ResultText(result));
+    }
+
+    [Fact]
+    public async Task UnboundWorkspaceTool_RendersRunningSnapshotWithoutCallingTool()
+    {
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-workspace", runGeneration: 21),
+        };
+
+        var result = await InvokeFilterAsync(
+            binding, "workspace", (_, _) => Task.FromResult(TextResult("unreachable")),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal("bootstrap: running /tmp/miller-workspace, started 0s ago", ResultText(result));
+    }
+
+    [Fact]
+    public async Task BoundWorkspaceTool_CallsNextHandler()
+    {
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = BoundSnapshot("/tmp/miller-bound-workspace", runGeneration: 23),
+        };
+        int nextCalls = 0;
+
+        var result = await InvokeFilterAsync(binding, "workspace", (_, _) =>
+        {
+            nextCalls++;
+            return Task.FromResult(TextResult("workspace-status"));
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, nextCalls);
+        Assert.Equal("workspace-status", ResultText(result));
     }
 
     [Fact]
@@ -72,5 +263,141 @@ public sealed class WorkspaceBindingCallToolFilterTests
         try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5), ct); } catch (Exception) { }
 
         Assert.Equal(1, binding.EnsureCalls);
+    }
+
+    [Fact]
+    public async Task BindingFilter_ComposesOutsideTelemetry_ForUnboundResponses()
+    {
+        using var env = ScopedEnvironment.Set("MILLER_BOOTSTRAP_GRACE_SECONDS", "0");
+        var ct = TestContext.Current.CancellationToken;
+        var binding = new ScriptedBindingService
+        {
+            Snapshot = RunningSnapshot("/tmp/miller-order", runGeneration: 29),
+        };
+
+        var clientToServer = new Pipe();
+        var serverToClient = new Pipe();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IWorkspaceBindingService>(binding);
+        services.AddSingleton<TelemetryLedger>(_ => throw new InvalidOperationException(
+            "telemetry filter ran before binding produced the unbound response"));
+        services
+            .AddMcpServer(o => { o.ServerInfo = new() { Name = "bind-filter-order", Version = "0" }; })
+            .WithStreamServerTransport(clientToServer.Reader.AsStream(), serverToClient.Writer.AsStream())
+            .WithToolsFromAssembly(typeof(PinProbeTool).Assembly)
+            .WithRequestFilters(f =>
+            {
+                f.AddCallToolFilter(WorkspaceBindingCallToolFilter.Create());
+                f.AddCallToolFilter(TelemetryCallToolFilter.Create());
+            });
+
+        await using var provider = services.BuildServiceProvider();
+        var server = provider.GetRequiredService<McpServer>();
+        var serverTask = server.RunAsync(ct);
+
+        var clientTransport = new StreamClientTransport(
+            clientToServer.Writer.AsStream(), serverToClient.Reader.AsStream(), NullLoggerFactory.Instance);
+        await using var client = await McpClient.CreateAsync(clientTransport, cancellationToken: ct);
+
+        var result = await client.CallToolAsync(
+            "pin_greet", new Dictionary<string, object?> { ["who"] = "order" }!, cancellationToken: ct);
+
+        await client.DisposeAsync();
+        await clientToServer.Writer.CompleteAsync();
+        await serverToClient.Writer.CompleteAsync();
+        try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5), ct); } catch (Exception) { }
+
+        Assert.Equal(true, result.IsError);
+        Assert.Contains("/tmp/miller-order", ResultText(result), StringComparison.Ordinal);
+    }
+
+    private static async Task<CallToolResult> InvokeFilterAsync(
+        IWorkspaceBindingService binding,
+        string toolName,
+        Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResult>> next,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken == default)
+            cancellationToken = TestContext.Current.CancellationToken;
+
+        var services = new ServiceCollection();
+        var clientToServer = new Pipe();
+        var serverToClient = new Pipe();
+        services.AddSingleton(binding);
+        services.AddSingleton<IWorkspaceBindingService>(binding);
+        services
+            .AddMcpServer(o => { o.ServerInfo = new() { Name = "bind-filter-direct", Version = "0" }; })
+            .WithStreamServerTransport(clientToServer.Reader.AsStream(), serverToClient.Writer.AsStream());
+
+        await using var provider = services.BuildServiceProvider();
+        var server = provider.GetRequiredService<McpServer>();
+        var request = new RequestContext<CallToolRequestParams>(
+            server,
+            new JsonRpcRequest { Method = "tools/call" },
+            new CallToolRequestParams { Name = toolName });
+        var filtered = WorkspaceBindingCallToolFilter.Create()(async (ctx, ct) => await next(ctx, ct));
+        return await filtered(request, cancellationToken);
+    }
+
+    private static BootstrapSnapshot BoundSnapshot(
+        string canonicalRoot = "/tmp/miller-bound", int runGeneration = 1) =>
+        new(
+            BootstrapPhase.Bound,
+            canonicalRoot,
+            StartedAtUtc: null,
+            FailureMessage: null,
+            LastFailureMessage: null,
+            runGeneration);
+
+    private static BootstrapSnapshot RunningSnapshot(
+        string canonicalRoot,
+        int runGeneration,
+        string? lastFailureMessage = null) =>
+        new(
+            BootstrapPhase.Running,
+            canonicalRoot,
+            DateTimeOffset.UtcNow.AddSeconds(1),
+            FailureMessage: null,
+            lastFailureMessage,
+            runGeneration);
+
+    private static BootstrapSnapshot FailedSnapshot(
+        string canonicalRoot,
+        string failureMessage,
+        int runGeneration) =>
+        new(
+            BootstrapPhase.Failed,
+            canonicalRoot,
+            StartedAtUtc: null,
+            failureMessage,
+            failureMessage,
+            runGeneration);
+
+    private static CallToolResult TextResult(string text, bool isError = false) =>
+        new()
+        {
+            IsError = isError,
+            Content = [new TextContentBlock { Text = text }],
+        };
+
+    private static string ResultText(CallToolResult result) =>
+        Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+
+    private sealed class ScopedEnvironment : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previous;
+
+        private ScopedEnvironment(string name, string? value)
+        {
+            _name = name;
+            _previous = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public static ScopedEnvironment Set(string name, string? value) => new(name, value);
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _previous);
     }
 }

--- a/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
@@ -132,7 +132,7 @@ public sealed class WorkspaceBindingServiceTests
         {
             using var registry = WorkspaceRegistry.Open(failedWorkspace.RegistryDbPath);
             row = registry.Get(failedWorkspace.WorkspaceId);
-            return row is not null;
+            return row?.State == WorkspaceRegistryState.Error;
         }, TestContext.Current.CancellationToken);
         Assert.Equal(WorkspaceRegistryState.Error, row!.State);
         Assert.Equal("synthetic async failure", row.LastError);
@@ -337,6 +337,68 @@ public sealed class WorkspaceBindingServiceTests
         Assert.Equal(2, bindCount);
         Assert.True(bootstrap.BindingGeneration > genAfterFirst);
         Assert.Equal(PathCanonicalizer.CanonicalizeRoot(projectB), bootstrap.Workspace.CanonicalRoot);
+    }
+
+    [Fact]
+    public async Task RebindDeferred_KeepsRootsDirtyUntilInFlightRunCompletes()
+    {
+        string projectA = CreateTempDir();
+        string projectB = CreateTempDir();
+        string canonicalA = PathCanonicalizer.CanonicalizeRoot(projectA);
+        string canonicalB = PathCanonicalizer.CanonicalizeRoot(projectB);
+        var startedRoots = new List<string>();
+        var startedA = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseA = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        bootstrap.TestRunBootstrapOverride = canonicalRoot =>
+        {
+            lock (startedRoots)
+                startedRoots.Add(canonicalRoot);
+
+            if (IndexBootstrapService.RootPathsEqual(canonicalRoot, canonicalA))
+            {
+                startedA.TrySetResult();
+                releaseA.Task.GetAwaiter().GetResult();
+            }
+
+            SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        };
+        var binding = new WorkspaceBindingService(bootstrap, NullLogger<WorkspaceBindingService>.Instance);
+        var ct = TestContext.Current.CancellationToken;
+
+        string previous = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+            await bootstrap.StartAsync(CancellationToken.None);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previous);
+        }
+
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectA}"], ct);
+        await startedA.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        int runA = bootstrap.Snapshot.RunGeneration;
+
+        binding.MarkRootsDirty();
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectB}"], ct);
+        Assert.Equal(BootstrapPhase.Running, bootstrap.Snapshot.Phase);
+        Assert.Equal(canonicalA, bootstrap.Snapshot.CanonicalRoot);
+
+        releaseA.TrySetResult();
+        await bootstrap.WaitForRunAsync(runA, ct);
+        Assert.Equal(canonicalA, bootstrap.Workspace.CanonicalRoot);
+
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectB}"], ct);
+        await WaitUntilAsync(() =>
+        {
+            lock (startedRoots)
+                return startedRoots.Any(root => IndexBootstrapService.RootPathsEqual(root, canonicalB));
+        }, ct);
+        await bootstrap.WaitForRunAsync(bootstrap.Snapshot.RunGeneration, ct);
+
+        Assert.Equal(canonicalB, bootstrap.Workspace.CanonicalRoot);
     }
 
     private static string CreateTempDir()

--- a/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
@@ -61,6 +61,172 @@ public sealed class WorkspaceBindingServiceTests
     }
 
     [Fact]
+    public async Task BootstrapForRoot_DispatchesRunInBackgroundAndPublishesOnlyWhenComplete()
+    {
+        string project = CreateTempDir();
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bootstrap.TestRunBootstrapOverride = canonicalRoot =>
+        {
+            started.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+            SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        };
+
+        int runGeneration;
+        try
+        {
+            var outcome = bootstrap.BootstrapForRoot(project, WorkspaceBindingResolver.WorkspaceSource.Roots);
+
+            Assert.Equal(BindOutcome.Started, outcome);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.False(bootstrap.IsBound);
+            var snapshot = bootstrap.Snapshot;
+            runGeneration = snapshot.RunGeneration;
+            Assert.Equal(BootstrapPhase.Running, snapshot.Phase);
+            Assert.Equal(PathCanonicalizer.CanonicalizeRoot(project), snapshot.CanonicalRoot);
+            Assert.NotNull(snapshot.StartedAtUtc);
+            Assert.Null(snapshot.FailureMessage);
+            Assert.Throws<InvalidOperationException>(() => bootstrap.Holder);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await bootstrap.WaitForRunAsync(runGeneration, TestContext.Current.CancellationToken);
+        Assert.True(bootstrap.IsBound);
+        Assert.Equal(BootstrapPhase.Bound, bootstrap.Snapshot.Phase);
+        Assert.Equal(PathCanonicalizer.CanonicalizeRoot(project), bootstrap.Workspace.CanonicalRoot);
+    }
+
+    [Fact]
+    public async Task BootstrapForRoot_WhenRunFails_MarksFailedCompletesRunWaitAndRetries()
+    {
+        string project = CreateTempDir();
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        bootstrap.TestRunBootstrapOverride = _ => throw new InvalidOperationException("synthetic async failure");
+
+        var outcome = bootstrap.BootstrapForRoot(project, WorkspaceBindingResolver.WorkspaceSource.Roots);
+        Assert.Equal(BindOutcome.Started, outcome);
+        int failedRunGeneration = bootstrap.Snapshot.RunGeneration;
+
+        await bootstrap.WaitForRunAsync(failedRunGeneration, TestContext.Current.CancellationToken);
+
+        var failed = bootstrap.Snapshot;
+        Assert.Equal(BootstrapPhase.Failed, failed.Phase);
+        Assert.Equal("synthetic async failure", failed.FailureMessage);
+        Assert.Equal("synthetic async failure", failed.LastFailureMessage);
+        Assert.False(bootstrap.IsBound);
+
+        string canonicalRoot = PathCanonicalizer.CanonicalizeRoot(project);
+        var failedWorkspace = WorkspaceContext.Create(canonicalRoot, AppContext.BaseDirectory) with
+        {
+            WorkspaceId = WorkspaceId.FromCanonicalRoot(canonicalRoot),
+            CanonicalRoot = canonicalRoot,
+            CanonicalExtractDbPath = Path.Combine(canonicalRoot, ".miller", "symbols.db"),
+        };
+        WorkspaceRegistryRow? row = null;
+        await WaitUntilAsync(() =>
+        {
+            using var registry = WorkspaceRegistry.Open(failedWorkspace.RegistryDbPath);
+            row = registry.Get(failedWorkspace.WorkspaceId);
+            return row is not null;
+        }, TestContext.Current.CancellationToken);
+        Assert.Equal(WorkspaceRegistryState.Error, row!.State);
+        Assert.Equal("synthetic async failure", row.LastError);
+
+        bootstrap.TestRunBootstrapOverride = canonicalRoot => SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        var retryOutcome = bootstrap.BootstrapForRoot(project, WorkspaceBindingResolver.WorkspaceSource.Roots);
+        Assert.Equal(BindOutcome.Started, retryOutcome);
+        int retryRunGeneration = bootstrap.Snapshot.RunGeneration;
+
+        await bootstrap.WaitForRunAsync(retryRunGeneration, TestContext.Current.CancellationToken);
+
+        Assert.True(bootstrap.IsBound);
+        Assert.Equal(BootstrapPhase.Bound, bootstrap.Snapshot.Phase);
+        Assert.Equal(PathCanonicalizer.CanonicalizeRoot(project), bootstrap.Workspace.CanonicalRoot);
+    }
+
+    [Fact]
+    public async Task BootstrapForRoot_WhenSameRootAlreadyRunning_JoinsExistingRun()
+    {
+        string project = CreateTempDir();
+        int runs = 0;
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bootstrap.TestRunBootstrapOverride = canonicalRoot =>
+        {
+            Interlocked.Increment(ref runs);
+            started.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+            SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        };
+
+        int runGeneration;
+        try
+        {
+            var first = bootstrap.BootstrapForRoot(project, WorkspaceBindingResolver.WorkspaceSource.Roots);
+            Assert.Equal(BindOutcome.Started, first);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            runGeneration = bootstrap.Snapshot.RunGeneration;
+
+            var second = bootstrap.BootstrapForRoot(project, WorkspaceBindingResolver.WorkspaceSource.Roots);
+
+            Assert.Equal(BindOutcome.JoinedRunning, second);
+            Assert.Equal(1, runs);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await bootstrap.WaitForRunAsync(runGeneration, TestContext.Current.CancellationToken);
+        Assert.True(bootstrap.IsBound);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithUsableCwd_ReturnsBeforeBackgroundRunCompletes()
+    {
+        string project = CreateTempDir();
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bootstrap.TestRunBootstrapOverride = canonicalRoot =>
+        {
+            started.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+            SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        };
+
+        string previous = Directory.GetCurrentDirectory();
+        int runGeneration;
+        try
+        {
+            Directory.SetCurrentDirectory(project);
+            await bootstrap.StartAsync(TestContext.Current.CancellationToken);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            Assert.False(bootstrap.IsDeferred);
+            Assert.False(bootstrap.IsBound);
+            var snapshot = bootstrap.Snapshot;
+            runGeneration = snapshot.RunGeneration;
+            Assert.Equal(BootstrapPhase.Running, snapshot.Phase);
+            Assert.Equal(PathCanonicalizer.CanonicalizeRoot(project), snapshot.CanonicalRoot);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previous);
+            release.TrySetResult();
+        }
+
+        await bootstrap.WaitForRunAsync(runGeneration, TestContext.Current.CancellationToken);
+        Assert.True(bootstrap.IsBound);
+    }
+
+    [Fact]
     public async Task EnsurePrimaryBoundFromRootsAsync_BindsDeferredBootstrap()
     {
         string project = CreateTempDir();
@@ -178,5 +344,30 @@ public sealed class WorkspaceBindingServiceTests
         string dir = Path.Combine(Path.GetTempPath(), "miller-bindsvc-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         return dir;
+    }
+
+    private static void SeedEmptyWorkspace(IndexBootstrapService bootstrap, string canonicalRoot)
+    {
+        var workspace = WorkspaceContext.Create(canonicalRoot, AppContext.BaseDirectory) with
+        {
+            WorkspaceId = WorkspaceId.FromCanonicalRoot(canonicalRoot),
+            CanonicalRoot = canonicalRoot,
+        };
+        bootstrap.SeedForTest(workspace, new IndexHolder(
+            MillerRepositoryIndex.Build(Array.Empty<IndexedSymbol>()), builtRevision: 0));
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (condition())
+                return;
+            await Task.Delay(10, cancellationToken);
+        }
+
+        Assert.True(condition(), "condition was not met before the timeout");
     }
 }

--- a/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
@@ -401,6 +401,40 @@ public sealed class WorkspaceBindingServiceTests
         Assert.Equal(canonicalB, bootstrap.Workspace.CanonicalRoot);
     }
 
+    [Fact]
+    public async Task RebindFailureWhileBound_NextEnsureStartsRetry()
+    {
+        string projectA = CreateTempDir();
+        string projectB = CreateTempDir();
+        string canonicalA = PathCanonicalizer.CanonicalizeRoot(projectA);
+        string canonicalB = PathCanonicalizer.CanonicalizeRoot(projectB);
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        bootstrap.TestRunBootstrapOverride = canonicalRoot => SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        var binding = new WorkspaceBindingService(bootstrap, NullLogger<WorkspaceBindingService>.Instance);
+        var ct = TestContext.Current.CancellationToken;
+
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectA}"], ct);
+        await WaitUntilAsync(() => bootstrap.IsBound, ct);
+
+        bootstrap.TestRunBootstrapOverride = _ => throw new InvalidOperationException("synthetic rebind failure");
+        binding.MarkRootsDirty();
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectB}"], ct);
+        await WaitUntilAsync(() => bootstrap.Snapshot.Phase == BootstrapPhase.Failed, ct);
+
+        // The failed rebind keeps the previous workspace serving...
+        Assert.True(bootstrap.IsBound);
+        Assert.Equal(canonicalA, bootstrap.Workspace.CanonicalRoot);
+
+        // ...and the NEXT ensure call must start the retry (design: Failed → BootstrapForRoot (retry) → Running),
+        // not early-return on IsBound and strand the Failed phase with no in-band recovery.
+        bootstrap.TestRunBootstrapOverride = canonicalRoot => SeedEmptyWorkspace(bootstrap, canonicalRoot);
+        await binding.EnsurePrimaryBoundFromRootsAsync([$"file://{projectB}"], ct);
+        await WaitUntilAsync(() =>
+            bootstrap.Snapshot.Phase == BootstrapPhase.Bound &&
+            IndexBootstrapService.RootPathsEqual(bootstrap.Workspace.CanonicalRoot, canonicalB), ct);
+        Assert.Null(bootstrap.Snapshot.LastFailureMessage);
+    }
+
     private static string CreateTempDir()
     {
         string dir = Path.Combine(Path.GetTempPath(), "miller-bindsvc-" + Guid.NewGuid().ToString("N"));

--- a/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceBindingServiceTests.cs
@@ -29,6 +29,38 @@ public sealed class WorkspaceBindingServiceTests
     }
 
     [Fact]
+    public void BootstrapForRoot_RejectsSensitiveRootFromMcpRoots()
+    {
+        // Incident 2026-07-06: sessions launched with cwd=$HOME correctly deferred bootstrap, but the MCP
+        // client then offered file://$HOME as its root and the Roots source bound it UNGUARDED — kicking off
+        // a full julie-extract scan of the home directory. Every binding source must pass the sensitive-root
+        // guard, not just Cwd.
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        bootstrap.TestBootstrapInterceptor = (_, _) => throw new InvalidOperationException(
+            "guard must reject before any bootstrap work runs");
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => bootstrap.BootstrapForRoot(home, WorkspaceBindingResolver.WorkspaceSource.Roots));
+        Assert.Contains("sensitive system path", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BootstrapForRoot_RejectsSensitiveRootFromEnv()
+    {
+        var bootstrap = new IndexBootstrapService(NullLogger<IndexBootstrapService>.Instance);
+        bootstrap.TestBootstrapInterceptor = (_, _) => throw new InvalidOperationException(
+            "guard must reject before any bootstrap work runs");
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => bootstrap.BootstrapForRoot(home, WorkspaceBindingResolver.WorkspaceSource.Env));
+        Assert.Contains("sensitive system path", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EnsurePrimaryBoundFromRootsAsync_BindsDeferredBootstrap()
     {
         string project = CreateTempDir();

--- a/tests/Miller.Tests/Server/WorkspaceToolTests.cs
+++ b/tests/Miller.Tests/Server/WorkspaceToolTests.cs
@@ -137,7 +137,7 @@ public sealed class WorkspaceToolTests : IDisposable
             utcNow: () => DateTimeOffset.UtcNow,
             sidecar: SymbolSearchSidecar.Disabled);
         var tool = new WorkspaceTool(
-            holder, workspace, indexer, freshness, probe, ledger, runner, registry, crossRefresh,
+            holder, workspace, indexer, freshness, probe, bootstrap, ledger, runner, registry, crossRefresh,
             SymbolSearchSidecar.Disabled,
             openScan ?? ((scanRoot, scanDb, force) => runner.Scan(scanRoot, scanDb, force)),
             acquireLock ?? (millerDir => SingleWriterLock.TryAcquire(millerDir)),
@@ -147,7 +147,7 @@ public sealed class WorkspaceToolTests : IDisposable
                 ProcessId: null,
                 Message: "already running")),
             NullLogger<WorkspaceTool>.Instance);
-        return new WorkspaceToolHarness(tool, indexer, ledger, root, workspace, registry);
+        return new WorkspaceToolHarness(tool, indexer, ledger, root, workspace, registry, bootstrap);
     }
 
     private static string DisplayFor(string canonicalRoot, string workspaceId) =>
@@ -159,7 +159,8 @@ public sealed class WorkspaceToolTests : IDisposable
         TelemetryLedger Ledger,
         string Root,
         WorkspaceContext Workspace,
-        WorkspaceRegistry Registry);
+        WorkspaceRegistry Registry,
+        IndexBootstrapService Bootstrap);
 
     private static JulieDbFixture CreateSynth(long revision, string? workspaceId) =>
         JulieDbFixture.Create(
@@ -359,6 +360,36 @@ public sealed class WorkspaceToolTests : IDisposable
         Assert.Contains("reader", output, StringComparison.OrdinalIgnoreCase);
         // The seeded telemetry row shows in the embedded breakdown.
         Assert.Contains("search", output);
+        Assert.DoesNotContain("rebinding:", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Status_WhenRebindRunning_RendersCompactNotice()
+    {
+        using var fx = CreateSynth(revision: 4, workspaceId: Ws);
+        var harness = BuildHarness(fx, builtRevision: 4, workspaceId: Ws);
+        string rebindRoot = NewTempDir("rebind-running");
+        string canonicalRebindRoot = PathCanonicalizer.CanonicalizeRoot(rebindRoot);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Bootstrap.TestRunBootstrapOverride = _ =>
+        {
+            release.Task.GetAwaiter().GetResult();
+        };
+
+        try
+        {
+            var outcome = harness.Bootstrap.BootstrapForRoot(
+                rebindRoot, WorkspaceBindingResolver.WorkspaceSource.Roots);
+            Assert.Equal(BindOutcome.Started, outcome);
+
+            string output = harness.Tool.Workspace(operation: "status");
+
+            Assert.Contains($"rebinding: {canonicalRebindRoot} (started 0s ago)", output);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Status: Complete — evidence gate PASSED

## What shipped
- `miller references candidates [--json]`: pure evaluator (Miller.Core) + artifact reader (Miller.Indexing) + CLI rendering/capabilities.
- Eleven suppression rules (nine designed + corrective `override_member`, `live_member_container`, and a test-path fallback in `test_symbol`).
- Contract doc `docs/contracts/references-candidates-v1.md` + Eros-ownership truth-ups + CLAUDE.md boundary update.
- julie-extract pin 2.9.0 → 2.10.0 with published-asset sha256s (download restore verified).

## Evidence gate
Full-repo scan with julie-extract v2.10.0 (`variable_ref` emission): **392 → 5 candidates, zero confirmed-live** — the design's hard gate met literally. History and hand-verification: `docs/findings/2026-07-07-dead-code-candidates-dogfood.md` (FINAL VERDICT section).

## External review
Codex adversarial review on the extractor lane: 2 findings, both confirmed by live probes and fixed pre-publish (java FQ static receivers, python match-pattern bindings), plus grammar-level fixes (tree-sitter-razor fork, upstream PR tris203/tree-sitter-razor#27; C# A*B mis-parse recovery).

## Blockers
None.

## Next steps
- Repoint tree-sitter-razor at upstream when PR #27 merges.
- The 4 verified-dead SearchTool/WorkspaceTool members can be deleted in a follow-up.
- Report/dashboard/MCP surfacing stays gated on explicit approval.

Full judgment-call log: `.memories/autonomous-run-2026-07-07-dead-code-candidates.md` (in this PR).

https://claude.ai/code/session_019Bhuq8Rev4VbFXauv7LUWW