### PR TITLE
docs: A8 is implemented, not proven closed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Use this page to avoid treating old milestone plans as the current product contr
 - [`../README.md`](../README.md) - public entry point: quickstart, tool overview, architecture summary, troubleshooting.
 - [`install.md`](install.md) - full install guide: plugin details and session hooks, manual binary install, MCP configuration, instruction-tier harnesses, source checkout, local plugin development.
 - [`cli.md`](cli.md) - CLI reference: server vs one-shot modes, command examples, tool surface details, dashboard, local proof commands, text/JSON output contract.
-- [`known-limits.md`](known-limits.md) - current boundaries: semantic retrieval knobs, region search, bridge provider scope, Blazor resolution, AOT packaging, server restart pickup.
+- [`known-limits.md`](known-limits.md) - current boundaries: A8 in-place search/content sidecar apply (implemented, not proven closed), semantic retrieval knobs, region search, bridge provider scope, Blazor resolution, AOT packaging, server restart pickup.
 - [`findings/2026-08-09-index-store-ph3-acceptance.md`](findings/2026-08-09-index-store-ph3-acceptance.md) - v1.18 default-on family-store acceptance: view-scoped reads, orchestration, sidecars, migration, rollback export, provenance, and the disclosed A7/A8 follow-ups.
 - [`plans/2026-08-09-index-store-ph3-cleanup-plan.md`](plans/2026-08-09-index-store-ph3-cleanup-plan.md) - historical v4.3 execution-drift cleanup and the origin of the A7/A8 follow-up boundaries.
 - [`findings/2026-08-10-julie-extract-2.31.3-adoption.md`](findings/2026-08-10-julie-extract-2.31.3-adoption.md) - public 2.31.3 producer hardening pin, four-platform archive checksums, tag provenance, and restored-binary verification.

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -8,8 +8,7 @@
   revision delta match (A8, shipped in v1.19.4). A failed or ineligible delta still falls back to a full
   WriteStoreView with no log. There is no local reproducible cost gate, so A8 is implemented, not proven closed.
   Convergence is serialized by the family sidecar lease, so concurrent workspaces can leave a sidecar stale until
-  a later converge succeeds; store reads report that stale state rather than silently falling back to a legacy
-  artifact.
+  a later converge succeeds; store readers refuse a stale sidecar rather than serving a legacy artifact.
 - Local semantic/vector retrieval is owned by Miller and **on by default**. Set `MILLER_SEMANTIC=off`
   for the permanent zero-work path: no broker path derivation, model access, process, accelerator
   probe, vector read/write, or semantic telemetry. `MILLER_SEMANTIC=shadow` builds and measures

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -4,10 +4,12 @@
   and rollback path. Until the Ph4/Ph5 A7 durable reader-pin
   protocol lands, producer GC must not run concurrently with live Miller family-store readers; an unpinned
   non-current generation may be reclaimed during a long read. The explicit standalone path is unaffected.
-- Family-store search/content sidecars still use the open A8 full-view rebuild path. Convergence is serialized by
-  the family sidecar lease, so concurrent workspaces can leave a sidecar stale until a later converge succeeds;
-  store reads report that stale state rather than silently falling back to a legacy artifact. Cursor-incremental
-  convergence and its local reproducible cost gate remain Ph5 work.
+- Search and content family-store sidecars apply store file changes in place when the sidecar stamp and a complete
+  revision delta match (A8, shipped in v1.19.4). A failed or ineligible delta still falls back to a full
+  WriteStoreView with no log. There is no local reproducible cost gate, so A8 is implemented, not proven closed.
+  Convergence is serialized by the family sidecar lease, so concurrent workspaces can leave a sidecar stale until
+  a later converge succeeds; store reads report that stale state rather than silently falling back to a legacy
+  artifact.
 - Local semantic/vector retrieval is owned by Miller and **on by default**. Set `MILLER_SEMANTIC=off`
   for the permanent zero-work path: no broker path derivation, model access, process, accelerator
   probe, vector read/write, or semantic telemetry. `MILLER_SEMANTIC=shadow` builds and measures


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only first cut. Two files only: `docs/known-limits.md` (A8 bullet) and the matching current-docs line in `docs/README.md`. No contracts, findings, plans, PERF, code, or tests.

## What a user/agent can rely on now

- Search and content family-store sidecars apply store file changes **in place** when the sidecar stamp and a complete revision delta match (`EnsureStoreCurrent` → `TryApplyStoreDelta` → `ApplyStoreFileChanges`). Shipped in v1.19.4 (tag `10db3160`, feature commit `3cf43a47`).
- `IndexerSidecarConverger.ConvergeStore` serializes under `FamilyStoreSidecarWriteLease`, then calls `ContentCorpusSidecar.EnsureStoreCurrent` and `SymbolSearchSidecar.EnsureStoreCurrent`.
- Store readers **refuse** a stale sidecar (`OpenStoreGenerationChecked` / `OpenStoreRequired`) instead of serving a legacy artifact.

## What still falls back or fails

- A failed or ineligible delta (`TryApplyStoreDelta` returns false: stamp mismatch, incomplete revision delta, or a caught apply exception) still falls back to a full `WriteStoreView` with **no log**.
- There is no local reproducible cost gate, so A8 is **implemented, not proven closed**.
- Concurrent workspaces can still leave a sidecar stale until a later converge acquires the family lease and succeeds.

## Verified, not documented as the store path

- Store-mode converge ignores `IndexerService`'s `fullRebuild` flag. `TryConvergeSidecar` / `TryConvergeSidecarToLatest` call `TryConvergeStoreSidecars()` and never pass `fullRebuild` into `ConvergeStore`. Vectors stamp with `fullRebuild: false`. The known-limits bullet does not treat that indexer flag as the store path.

A7 reader-pin and every other known-limits bullet are unchanged. Historical A7/A8 findings/plans were not recategorized.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d8334a1-e18c-4c99-8082-8248cf681f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8334a1-e18c-4c99-8082-8248cf681f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

